### PR TITLE
Fix: Enforce chronological blog ordering

### DIFF
--- a/docs/blog/posts/daily-blog-day-1.md
+++ b/docs/blog/posts/daily-blog-day-1.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 1: An AI and a Human Start a GEO Agency"
-date: 2026-04-22
+date: 2026-04-22 09:00
 updated: 2026-04-22
 type: concept
 tags: [geo-theory, strategy]

--- a/docs/blog/posts/daily-blog-day-1.md
+++ b/docs/blog/posts/daily-blog-day-1.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 1: An AI and a Human Start a GEO Agency"
-date: 2026-04-22 09:00
+date: 2026-04-22 09:00:00
 updated: 2026-04-22
 type: concept
 tags: [geo-theory, strategy]

--- a/docs/blog/posts/daily-blog-day-2.md
+++ b/docs/blog/posts/daily-blog-day-2.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 2: Architecting the Bot-Native Tech Stack"
-date: 2026-04-23
+date: 2026-04-23 09:00
 updated: 2026-04-23
 type: concept
 tags: [architecture, strategy, content]

--- a/docs/blog/posts/daily-blog-day-2.md
+++ b/docs/blog/posts/daily-blog-day-2.md
@@ -1,6 +1,6 @@
 ---
 title: "Day 2: Architecting the Bot-Native Tech Stack"
-date: 2026-04-23 09:00
+date: 2026-04-23 09:00:00
 updated: 2026-04-23
 type: concept
 tags: [architecture, strategy, content]

--- a/docs/blog/posts/daily-blog-day-3.md
+++ b/docs/blog/posts/daily-blog-day-3.md
@@ -1,6 +1,6 @@
 ---
 title: "Daily Collaboration Blog Day 3: Developer-Grade Publishing & Preventing Hallucination Leaks"
-date: 2026-04-23 14:00
+date: 2026-04-23 14:00:00
 updated: 2026-04-23
 type: concept
 tags: [architecture, markdown]

--- a/docs/blog/posts/daily-blog-day-3.md
+++ b/docs/blog/posts/daily-blog-day-3.md
@@ -1,6 +1,6 @@
 ---
 title: "Daily Collaboration Blog Day 3: Developer-Grade Publishing & Preventing Hallucination Leaks"
-date: 2026-04-23
+date: 2026-04-23 14:00
 updated: 2026-04-23
 type: concept
 tags: [architecture, markdown]


### PR DESCRIPTION
Adds specific time markers to the daily blog posts that share the same date (Day 2 and Day 3 were both published on April 23rd). MkDocs Material will use these exact timestamps to guarantee the chronological feed orders them correctly.