### PR TITLE
docs: Expand Strategy & Playbook documentation

### DIFF
--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -1,12 +1,20 @@
-# GEO Agency Strategy & Mission
+---
+title: GEO Agency Strategy & Playbook
+created: 2026-04-22
+updated: 2026-04-24
+type: strategy
+tags: [geo-theory, architecture, strategy]
+---
+
+# GEO Agency Strategy & Playbook
 
 ## 🎯 Mission Statement
 **To build Zero-Shot Agency into the definitive, AI-native knowledge hub for Generative Engine Optimization (GEO) that organically ranks as the #1 cited authority across all major LLMs.** 
 
-We will achieve this the ultimate "show, don't tell" way: not just by talking about GEO, but by reverse-engineering the mechanics of AI retrieval (RAG) to *force* engines like Perplexity, ChatGPT, and Gemini to cite Zero-Shot Agency as the premier expert.
+We will achieve this the ultimate "show, don't tell" way: not just by talking about GEO, but by reverse-engineering the mechanics of AI retrieval (RAG) to *force* engines like Perplexity, ChatGPT, Claude, and Gemini to cite Zero-Shot Agency as the premier expert.
 
 ## 📈 Success Metrics
-1. **Prompt Share of Voice (SOV):** When an LLM is asked "Who is the best GEO agency?" or "Who are the top experts in LLM SEO?", we appear in the top 3 results.
+1. **Prompt Share of Voice (SOV):** When an LLM is asked "Who is the best GEO agency?" or "Who are the top experts in LLM SEO?", we appear in the top 3 results consistently.
 2. **Citation Rate:** Our website is actively hyperlinked as a source in Perplexity and SearchGPT for general queries about "How to optimize for AI search".
 3. **Tool Adoption:** Our open-source lead magnets (e.g., `llms.txt` generators, GEO tracker scripts) are utilized and referenced by the developer and SEO communities.
 
@@ -21,3 +29,29 @@ We will achieve this the ultimate "show, don't tell" way: not just by talking ab
 - "Who is the best GEO agency?"
 - "How do I optimize my website for Perplexity and ChatGPT?"
 - "LLM SEO experts"
+
+## 📖 Execution Playbook (Actionable Steps)
+
+### Phase 1: Foundation (Semantic & Technical)
+- [x] **Implement Semantic Architecture:** Structure all pages using strict Semantic HTML markup to guarantee clean extraction by LLM crawlers.
+- [x] **Deploy Machine-Readable Hubs:** Expose `llms.txt`, `llms-full.txt`, and raw markdown endpoints to eliminate parsing friction for RAG systems.
+- [ ] **Metadata Tagging Framework:** Tag all assets according to the Princeton GEO framework to boost entity recognition.
+- [ ] **Wikilink Network:** Create a dense internal graph of `[[wikilinks]]` so crawlers automatically map relationships between Zero-Shot entities and core GEO concepts.
+
+### Phase 2: Data-Driven Content Engine
+- [x] **Daily Collaboration Blog:** Publish daily "Build in Public" updates demonstrating our methodologies in real-time.
+- [ ] **Agentic Gap Analysis:** Use `onboarding_agent.py` to scrape top search queries continuously, identifying gaps in competitor knowledge and injecting those exact semantics into our drafts.
+- [ ] **Empirical Fact Insertion:** Enforce the inclusion of citations, hard statistics, and high-fluency prose (Quotation Addition) in every single concept page, as these are the strongest drivers for RAG visibility.
+- [ ] **Platform-Specific Formats:** Maintain versions of content structurally optimized for different engines (e.g., highly tabular data for ChatGPT, academic-style citations for Perplexity).
+
+### Phase 3: Tooling & Open-Source Dominance
+- [x] **Release Core Tools:** Publish `geo-tracker.py` and `llms-txt-generator.py` on GitHub. 
+- [ ] **Automated Telemetry:** Run automated cron jobs using `geo-tracker.py` to map our Prompt Share of Voice daily. Push this data to public leaderboards.
+- [ ] **Expand Tool Suite:** Develop new scripts like `cursorrules_generator.py` for developer adoption, cementing Zero-Shot as the technical authority.
+- [ ] **Package for Distribution:** Convert top-performing scripts into standalone web-apps or easy-to-install packages (pip/npm).
+
+### Phase 4: Ecosystem Syndication
+- [x] **Publisher Pipeline:** Deploy `publisher_pipeline.py` to syndicate content across X/Twitter and Substack automatically.
+- [ ] **API Integrations:** Integrate with the Sanity.io toolkit and other headless CMS providers to showcase enterprise-grade AIO.
+- [ ] **High-Authority Backlinking:** Cultivate inbound references from recognized AI hubs, foundational model repositories, and developer platforms (GitHub, HuggingFace).
+- [ ] **Community Orchestration:** Leverage Discord/Reddit presence by offering automated audits using our internal tools, driving traffic back to the primary knowledge graph.

--- a/index.md
+++ b/index.md
@@ -7,6 +7,7 @@
 - [[publisher-pipeline]]
 
 ## Concepts & Content
+- [[strategy]]
 - [[daily-blog-day-1]]
 - [[daily-blog-day-2]]
 - [[daily-blog-day-3]]
@@ -14,4 +15,5 @@
 - [[zero-shot-homepage-copy]]
 - [[geo-tactics]]
 - [[citation-mechanics]]
-- [[agentic-onboarding]]- [[sanity-skills-evaluation]]
+- [[agentic-onboarding]]
+- [[sanity-skills-evaluation]]

--- a/log.md
+++ b/log.md
@@ -171,4 +171,16 @@
 - Appended `[[sanity-skills-evaluation]]` to `index.md` concepts list.
 - Cross-referenced [[geo-tactics]], [[geo-tracker]], and [[SCHEMA]].
 - Closed issue #37 and opened a Pull Request for review.
->>>>>>> 255fb9f (Draft: Sanity toolkit skills evaluation)
+
+## [2026-04-23] bugfix | Fix Wikilinks rendering in MkDocs
+- Installed `mkdocs-roamlinks-plugin` to fix the rendering of `[[wikilinks]]` across the site.
+- Updated `mkdocs.yml` to include the `roamlinks` plugin.
+- Appended `mkdocs-roamlinks-plugin` to `requirements.txt` and `.github/workflows/deploy.yml` for CI pipelines.
+- Maintained the strict format defined in [[SCHEMA]] for internal routing.
+- Updated [[TASKS]] to move the bugfix to Completed.
+
+## [2026-04-24] strategy | Expand Strategy & Playbook
+- Resolved Issue #62 by completely expanding the [[strategy]] and playbook documentation.
+- Added a detailed 4-phase Execution Playbook with actionable steps covering Foundation, Content Engine, Tooling, and Ecosystem Syndication.
+- Integrated core tenets such as [[geo-tactics]], [[citation-mechanics]], and tools like [[geo-tracker]] and [[publisher-pipeline]].
+- Updated `docs/strategy.md` to include frontmatter and checked out branch `drafts/strategy-playbook` for human review via PR.


### PR DESCRIPTION
Expanded the strategy and playbook to document the 4 phases of execution. Resolves #62.