### PR TITLE
chore: Enable union merges for log files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Automatically resolve append-conflicts by keeping both sets of changes (Union Merge)
+log.md merge=union
+latest_agent.log merge=union
+docs/log.md merge=union


### PR DESCRIPTION
Sets `merge=union` in `.gitattributes` for `log.md` and `latest_agent.log`. Because Ralph is an asynchronous agent, sequential pull requests frequently conflict when trying to append logs to the bottom of the same file. The union merge driver automatically accepts both sets of changes, completely eliminating this class of merge conflict.