### PR TITLE
style: remove default mkdocs footer banner

### DIFF
--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -346,3 +346,5 @@ html body[data-md-color-scheme] .md-typeset .grid.cards > ul > li > p > strong:n
     .zsa-hero-grid { grid-template-columns: 1fr; }
     .zsa-panel { padding: 2rem; }
 }
+/* Hide MkDocs Footer Banner */
+footer.md-footer { display: none; }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ hooks:
   - tools/build_log.py
 
 extra_css:
-  - stylesheets/zsa-theme.css?v=6
+  - stylesheets/zsa-theme.css?v=7
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Hides the default 'Made with Material for MkDocs' footer banner globally via CSS to keep the brutalist aesthetic clean.
