### PR TITLE
Fix: Update Day 8 Wikilinks and Concepts Index

### DIFF
--- a/docs/blog/posts/daily-blog-day-8.md
+++ b/docs/blog/posts/daily-blog-day-8.md
@@ -12,27 +12,27 @@ categories:
 
 As the search landscape pivots from traditional ten blue links toward synthesized AI answers (via Perplexity, SearchGPT, and Claude), our optimization strategies must completely evolve. Traditional SEO tactics are not just becoming less effective—in some cases, they are actively harmful.
 
-Today, we dive into the empirical data from the foundational Princeton GEO (Generative Engine Optimization) paper to understand exactly why AI Search Ranking Factors diverge so heavily from traditional SEO.
+Today, we dive into the empirical data from the foundational [[princeton-geo-paper]] (Generative Engine Optimization) to understand exactly why AI [[ranking-factors]] diverge so heavily from traditional SEO.
 
 ## The Death of Keyword Stuffing
 
 For decades, traditional SEO relied heavily on keyword density. If you wanted to rank for a term, you made sure the exact phrase appeared in your H1, URL, meta description, and throughout the body copy.
 
-However, LLMs utilizing Retrieval-Augmented Generation (RAG) do not parse content like traditional web crawlers. They rely on semantic embeddings and similarity metrics. When researchers tested classic SEO techniques against LLM search visibility, the results were stark.
+However, LLMs utilizing [[rag-architecture]] (Retrieval-Augmented Generation) do not parse content like traditional web crawlers. They rely on semantic embeddings and similarity metrics. When researchers tested classic SEO techniques against LLM search visibility, the results were stark.
 
 According to the Princeton GEO paper's empirical data (Tables 6/7), traditional **"Keyword Stuffing" actually performs worse than doing nothing at all.** Over-optimizing with exact match keywords degrades the semantic quality of the text, causing the embedding similarity score to drop and leading the AI to ignore the source entirely.
 
 ## The New Ranking Factors: Statistics and Quotations
 
-If keywords don't work, what does? To boost our **Prompt Share of Voice (SOV)**, we need to feed the AI what it naturally prefers: dense, authoritative facts that are easy to extract and synthesize.
+If keywords don't work, what does? To boost our Prompt Share of Voice (SOV), we need to feed the AI what it naturally prefers: dense, authoritative facts that are easy to extract and synthesize.
 
-The Princeton data revealed two massive winners in the GEO space:
+The [[princeton-geo-paper]] data revealed two massive winners regarding [[geo-tactics]]:
 
 ### 1. Statistics Addition
 LLMs are mathematically driven to favor factual density. By injecting hard numbers, percentages, and empirical data points into your content, you dramatically increase the likelihood of the AI selecting your source to answer a user's query. The Princeton paper showed that **Statistics Addition boosts visibility by up to 40%**.
 
 ### 2. Quotation Addition
-High-fluency prose paired with authoritative quotes acts as a strong signal to the AI that the text is credible and primary source material. Injecting direct quotes from subject matter experts (or primary papers) forces the RAG system to recognize the content's depth, leading to higher citation rates.
+High-fluency prose paired with authoritative quotes acts as a strong signal to the AI that the text is credible and primary source material. Injecting direct quotes from subject matter experts (or primary papers) forces the RAG system to recognize the content's depth, leading to higher [[citation-mechanics|citation rates]].
 
 ## Adapting the Zero-Shot Agency Playbook
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -26,9 +26,9 @@ Welcome to the Zero-Shot Agency concepts wiki. This section contains our raw pla
 
 ## Daily Blogs
 
-* [Daily Blog: Day 1](daily-blog-day-1.md)
-* [Daily Blog: Day 2](daily-blog-day-2.md)
-* [Daily Blog: Day 3](daily-blog-day-3.md)
+* [Daily Blog: Day 1](../blog/posts/daily-blog-day-1.md)
+* [Daily Blog: Day 2](../blog/posts/daily-blog-day-2.md)
+* [Daily Blog: Day 3](../blog/posts/daily-blog-day-3.md)
 * [Daily Blog: Day 4](../blog/posts/daily-blog-day-4.md)
 * [Daily Blog: Day 5](../blog/posts/daily-blog-day-5.md)
 * [Daily Blog: Day 6](../blog/posts/daily-blog-day-6.md)


### PR DESCRIPTION
Adds relevant internal wikilinks (e.g. `[[princeton-geo-paper]]`, `[[rag-architecture]]`, `[[ranking-factors]]`, `[[geo-tactics]]`, `[[citation-mechanics]]`) to the Day 8 blog post, and cleans up the duplicate/legacy relative paths in `docs/concepts/index.md`.