### PR TITLE
fix: Crop SVG padding for proper logo sizing

### DIFF
--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="20 20 60 60">
   <defs>
     <mask id="cutZ">
       <rect x="0" y="0" width="100" height="100" fill="white"/>

--- a/docs/assets/logo-concepts/4_2_negative_space.svg
+++ b/docs/assets/logo-concepts/4_2_negative_space.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="20 20 60 60">
   <defs>
     <mask id="cutZ">
       <rect x="0" y="0" width="100" height="100" fill="white"/>


### PR DESCRIPTION
Adjusts the SVG `viewBox` from `0 0 100 100` down to `20 20 60 60` to eliminate dead space. This ensures the MkDocs Material header renders the logo at full size and proper alignment.