### PR TITLE
style: Tighten gap between logo and site title

### DIFF
--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -1,0 +1,4 @@
+/* Bring the site title closer to the logo without altering the logo's symmetrical hit area */
+.md-header__title {
+    margin-left: 0.25rem !important; 
+}

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -1,4 +1,4 @@
 /* Bring the site title closer to the logo without altering the logo's symmetrical hit area */
-.md-header__title {
-    margin-left: 0.25rem !important; 
+header.md-header nav.md-header__inner .md-header__title {
+    margin-left: 0.25rem; 
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,9 @@ plugins:
 hooks:
   - docs/tools/blog_hook.py
 
+extra_css:
+  - stylesheets/custom.css
+
 markdown_extensions:
   - admonition
   - pymdownx.details


### PR DESCRIPTION
Reduces the `margin-left` on the `.md-header__title` to bring the text closer to the logo. This preserves the logo's symmetrical hit area and prevents alignment breakage on mobile viewports.