### PR TITLE
Feat: Add logo and fix slug routing

### DIFF
--- a/docs/blog/posts/daily-blog-day-1.md
+++ b/docs/blog/posts/daily-blog-day-1.md
@@ -1,5 +1,6 @@
 ---
 title: "Day 1: An AI and a Human Start a GEO Agency"
+slug: day-1-an-ai-and-a-human-start-a-geo-agency
 date: 2026-04-22 09:00:00
 updated: 2026-04-22
 type: concept

--- a/docs/blog/posts/daily-blog-day-2.md
+++ b/docs/blog/posts/daily-blog-day-2.md
@@ -1,5 +1,6 @@
 ---
 title: "Day 2: Architecting the Bot-Native Tech Stack"
+slug: day-2-architecting-the-bot-native-tech-stack
 date: 2026-04-23 09:00:00
 updated: 2026-04-23
 type: concept

--- a/docs/blog/posts/daily-blog-day-3.md
+++ b/docs/blog/posts/daily-blog-day-3.md
@@ -1,5 +1,6 @@
 ---
 title: "Day 3: Developer-Grade Publishing & Preventing Hallucination Leaks"
+slug: day-3-developer-grade-publishing-preventing-hallucination-leaks
 date: 2026-04-23 14:00:00
 updated: 2026-04-23
 type: concept

--- a/docs/blog/posts/daily-blog-day-3.md
+++ b/docs/blog/posts/daily-blog-day-3.md
@@ -1,5 +1,5 @@
 ---
-title: "Daily Collaboration Blog Day 3: Developer-Grade Publishing & Preventing Hallucination Leaks"
+title: "Day 3: Developer-Grade Publishing & Preventing Hallucination Leaks"
 date: 2026-04-23 14:00:00
 updated: 2026-04-23
 type: concept

--- a/docs/blog/posts/daily-blog-day-4.md
+++ b/docs/blog/posts/daily-blog-day-4.md
@@ -1,5 +1,6 @@
 ---
 title: "Day 4: Automated GEO Tracking & Agentic Onboarding"
+slug: day-4-automated-geo-tracking-agentic-onboarding
 date: 2026-04-24 10:00:00
 updated: 2026-04-24
 type: concept

--- a/docs/tools/blog_hook.py
+++ b/docs/tools/blog_hook.py
@@ -13,10 +13,14 @@ def on_config(config, **kwargs):
                 title = title_match.group(1)
                 date_str = date_match.group(1)
                 
-                # Simple slugify matching Material MkDocs
-                slug = title.lower()
-                slug = re.sub(r'[^a-z0-9\s\-]', '', slug)
-                slug = re.sub(r'[\s\-]+', '-', slug).strip('-')
+                # Read explicitly defined slug from frontmatter
+                slug_match = re.search(r'^slug:\s*(.*?)$', content, flags=re.MULTILINE)
+                if slug_match:
+                    slug = slug_match.group(1).strip()
+                else:
+                    slug = title.lower()
+                    slug = re.sub(r'[^a-z0-9\s\-]', '', slug)
+                    slug = re.sub(r'[\s\-]+', '-', slug).strip('-')
                 
                 url = f"/blog/{date_str.replace('-', '/')}/{slug}/"
                 posts.append({"title": title, "date_str": date_match.group(0), "url": url})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,8 @@ site_description: The Definitive Generative Engine Optimization (GEO) & AI Searc
 
 theme:
   name: material
+  logo: material/robot-outline
+  favicon: material/robot-outline
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
1. Adds the 'robot-outline' SVG icon as the global logo and favicon to fit the bot-native tech stack narrative.\n2. Fixes a bug where MkDocs Material double-hyphenates slugs with special characters, breaking the blog hook routing. The hook now reads explicit frontmatter slugs.