### PR TITLE
style: restore premium hero background gradient dynamically via scheme attribute

### DIFF
--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -9,10 +9,19 @@ header.md-header nav.md-header__inner .md-header__title {
     border-radius: 0.5rem;
     border: 1px solid var(--md-default-fg-color--lightest);
     border-top: 3px solid var(--md-accent-fg-color);
-    background-color: var(--md-default-bg-color);
     margin-bottom: 2rem;
     text-align: center;
     box-shadow: var(--md-shadow-z1);
+}
+
+/* Light Mode Hero Background */
+[data-md-color-scheme="default"] .md-typeset .zsa-hero {
+    background: linear-gradient(135deg, #f0fdfa 0%, #ffffff 100%);
+}
+
+/* Dark Mode Hero Background */
+[data-md-color-scheme="slate"] .md-typeset .zsa-hero {
+    background: linear-gradient(135deg, #001a1a 0%, #000000 100%);
 }
 
 .md-typeset .zsa-hero h1 {


### PR DESCRIPTION
## Restore Hero Banner Gradient (Safely)

In PR #142, by removing the hardcoded colors to fix the native button hovers, we accidentally made the Hero Banner background the *exact same color* as the page body (`var(--md-default-bg-color)`). 

This is why the latest screenshot looked completely "undone"—without a distinct background, the banner just looks like a wireframe box floating in the middle of the screen, losing all its premium impact.

**The Fix:**
Instead of hardcoding colors globally, this PR uses MkDocs' native `[data-md-color-scheme="slate"]` and `[data-md-color-scheme="default"]` HTML attributes to scope the CSS.

- **Dark Mode:** Restores the dark teal/black gradient you liked.
- **Light Mode:** Applies a clean, subtle teal/white gradient. 

The background is back, and the buttons still keep their native hover/ripple effects!
