### PR TITLE
fix: add cache-buster to custom.css to bypass cloudflare edge caching

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ hooks:
   - tools/build_log.py
 
 extra_css:
-  - stylesheets/custom.css
+  - stylesheets/custom.css?v=1.1
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Add CSS Cache Buster

Since we are fronting GitHub Pages with Cloudflare, our `.css` updates are getting aggressively cached at the edge node level. This means every time we merge a styling PR, the HTML updates immediately but users still see broken or old CSS unless they manually clear their Cloudflare dashboard cache.

This PR adds a version query string (`?v=1.1`) to the `mkdocs.yml` CSS inclusion. This forces Cloudflare and local browsers to recognize it as a new file and fetch the latest styles immediately.
