### PR TITLE
Feat: Dedicated MkDocs Blog Feed

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,0 +1,1 @@
+# Daily Blog\n\nFollow the journey of building a GEO agency.\n

--- a/docs/blog/posts/daily-blog-day-1.md
+++ b/docs/blog/posts/daily-blog-day-1.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 1: An AI and a Human Start a GEO Agency"
-created: 2026-04-22
+date: 2026-04-22
 updated: 2026-04-22
 type: concept
 tags: [geo-theory, strategy]

--- a/docs/blog/posts/daily-blog-day-2.md
+++ b/docs/blog/posts/daily-blog-day-2.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 2: Architecting the Bot-Native Tech Stack"
-created: 2026-04-23
+date: 2026-04-23
 updated: 2026-04-23
 type: concept
 tags: [architecture, strategy, content]

--- a/docs/blog/posts/daily-blog-day-3.md
+++ b/docs/blog/posts/daily-blog-day-3.md
@@ -1,6 +1,6 @@
 ---
 title: "Daily Collaboration Blog Day 3: Developer-Grade Publishing & Preventing Hallucination Leaks"
-created: 2026-04-23
+date: 2026-04-23
 updated: 2026-04-23
 type: concept
 tags: [architecture, markdown]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,9 +27,7 @@ theme:
     - search.highlight
     - content.code.copy
 
-plugins:
-  - search
-  - roamlinks
+plugins:\n  - search\n  - roamlinks\n  - blog:\n      blog_dir: blog\n      post_dir: blog/posts
 
 markdown_extensions:
   - admonition
@@ -43,18 +41,10 @@ markdown_extensions:
   - def_list
   - attr_list
 
-nav:
-  - Home: index.md
-  - Strategy & Playbook: strategy.md
-  - Concepts:
+nav:\n  - Home: index.md\n  - Strategy & Playbook: strategy.md\n  - Blog: blog/index.md\n  - Concepts:
     - Overview: concepts/index.md
     - Citation Mechanics: concepts/citation-mechanics.md
-    - Semantic Structure: concepts/geo-semantic-structure.md
-    - GEO Tactics: concepts/geo-tactics.md
-    - Daily Blog: concepts/daily-blog-day-1.md
-    - Daily Blog Day 2: concepts/daily-blog-day-2.md
-    - Daily Blog Day 3: concepts/daily-blog-day-3.md
-  - Entities:
+    - Semantic Structure: concepts/geo-semantic-structure.md\n    - GEO Tactics: concepts/geo-tactics.md\n  - Entities:
     - Overview: entities/index.md
     - Princeton Paper: entities/princeton-geo-paper.md
     - Cursorrules Gen: entities/cursorrules-generator.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,12 @@ theme:
     - search.highlight
     - content.code.copy
 
-plugins:\n  - search\n  - roamlinks\n  - blog:\n      blog_dir: blog\n      post_dir: blog/posts
+plugins:
+  - search
+  - roamlinks
+  - blog:
+      blog_dir: blog
+      post_dir: blog/posts
 
 markdown_extensions:
   - admonition
@@ -41,10 +46,16 @@ markdown_extensions:
   - def_list
   - attr_list
 
-nav:\n  - Home: index.md\n  - Strategy & Playbook: strategy.md\n  - Blog: blog/index.md\n  - Concepts:
+nav:
+  - Home: index.md
+  - Strategy & Playbook: strategy.md
+  - Blog: blog/index.md
+  - Concepts:
     - Overview: concepts/index.md
     - Citation Mechanics: concepts/citation-mechanics.md
-    - Semantic Structure: concepts/geo-semantic-structure.md\n    - GEO Tactics: concepts/geo-tactics.md\n  - Entities:
+    - Semantic Structure: concepts/geo-semantic-structure.md
+    - GEO Tactics: concepts/geo-tactics.md
+  - Entities:
     - Overview: entities/index.md
     - Princeton Paper: entities/princeton-geo-paper.md
     - Cursorrules Gen: entities/cursorrules-generator.md


### PR DESCRIPTION
Migrates the daily blog entries from hardcoded concepts into the native Material for MkDocs Blog plugin for chronological pagination and tagging.