### PR TITLE
fix: Use correct model slugs in citations.csv

### DIFF
--- a/docs/logs/entries/2026-04-27-issue-113.md
+++ b/docs/logs/entries/2026-04-27-issue-113.md
@@ -1,0 +1,4 @@
+## [2026-04-27] bugfix | Fix Tracker Model Slugs in CSV
+- Discovered that the OpenRouter refactor in PR #66 mapped arbitrary keys (`openai_best`, `xai_best`) to the CSV headers instead of the actual model slugs.
+- Because `generate_leaderboard.py` parses these headers dynamically, the leaderboard would have displayed "openai_best" instead of "gpt-5.5-pro".
+- Patched `geo-tracker.py` to extract the correct string from the OpenRouter model ID (e.g. `gpt-5.5-pro`) and inject that into the `citations.csv` headers.

--- a/geo-tracker.py
+++ b/geo-tracker.py
@@ -78,13 +78,13 @@ def main():
 
     csv_data = []
     
-    fieldnames = ["query"] + [f"{k}_mentioned" for k in MODELS]
+    fieldnames = ["query"] + [f"{model_id.split('/')[-1]}_mentioned" for model_id in MODELS.values()]
 
     for idx, query in enumerate(args.queries, 1):
         print(f"Query {idx}/{len(args.queries)}: '{query}'")
         row = {"query": query}
-        for k in MODELS:
-            row[f"{k}_mentioned"] = False
+        for model_id in MODELS.values():
+            row[f"{model_id.split('/')[-1]}_mentioned"] = False
         
         for model_key, model_id in MODELS.items():
             print(f"  Querying {model_key} ({model_id})...")
@@ -96,7 +96,7 @@ def main():
             if mentioned: 
                 results[model_key]["mentions"] += 1
                 
-            row[f"{model_key}_mentioned"] = mentioned
+            row[f"{model_id.split('/')[-1]}_mentioned"] = mentioned
             print(f"  -> Mentioned: {mentioned} (Took {time.time() - start_time:.2f}s)")
             time.sleep(1)  # Brief pause between models to avoid aggressive rate limiting
 


### PR DESCRIPTION
Fixes an edge case introduced by the 12-model OpenRouter refactor (PR #66). 

Because the tracker used generic dictionary keys (, ) for the CSV headers, the  script was going to print  directly onto the public website's leaderboard instead of the actual  model slug.

This PR patches  to parse the actual model ID (e.g., extracting  from ) so that the CSV file matches the public leaderboard perfectly.