### PR TITLE
fix: Automate dynamic blog navigation hook

### DIFF
--- a/docs/logs/entries/2026-04-27-issue-121.md
+++ b/docs/logs/entries/2026-04-27-issue-121.md
@@ -1,0 +1,5 @@
+## [2026-04-27] bugfix | Automate Blog Navigation Hook
+- Discovered that the "Most Recent Blog Posts" links in the sidebar navigation were failing to update dynamically.
+- Identified the root cause in `docs/tools/blog_hook.py`: The python script was attempting to manually construct absolute HTML paths (`/blog/YYYY/MM/DD/slug/`). MkDocs treats paths starting with `/` as external, completely bypassing its internal routing and failing to update the navigation accurately.
+- Refactored `blog_hook.py` to simply pass the internal Markdown paths (`blog/posts/[filename].md`) to the `nav` dictionary.
+- MkDocs Material now correctly intercepts these files, automatically converts them to their corresponding live URLs, and seamlessly updates the sidebar with the latest 3 posts on every site build.

--- a/docs/tools/blog_hook.py
+++ b/docs/tools/blog_hook.py
@@ -22,7 +22,7 @@ def on_config(config, **kwargs):
                     slug = re.sub(r'[^a-z0-9\s\-]', '', slug)
                     slug = re.sub(r'[\s\-]+', '-', slug).strip('-')
                 
-                url = f"/blog/{date_str.replace('-', '/')}/{slug}/"
+                url = f"blog/posts/{file.name}"
                 posts.append({"title": title, "date_str": date_match.group(0), "url": url})
     
     # Sort descending based on exact date string


### PR DESCRIPTION
Fixes the 'Recent Blog Posts' sidebar navigation. 

Previously, `blog_hook.py` was attempting to manually construct absolute HTML URLs (`/blog/2026/...`), which caused MkDocs to treat them as external links and fail to map them dynamically. 

This PR refactors the Python script to directly pass the internal Markdown file paths (`blog/posts/daily-blog-day-7.md`) to the `nav` block. MkDocs now intercepts the files correctly and automatically builds the URLs, ensuring the sidebar will continuously update with the 3 most recent posts on every build without manual intervention.