### PR TITLE
chore: ignore audit scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__/
 .cache/
 latest_agent.log
 ef_geo_audit.md
+audit_site.py
+*-audit.md

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ latest_agent.log
 ef_geo_audit.md
 audit_site.py
 *-audit.md
+audit_site.py
+*-audit.md

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,3 @@ latest_agent.log
 ef_geo_audit.md
 audit_site.py
 *-audit.md
-audit_site.py
-*-audit.md


### PR DESCRIPTION
Prevents ralph from blindly scooping up local audit scripts during git add .