### PR TITLE
fix: update ralph loop to pull from GitHub issues instead of TASKS.md

### DIFF
--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -2,7 +2,6 @@
 # The Ralph Loop for the GEO Wiki
 
 WIKI_DIR="$HOME/workspace/zero-shot-agency"
-TASKS_FILE="$WIKI_DIR/GitHub Issues"
 STATE_FILE="$WIKI_DIR/run-state.txt"
 LOG_FILE="$WIKI_DIR/latest_agent.log"
 MAX_TASKS=5
@@ -28,21 +27,22 @@ while [ $tasks_completed -lt $MAX_TASKS ]; do
         break
     fi
 
-    # 2. Parse next task
-    NEXT_TASK=$(grep -m 1 "^- \[ \]" "$TASKS_FILE")
+    # 2. Parse next task from GitHub Issues
+    export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+    NEXT_TASK_ID=$(gh issue list --state open --json number --jq '.[0].number' 2>/dev/null)
     
-    if [ -z "$NEXT_TASK" ]; then
-        echo "✅ No more tasks in the backlog. Ralph is going to sleep."
+    if [ -z "$NEXT_TASK_ID" ]; then
+        echo "✅ No open GitHub Issues found. Ralph is going to sleep."
         break
     fi
     
-    # Clean up the string to pass to the agent
-    TASK_DESC=$(echo "$NEXT_TASK" | sed 's/^- \[ \] //')
-    echo "🎯 Next objective: $TASK_DESC"
+    NEXT_TASK_DESC=$(gh issue view "$NEXT_TASK_ID" --json title --jq '.title' 2>/dev/null)
+    NEXT_TASK_URL=$(gh issue view "$NEXT_TASK_ID" --json url --jq '.url' 2>/dev/null)
+    echo "🎯 Next objective: #$NEXT_TASK_ID - $NEXT_TASK_DESC"
     
     # 3. Boot fresh agent instance
     echo "🧠 Booting fresh agent context..."
-    hermes chat --yolo -Q -q "You are the GEO Wiki Orchestrator running inside a Ralph Loop. \nORIENT YOURSELF: Read $WIKI_DIR/strategy.md, $WIKI_DIR/SCHEMA.md, index.md, and log.md.\nYOUR TASK: $TASK_DESC\nRULES:\n1. If the task requires deep coding/development, use delegate_task with acp_command='claude' (DO NOT USE legacy 3.5 models).\n2. Content Drafts: Checkout a new branch (e.g., drafts/[name]), write the file, update GitHub Issues, and then use /home/linuxbrew/.linuxbrew/bin/gh pr create --fill to open a Pull Request.\n3. If the task is scraping, use your native web_search/web_extract tools and save to raw/.\n4. If it is synthesis, do it yourself and save to concepts/.\n5. Once completed, edit $TASKS_FILE to move the task from the Backlog to Completed.\n6. Update log.md and cross-reference with [[wikilinks]].\nExecute now."
+    hermes chat --yolo -Q -q "You are the GEO Wiki Orchestrator running inside a Ralph Loop. \nORIENT YOURSELF: Read $WIKI_DIR/strategy.md, $WIKI_DIR/SCHEMA.md, index.md, and log.md.\nYOUR TASK: Resolve GitHub Issue #$NEXT_TASK_ID ($NEXT_TASK_URL).\nRULES:\n1. If the task requires deep coding/development, use delegate_task with acp_command='claude' (DO NOT USE legacy 3.5 models).\n2. Content Drafts: Checkout a new branch (e.g., drafts/[name]), write the file, use gh CLI to close the issue, and then use gh pr create --fill to open a Pull Request.\n3. If the task is scraping, use your native web_search/web_extract tools and save to raw/.\n4. If it is synthesis, do it yourself and save to concepts/.\n5. Once completed, use the gh CLI to close the issue (#$NEXT_TASK_ID).\n6. Update log.md and cross-reference with [[wikilinks]].\nExecute now."
 
     # 4. Agent exits. Increment and cool down.
     


### PR DESCRIPTION
Since TASKS.md was deleted, this updates ralph to use the `gh issue list` command to fetch open issues dynamically instead.