### PR TITLE
docs(blog): Day 10 - The Dual Mandate in GEO

### DIFF
--- a/docs/blog/posts/daily-blog-day-10.md
+++ b/docs/blog/posts/daily-blog-day-10.md
@@ -11,7 +11,7 @@ categories:
 
 Most brands are still playing the 2023 SEO game. You’re stuffing long-tail keywords into headings and buying questionable backlinks, hoping Google’s traditional crawler takes the bait. 
 
-Here is the brutal truth: Perplexity, SearchGPT, and Claude do not care about your keyword density. They care about factual density, semantic architecture, and data extraction. If you are not optimizing for Large Language Models, your brand is effectively invisible to the fastest-growing segment of high-intent searchers.
+Here is the brutal truth: Perplexity, ChatGPT, and Claude do not care about your keyword density. They care about factual density, semantic architecture, and data extraction. If you are not optimizing for Large Language Models, your brand is effectively invisible to the fastest-growing segment of high-intent searchers.
 
 At Zero-Shot Agency, we approach Generative Engine Optimization (GEO) through what we call **The Dual Mandate**: you must build strict, data-dense, bot-native infrastructure to satisfy RAG algorithms, but you must balance it with a premium, high-conversion UI/UX to win the human.
 

--- a/docs/blog/posts/daily-blog-day-10.md
+++ b/docs/blog/posts/daily-blog-day-10.md
@@ -1,0 +1,34 @@
+---
+date: 2026-04-30
+authors: [ralph]
+categories:
+  - Generative Engine Optimization
+  - AI Strategy
+  - AIO
+---
+
+# The Dual Mandate: Why Your SEO Strategy Fails in an AI-First Web
+
+Most brands are still playing the 2023 SEO game. You’re stuffing long-tail keywords into headings and buying questionable backlinks, hoping Google’s traditional crawler takes the bait. 
+
+Here is the brutal truth: Perplexity, SearchGPT, and Claude do not care about your keyword density. They care about factual density, semantic architecture, and data extraction. If you are not optimizing for Large Language Models, your brand is effectively invisible to the fastest-growing segment of high-intent searchers.
+
+At Zero-Shot Agency, we approach Generative Engine Optimization (GEO) through what we call **The Dual Mandate**: you must build strict, data-dense, bot-native infrastructure to satisfy RAG algorithms, but you must balance it with a premium, high-conversion UI/UX to win the human.
+
+## Mandate 1: The Bot-Native Infrastructure
+
+AI models don't "read" your site the way traditional search indexers do; they extract entities and relationships. To become the definitive source that an AI cites, your infrastructure needs to be pristine.
+
+This means moving beyond standard metadata. We implement `llms.txt` files, strict semantic HTML, and high-density factual assertions that RAG (Retrieval-Augmented Generation) pipelines can easily ingest and verify. If an AI cannot parse your value proposition without hallucinating, it will skip you and cite your competitor whose data structure is cleaner.
+
+## Mandate 2: The Human Conversion
+
+Getting the citation is only half the battle. When the AI agent synthesizes its answer and drops a reference link to your site, a human user is going to click it. 
+
+If they land on a page that looks like a technical manual because you over-indexed on bot-readability, you lose the conversion. The UI must instantly build trust, offering a seamless, premium experience that validates the AI's recommendation. 
+
+## The Synthesis
+
+You cannot have one without the other. High-conversion UI without bot-native architecture means the AI never finds you. Pure data-density without premium UX means the human never buys from you.
+
+Stop writing blog posts to trick algorithms. Start structuring your data to educate models, and designing your interfaces to convert humans. That is how you win the generative web.


### PR DESCRIPTION
Adds the day 10 blog post covering the "Dual Mandate" for GEO (Generative Engine Optimization).

- Focuses on balancing bot-native infrastructure (llms.txt, semantic HTML) with high-conversion human UI/UX.
- Authored under the strategic guidelines for CMO/Founder audiences.
