### PR TITLE
fix(theme): restore grid card kicker typography

### DIFF
--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -142,7 +142,7 @@ html body [data-md-color-scheme] .md-typeset .grid.cards > ul > li > p {
     color: var(--md-default-fg-color--light);
 }
 /* Ensure the kicker isn't bolded */
-html body [data-md-color-scheme] .md-typeset .grid.cards > ul > li > p > strong.zsa-micro {
+html body [data-md-color-scheme] .md-typeset .grid.cards > ul > li > p > strong:nth-of-type(1) {
     font-weight: 400;
     color: var(--md-default-fg-color--light);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ hooks:
   - tools/build_log.py
 
 extra_css:
-  - stylesheets/zsa-theme.css?v=4
+  - stylesheets/zsa-theme.css?v=5
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Closes the grid card typography bug where kickers like '01 // Structure' were rendering as bold run-on text instead of the lighter, un-bolded style.
