### PR TITLE
style: remove overriding typography rules to restore native responsive scale

### DIFF
--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -18,7 +18,6 @@ header.md-header nav.md-header__inner .md-header__title {
 .md-typeset .zsa-hero h1 {
     margin-top: 0;
     border-bottom: none;
-    font-weight: 700;
 }
 
 .md-typeset .zsa-hero p {
@@ -27,7 +26,6 @@ header.md-header nav.md-header__inner .md-header__title {
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 1.5rem;
-    font-size: 1.1rem;
 }
 
 .md-typeset .zsa-hero-buttons {


### PR DESCRIPTION
## Restore Native Typography Scale

This PR removes the rogue `font-weight: 700` and `font-size: 1.1rem` CSS rules that were accidentally introduced to the `.zsa-hero` class in the previous PR.

By removing these hardcoded overrides, MkDocs Material can properly render the Hero text according to its native, responsive typography scale, fixing the mismatched sizes shown in the desktop layout.
