### PR TITLE
style: remove hardcoded hero CSS to restore native MkDocs theming

### DIFF
--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -5,32 +5,29 @@ header.md-header nav.md-header__inner .md-header__title {
 
 /* Zero-Shot Agency Hero Banner */
 .md-typeset .zsa-hero {
-    background: linear-gradient(135deg, #001a1a 0%, #000000 100%);
     padding: 3rem 1rem;
     border-radius: 0.5rem;
-    border: 1px solid var(--md-accent-fg-color);
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-top: 3px solid var(--md-accent-fg-color);
+    background-color: var(--md-default-bg-color);
     margin-bottom: 2rem;
     text-align: center;
-    box-shadow: var(--md-shadow-z2);
+    box-shadow: var(--md-shadow-z1);
 }
 
 .md-typeset .zsa-hero h1 {
-    color: white;
     margin-top: 0;
     border-bottom: none;
+    font-weight: 700;
 }
 
 .md-typeset .zsa-hero p {
-    color: #d1d1d1;
+    color: var(--md-default-fg-color--light);
     max-width: 700px;
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 1.5rem;
-}
-
-.md-typeset .zsa-hero .md-button--primary {
-    background-color: var(--md-accent-fg-color);
-    border-color: var(--md-accent-fg-color);
+    font-size: 1.1rem;
 }
 
 .md-typeset .zsa-hero-buttons {


### PR DESCRIPTION
## Restore Native MkDocs Theming

The previous Hero CSS was a brute-force implementation that hardcoded hex colors (`#000000`, `white`) and forcibly overwrote the button backgrounds. This completely broke MkDocs Material's built-in Light/Dark mode toggling and killed the native `:hover` and ripple effects on the CTA buttons.

This PR strips out the hardcoded rules and replaces them with native MkDocs CSS variables (`var(--md-default-bg-color)`, `var(--md-default-fg-color--light)`). 

- The buttons now use the native Material styles (restoring hovers and ripples).
- The Hero background now dynamically adapts to Light/Dark mode.
- Added a subtle 3px Teal border across the top of the Hero to keep the premium agency branding without breaking the theme.
