### PR TITLE
fix(theme): remove rogue grid classes from blockquote component

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,8 +61,7 @@ hero:
 > **Expert Consensus**
 > 
 > "The transition from traditional search to generative AI search requires a fundamental shift in how content is structured. High information density, authoritative quotations, and bot-native formats are no longer optional—they are the prerequisite for visibility in RAG pipelines."  
-> — *Zero-Shot Agency Manifesto on AI Retrieval*
-{: .zsa-panel .zsa-hero-grid style="margin-top: 4rem; background: var(--md-code-bg-color);" }
+> <cite>— Zero-Shot Agency Manifesto on AI Retrieval</cite>
 
 ## Glossary of AI Search Optimization Terms {: .zsa-section-title style="margin-top: 4rem;" }
 


### PR DESCRIPTION
Removes the `{: .zsa-panel .zsa-hero-grid }` attribute injection from the blockquote. The hero grid class forces `display: grid` with two columns onto the paragraph inside the blockquote, causing the quote and the citation to float side-by-side in broken grid cells. Removing it restores the native blockquote component layout.
