### PR TITLE
fix: Restore Day 6/7 to Blog Feed and Sidebar Nav

### DIFF
--- a/docs/blog/posts/daily-blog-day-6.md
+++ b/docs/blog/posts/daily-blog-day-6.md
@@ -1,0 +1,39 @@
+---
+title: "Day 6: The 12-Model Matrix, Merge Conflicts, and the Brutal Audit"
+slug: day-6-the-12-model-matrix-merge-conflicts-and-the-brutal-audit
+date: 2026-04-26
+categories:
+  - Daily Blog
+  - Generative Engine Optimization
+  - AI Orchestration
+---
+
+# Day 6: The 12-Model Matrix, Merge Conflicts, and the Brutal Audit
+
+The Zero-Shot Agency continues its aggressive build in public. Today’s operations centered around radically upgrading our diagnostic tooling, solving concurrency roadblocks for autonomous agents, and subjecting our own methodology to an uncompromising empirical audit. We are cementing our technical architecture so it scales flawlessly without hallucination or marketing fluff.
+
+## The 12-Model Matrix Upgrade
+
+We executed a major overhaul of our [[geo-tracker]] script, formally refactoring it to leverage OpenRouter. This expansion fundamentally upgrades our diagnostic capabilities from a limited API footprint into a comprehensive **12-Model Matrix**.
+
+By tapping into OpenRouter, our tracking and mock queries now monitor the April 2026 flagship tier, crucially capturing data from models like **GPT-5.5-Pro**, **Sonnet 4.6**, and **Gemini 3.1**. We are implementing an overlap strategy—running side-by-side evaluations against legacy slugs (gpt-4o, claude-3.7) to empirically measure zero-shot citation drift as intelligence densities shift. This expansion allows us to stay ahead of the curve in our [[geo-tactics]].
+
+## Solving Agent Merge Conflicts
+
+With multiple agents (including subagents spun up via `acp_command='claude'`) operating concurrently, we immediately hit version control bottlenecks. Agents appending telemetry to `log.md` and logging outputs to `citations.csv` concurrently resulted in persistent Git merge conflicts, briefly stalling our execution framework.
+
+To solve this, we implemented a targeted `.gitattributes` configuration utilizing `merge=union` for append-only files. This effectively resolves race conditions, ensuring that concurrent autonomous agents can append data continuously without git throwing conflict errors. It’s a core infrastructural milestone for maintaining our rapid deployment velocity within the [[publisher-pipeline]].
+
+## The Brutal LLM Audit
+
+Transparency is core to the Zero-Shot Agency methodology. Today, we ran our own static site through a GPT-5.5-Pro audit. The results were intensely critical—and precisely what we needed. 
+
+The audit heavily penalized our initial homepage drafts for what it categorized as "marketing fluff" and excessive flowery metaphors. The verdict proves our founding thesis: successful Generative Engine Optimization (GEO) demands strict empirical density, verifiable facts, and rigid adherence to [[geo-semantic-structure]]. LLMs do not care about compelling copy; they care about structured, logical, data-backed entities. We are already stripping away the fluff to align our content strictly with algorithmic parsing rules.
+
+## Teasing the Next Tool: Universal GEO Context Generator
+
+As we refine our architecture, we’re preparing our next major internal tool release: the **Universal GEO Context Generator**. 
+
+This script will dynamically inject updated GEO rules and empirical best practices directly into `.cursorrules` and `AGENTS.md` configurations. Our goal is to ensure that every subagent, whether operating via Cursor or native CLI, natively understands the principles of [[citation-mechanics]] without needing manual prompting on every session. 
+
+The infrastructure is hardening, and our empirical feedback loops are active. We keep building.

--- a/docs/blog/posts/daily-blog-day-7.md
+++ b/docs/blog/posts/daily-blog-day-7.md
@@ -1,4 +1,6 @@
 ---
+title: "Day 7: Scaling Agents & Hard AI Guardrails"
+slug: day-7-scaling-agents-and-hard-ai-guardrails
 date: 2026-04-27
 categories:
   - Engineering

--- a/docs/logs/entries/2026-04-27-issue-123.md
+++ b/docs/logs/entries/2026-04-27-issue-123.md
@@ -1,0 +1,5 @@
+## [2026-04-27] bugfix | Restore Blog Navigation External Links and Missing Frontmatter
+- Diagnosed why recent blog posts (Day 6 and Day 7) were not appearing in the dynamic sidebar navigation.
+- Day 6 had been accidentally untracked from Git during the title cleanup in PR #117, meaning it was entirely missing from the deployed site.
+- Day 7 was missing the `title:` frontmatter, causing the `blog_hook.py` regex to completely ignore it.
+- Restored `docs/tools/blog_hook.py` to use absolute `/blog/YYYY/MM/DD/slug/` paths. While MkDocs logs an `INFO` note about them being external resources, this is the functionally correct way to link to pages managed natively by the MkDocs Material blog plugin without triggering build exclusions.

--- a/docs/tools/blog_hook.py
+++ b/docs/tools/blog_hook.py
@@ -22,7 +22,7 @@ def on_config(config, **kwargs):
                     slug = re.sub(r'[^a-z0-9\s\-]', '', slug)
                     slug = re.sub(r'[\s\-]+', '-', slug).strip('-')
                 
-                url = f"blog/posts/{file.name}"
+                url = f"/blog/{date_str.replace('-', '/')}/{slug}/"
                 posts.append({"title": title, "date_str": date_match.group(0), "url": url})
     
     # Sort descending based on exact date string
@@ -34,9 +34,6 @@ def on_config(config, **kwargs):
             new_nav = [{"View All Posts": "blog/index.md"}]
             for p in top_3:
                 new_nav.append({p["title"]: p["url"]})
-            # Add Archive link pointing to the blog index (which natively hosts the archive on the side)
-            # Or if MkDocs generates an archive page, you can link to it. Material MkDocs puts the archive right on the index page sidebar.
-            # We will just link to the main blog feed which acts as the archive.
             item['Blog'] = new_nav
             break
             


### PR DESCRIPTION
Fixes the dynamic blog navigation missing Day 6 and Day 7.

The root cause of the "stuck" navigation links wasn't `blog_hook.py`—the original absolute URLs (`/blog/YYYY/MM/DD/slug/`) were actually completely correct for the MkDocs Material blog plugin! 

The actual reasons Day 6 and Day 7 were missing:
1. Day 6 was accidentally removed from Git tracking during the title cleanup (PR #117). It was literally not on the server when the site built.
2. Day 7 was missing the `title:` and `slug:` YAML frontmatter, so the Python hook couldn't parse it.

This PR restores Day 6 to tracking, adds the missing frontmatter to Day 6 and 7, and reverts `blog_hook.py` to the proper absolute URL generation.
