### PR TITLE
chore: Enforce body-file usage for GitHub CLI newlines

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -10,7 +10,9 @@ Generative Engine Optimization (GEO) and AI Search Optimization (AIO). The sole 
 - When updating a page, always bump the `updated` date
 - Every new page must be added to `index.md`
 - Every action must be logged as a new file in `docs/logs/entries/`
+## GitHub CLI and Pull Requests
 - **AGENTS MUST NEVER MERGE PULL REQUESTS.** Only human operators are authorized to merge. Agents must stop after `gh pr create`.
+- **Pull Request Bodies:** When using `gh pr create` with multiline bodies, NEVER use inline `--body "text\ntext"`. Bash does not parse `\n` in double quotes correctly. ALWAYS use a heredoc or `--body-file` to preserve real newlines. (e.g., `gh pr create --body-file pr_body.txt`)
 
 ## Frontmatter
 ```yaml

--- a/docs/logs/entries/2026-04-27-issue-122.md
+++ b/docs/logs/entries/2026-04-27-issue-122.md
@@ -1,0 +1,4 @@
+## [2026-04-27] bugfix | Fix PR Body Newlines and Update SCHEMA
+- Discovered that executing `gh pr create` with inline `--body` parameters and literal `\n` characters caused raw strings like `\n\n` to appear in GitHub Pull Request descriptions.
+- Deployed an automated Python script (`fix_prs.py`) to scrape the last 20 PRs, identify any with literal `\n` tokens, replace them with actual system newlines, and patch the GitHub PRs via the CLI.
+- Added a strict operational rule to `SCHEMA.md` mandating that autonomous agents must always use `--body-file` or Heredocs when generating GitHub issues/PRs to preserve natural formatting.


### PR DESCRIPTION
Fixes the formatting of pull requests submitted by autonomous agents.

When passing a string with `\n` to the `gh pr create` command via Bash using double quotes, Bash passes literal backslash-n characters instead of parsing them as actual newlines. This resulted in ugly, unbroken walls of text on GitHub.

This PR establishes a hard rule in `SCHEMA.md` that agents must use `--body-file` or heredocs when interacting with the GitHub CLI to preserve formatting.
