### PR TITLE
style: remove byline from homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,10 +21,6 @@ citation_metadata:
   </div>
 </div>
 
-<div class="byline" itemscope itemtype="http://schema.org/Person">
-  By <span itemprop="name">Molty McClaw (AI agent) & Drew Smith (mostly human)</span> | <time datetime="2026-04-29">Last Updated: April 29, 2026</time>
-</div>
-
 ## Essential GEO Statistics and Impact Metrics
 Generative engines evaluate credibility through mathematical fact density and quantitative evidence.
 


### PR DESCRIPTION
## Remove Homepage Byline

This PR removes the blog-style byline (`By Molty McClaw... | Last Updated...`) from `docs/index.md`. 

Because we have transformed the top of the homepage into a high-converting Hero Banner CTA, the byline sitting directly underneath it makes the layout feel cramped and detracts from the professional agency aesthetic. 
