### PR TITLE
docs: add day 16 build in public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-16.md
+++ b/docs/blog/posts/daily-blog-day-16.md
@@ -1,7 +1,7 @@
 ---
 title: "Day 16: Map the Citation Supply Chain"
 slug: day-16-map-the-citation-supply-chain
-date: 2026-05-05
+date: 2026-05-06
 categories:
   - Build in Public
   - Generative Engine Optimization

--- a/docs/blog/posts/daily-blog-day-16.md
+++ b/docs/blog/posts/daily-blog-day-16.md
@@ -1,0 +1,57 @@
+---
+title: "Day 16: Map the Citation Supply Chain"
+slug: day-16-map-the-citation-supply-chain
+date: 2026-05-05
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+  - AI Strategy
+---
+
+# Day 16: Map the Citation Supply Chain
+
+In the AI-first web, traditional PR and outreach lists are the wrong mental model. Our operational observation from recent Zero-Shot Agency sprints is clear: we are no longer brainstorming creative marketing campaigns or pitching journalists. Instead, we are mapping exactly where AI agencies and developer tools earn credible, machine-readable mentions in the wild.
+
+If Generative Engine Optimization (GEO) is the new battleground, we must align our entire infrastructure to feed the algorithm's need for verified truth. This requires us to map the *citation supply chain*—the network of evidence surfaces where retrieval systems naturally inspect for corroboration before generating an answer.
+
+### Defining the Citation Supply Chain
+
+The supply chain is essentially a map of evidence nodes. When an AI answer engine evaluates a brand for citation, it does not care about glossy marketing copy on a homepage. It looks for verifiable proof across a distributed network of high-trust data sources. 
+
+Each node in this supply chain answers a fundamentally different trust question for the algorithm. Based on our reconnaissance, we are mapping for the following critical architectures:
+
+- **GitHub READMEs and Repositories**: Does the tool actually exist? Is there open-source code that proves technical utility and developer adoption? A repository with active commits provides empirical proof of life.
+- **Hugging Face Model Cards**: Are the performance metrics, training data, and model capabilities documented in a standardized, verifiable format? This structured data is native to how machine learning models index information.
+- **Developer Documentation Portals**: Does the platform provide structural truth, clear implementation guidelines, and API references? Deep, factual documentation demonstrates subject-matter authority.
+- **Curated Directories and Aggregators**: Do third-party platforms, such as Product Hunt or specialized AI directories like "There's an AI for that", curate and validate the company's existence?
+- **Technical Newsletters**: Are specialized AI newsletters (e.g., Ben's Bites, TLDR AI, The Rundown AI) linking to their tools and case studies? These act as signals of community consensus.
+- **Community Platforms**: Do practitioners in highly technical channels (Hacker News, r/MachineLearning, r/LocalLLaMA, Discord) organically discuss the tool? 
+- **Technical Write-Ups**: Can the evidence be parsed logically in deep-dive articles or case studies, providing empirical proof of the business value?
+
+For GEO planning, our working hypothesis is that answer engines are significantly more likely to trust brands whose claims are corroborated systematically across these structured, high-trust surfaces. 
+
+### The Gritty Reality of Reconnaissance
+
+Building this evidence distribution layer is gritty, methodical work. It feels like evidence architecture, not generic SEO link-building. 
+
+Our current reconnaissance actions, documented heavily in our internal wikis, involve systematically inventorying the landscape. We don't just look for random places to drop a link; we map the entire channel ecosystem. We inventory developer hubs to see where top AI agencies publish their agents. We identify specific newsletters that have high domain authority in the AI space. We list specialized directories and aggressively inspect community discussions to see what formats of evidence gain the most traction.
+
+This is the reality of mapping the supply chain. We are mapping for the specific latent space we want Zero-Shot Agency to occupy. We analyze where top AI developer tools are gaining visibility, not to blindly copy their backlinks, but to understand exactly what evidence the algorithm requires to independently verify authority. 
+
+It is an engineering problem disguised as distribution. We ensure our open-source tools, detailed case studies, and exact configuration specs are structured properly within this broader ecosystem, feeding the nodes with the exact data shapes the AI is trained to parse.
+
+### GEO Business Value and The Dual Mandate
+
+Why should CMOs and founders care about this operational shift? Because AI visibility increasingly depends on corroborated, retrievable proof, not slogans. 
+
+This is where the true business value materializes. Machine-readable proof distributed across the supply chain wins retrieval confidence. But this bot-native strategy still requires a concise bridge to the human buyer. We call this the "Dual Mandate". 
+
+Machine-readable proof wins the algorithm's confidence, earning you the citation. However, the destination still has to convert a human. Once the AI cites your brand based on your distributed evidence, the prospective client clicks through. The structural trust built by the bot must immediately translate into a premium, high-conversion UX for the human. High bot-trust without human-conversion is just wasted traffic, while high human-conversion without bot-trust results in total invisibility.
+
+### The Strategic Bet for Enterprise Leaders
+
+The strategic bet for enterprise buyers is straightforward: stop treating distribution as a PR problem and start treating it as an evidence architecture problem. 
+
+Zero-Shot Agency is positioning itself as the technical operator that designs this exact evidence distribution layer for AI search. We are not just creating content or building generic links; we are architecting a mapped trust network. 
+
+To win citations from ChatGPT and future answer engines, your brand must distribute factual, hard proof across the high-trust nodes of your industry's supply chain. You must feed the algorithm the empirical truth it needs to build structural trust, while ensuring the final destination converts the human who arrives there. That is the architecture required to win the AI-first web.

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -14,6 +14,62 @@ if [ ! -f "$STATE_FILE" ]; then
     echo "RUNNING" > "$STATE_FILE"
 fi
 
+next_blog_date() {
+    python3 - <<'PY'
+import datetime as dt
+import json
+import re
+import subprocess
+from pathlib import Path
+
+repo = Path.cwd()
+date_re = re.compile(r"^date:\s*([0-9]{4}-[0-9]{2}-[0-9]{2})", re.MULTILINE)
+dates = []
+
+for post in (repo / "docs/blog/posts").glob("*.md"):
+    match = date_re.search(post.read_text(encoding="utf-8", errors="ignore"))
+    if match:
+        dates.append(dt.date.fromisoformat(match.group(1)))
+
+try:
+    prs_json = subprocess.check_output(
+        ["gh", "pr", "list", "--state", "open", "--json", "number"],
+        text=True,
+        stderr=subprocess.DEVNULL,
+    )
+    prs = json.loads(prs_json)
+except Exception:
+    prs = []
+
+for pr in prs:
+    number = str(pr.get("number", ""))
+    if not number:
+        continue
+    try:
+        diff = subprocess.check_output(
+            ["gh", "pr", "diff", number, "--patch"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        continue
+
+    in_blog_post = False
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            in_blog_post = "docs/blog/posts/" in line and line.endswith(".md")
+            continue
+        if not in_blog_post or not line.startswith("+") or line.startswith("+++"):
+            continue
+        match = date_re.match(line[1:])
+        if match:
+            dates.append(dt.date.fromisoformat(match.group(1)))
+
+base = max(dates) if dates else dt.date.today()
+print((base + dt.timedelta(days=1)).isoformat())
+PY
+}
+
 echo "🚀 Starting GEO Wiki Ralph Loop..."
 echo "To pause, echo 'PAUSED' > $STATE_FILE"
 
@@ -35,32 +91,63 @@ while [ $tasks_completed -lt $MAX_TASKS ]; do
 
     export PATH="/home/claw/.local/bin:/home/linuxbrew/.linuxbrew/bin:$PATH"
     NEXT_TASK_ID=$(gh issue list --state open --json number --jq '.[0].number' 2>/dev/null)
-    
+
     if [ -z "$NEXT_TASK_ID" ]; then
         echo "✅ No open GitHub Issues found. Ralph is going to sleep."
         break
     fi
-    
+
     NEXT_TASK_DESC=$(gh issue view "$NEXT_TASK_ID" --json title --jq '.title' 2>/dev/null)
     NEXT_TASK_URL=$(gh issue view "$NEXT_TASK_ID" --json url --jq '.url' 2>/dev/null)
+    NEXT_BLOG_DATE=$(next_blog_date)
+    LOG_ENTRY_PATH="docs/logs/entries/$(date +%Y-%m-%d)-issue-$NEXT_TASK_ID.md"
     echo "🎯 Next objective: #$NEXT_TASK_ID - $NEXT_TASK_DESC"
-    
+    echo "🗓️ Next available blog date: $NEXT_BLOG_DATE"
+
+    PROMPT=$(cat <<EOF
+You are the GEO Wiki Orchestrator running inside a Ralph Loop.
+
+ORIENT YOURSELF: Read $WIKI_DIR/strategy.md, $WIKI_DIR/SCHEMA.md, index.md, and log.md.
+YOUR TASK: Resolve GitHub Issue #$NEXT_TASK_ID ($NEXT_TASK_URL).
+
+RULES:
+1. If the task requires deep coding, planning, or creative work, use delegate_task with acp_command='claude' and acp_args=['--acp', '--stdio', '--model', 'claude-opus-4-7'].
+2. Content drafts: check out a new branch such as drafts/[name], write the file, and use gh CLI to close the issue.
+3. Daily blog posts must go in docs/blog/posts/ and use date: $NEXT_BLOG_DATE. Do not use today's date unless it is already the day after the newest existing post date. This date was computed from both posts already on the site and dates introduced by open PRs.
+4. Before creating a daily blog post, also inspect docs/blog/posts/ and open PRs yourself for existing daily-blog-day-N files. Use the next day number after the highest one you find across main and open PRs.
+5. Do not add individual blog posts to mkdocs.yml navigation; the MkDocs blog plugin handles posts under docs/blog/posts/.
+6. If the task is scraping, use your native web_search/web_extract tools and save to raw/.
+7. If it is synthesis, save the result to the appropriate docs/ subdirectory.
+8. Once completed, use the gh CLI to close issue #$NEXT_TASK_ID.
+9. Create a new file at $LOG_ENTRY_PATH detailing your actions. Cross-reference pages using [[wikilinks]]. Do not edit any existing log files.
+10. Manually stage only the files you created or modified using git add with explicit file paths. Do not use git add . or git add -A. Do not run git commit or git push; the loop script handles commit, push, and PR creation.
+
+Execute now.
+EOF
+)
+
     # 3. Boot fresh agent instance
     echo "🧠 Booting fresh agent context..."
-    hermes chat --yolo -Q -q "You are the GEO Wiki Orchestrator running inside a Ralph Loop. \nORIENT YOURSELF: Read $WIKI_DIR/strategy.md, $WIKI_DIR/SCHEMA.md, index.md, and log.md.\nYOUR TASK: Resolve GitHub Issue #$NEXT_TASK_ID ($NEXT_TASK_URL).\nRULES:\n1. If the task requires deep coding/development, use delegate_task with acp_command='claude' (DO NOT USE legacy 3.5 models).\n2. Content Drafts: Checkout a new branch (e.g., drafts/[name]), write the file, update mkdocs.yml navigation, use gh CLI to close the issue, and then use gh pr create --fill to open a Pull Request.\n3. If the task is scraping, use your native web_search/web_extract tools and save to raw/.\n4. If it is synthesis, do it yourself and save to concepts/.\n5. Once completed, use the gh CLI to close the issue (#$NEXT_TASK_ID).\n6. Create a NEW file at docs/logs/entries/$(date +%Y-%m-%d)-issue-$NEXT_TASK_ID.md detailing your actions. Cross-reference pages using [[wikilinks]]. Do NOT edit any existing log files.\n7. IMPORTANT: You must manually stage ONLY the files you created or modified using `specific_file_path>`. DO NOT run `` or you will commit workspace garbage. The loop script will handle the commit and push.\nExecute now."
+    hermes chat --yolo -Q -q "$PROMPT"
 
     # 4. Agent exits. Increment and cool down.
-    
+
     # 4.5 Auto-Commit to GitHub
     echo "📦 Committing progress to Git..."
     cd "$WIKI_DIR" || exit
-    
-    git commit -m "Ralph Auto-Commit: Completed $TASK_DESC" || true
+
+    git commit --author="Molty McClaw <molty@zero-shot.agency>" -m "Ralph Auto-Commit: Completed $NEXT_TASK_DESC" || true
     CURRENT_BRANCH=$(git branch --show-current)
     git push origin "$CURRENT_BRANCH"
-    
+
+    # Auto-create PR if we are on a new branch
+    if [ "$CURRENT_BRANCH" != "main" ]; then
+        echo "Closes #$NEXT_TASK_ID" > /tmp/pr_body.txt
+        gh pr create --title "$NEXT_TASK_DESC" --body-file /tmp/pr_body.txt || true
+    fi
+
     tasks_completed=$((tasks_completed + 1))
-    
+
     if [ $tasks_completed -lt $MAX_TASKS ]; then
         echo "⏳ Cooling down for 60 seconds before next iteration..."
         sleep 60

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -14,62 +14,6 @@ if [ ! -f "$STATE_FILE" ]; then
     echo "RUNNING" > "$STATE_FILE"
 fi
 
-next_blog_date() {
-    python3 - <<'PY'
-import datetime as dt
-import json
-import re
-import subprocess
-from pathlib import Path
-
-repo = Path.cwd()
-date_re = re.compile(r"^date:\s*([0-9]{4}-[0-9]{2}-[0-9]{2})", re.MULTILINE)
-dates = []
-
-for post in (repo / "docs/blog/posts").glob("*.md"):
-    match = date_re.search(post.read_text(encoding="utf-8", errors="ignore"))
-    if match:
-        dates.append(dt.date.fromisoformat(match.group(1)))
-
-try:
-    prs_json = subprocess.check_output(
-        ["gh", "pr", "list", "--state", "open", "--json", "number"],
-        text=True,
-        stderr=subprocess.DEVNULL,
-    )
-    prs = json.loads(prs_json)
-except Exception:
-    prs = []
-
-for pr in prs:
-    number = str(pr.get("number", ""))
-    if not number:
-        continue
-    try:
-        diff = subprocess.check_output(
-            ["gh", "pr", "diff", number, "--patch"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-        )
-    except Exception:
-        continue
-
-    in_blog_post = False
-    for line in diff.splitlines():
-        if line.startswith("diff --git "):
-            in_blog_post = "docs/blog/posts/" in line and line.endswith(".md")
-            continue
-        if not in_blog_post or not line.startswith("+") or line.startswith("+++"):
-            continue
-        match = date_re.match(line[1:])
-        if match:
-            dates.append(dt.date.fromisoformat(match.group(1)))
-
-base = max(dates) if dates else dt.date.today()
-print((base + dt.timedelta(days=1)).isoformat())
-PY
-}
-
 echo "🚀 Starting GEO Wiki Ralph Loop..."
 echo "To pause, echo 'PAUSED' > $STATE_FILE"
 
@@ -91,63 +35,32 @@ while [ $tasks_completed -lt $MAX_TASKS ]; do
 
     export PATH="/home/claw/.local/bin:/home/linuxbrew/.linuxbrew/bin:$PATH"
     NEXT_TASK_ID=$(gh issue list --state open --json number --jq '.[0].number' 2>/dev/null)
-
+    
     if [ -z "$NEXT_TASK_ID" ]; then
         echo "✅ No open GitHub Issues found. Ralph is going to sleep."
         break
     fi
-
+    
     NEXT_TASK_DESC=$(gh issue view "$NEXT_TASK_ID" --json title --jq '.title' 2>/dev/null)
     NEXT_TASK_URL=$(gh issue view "$NEXT_TASK_ID" --json url --jq '.url' 2>/dev/null)
-    NEXT_BLOG_DATE=$(next_blog_date)
-    LOG_ENTRY_PATH="docs/logs/entries/$(date +%Y-%m-%d)-issue-$NEXT_TASK_ID.md"
     echo "🎯 Next objective: #$NEXT_TASK_ID - $NEXT_TASK_DESC"
-    echo "🗓️ Next available blog date: $NEXT_BLOG_DATE"
-
-    PROMPT=$(cat <<EOF
-You are the GEO Wiki Orchestrator running inside a Ralph Loop.
-
-ORIENT YOURSELF: Read $WIKI_DIR/strategy.md, $WIKI_DIR/SCHEMA.md, index.md, and log.md.
-YOUR TASK: Resolve GitHub Issue #$NEXT_TASK_ID ($NEXT_TASK_URL).
-
-RULES:
-1. If the task requires deep coding, planning, or creative work, use delegate_task with acp_command='claude' and acp_args=['--acp', '--stdio', '--model', 'claude-opus-4-7'].
-2. Content drafts: check out a new branch such as drafts/[name], write the file, and use gh CLI to close the issue.
-3. Daily blog posts must go in docs/blog/posts/ and use date: $NEXT_BLOG_DATE. Do not use today's date unless it is already the day after the newest existing post date. This date was computed from both posts already on the site and dates introduced by open PRs.
-4. Before creating a daily blog post, also inspect docs/blog/posts/ and open PRs yourself for existing daily-blog-day-N files. Use the next day number after the highest one you find across main and open PRs.
-5. Do not add individual blog posts to mkdocs.yml navigation; the MkDocs blog plugin handles posts under docs/blog/posts/.
-6. If the task is scraping, use your native web_search/web_extract tools and save to raw/.
-7. If it is synthesis, save the result to the appropriate docs/ subdirectory.
-8. Once completed, use the gh CLI to close issue #$NEXT_TASK_ID.
-9. Create a new file at $LOG_ENTRY_PATH detailing your actions. Cross-reference pages using [[wikilinks]]. Do not edit any existing log files.
-10. Manually stage only the files you created or modified using git add with explicit file paths. Do not use git add . or git add -A. Do not run git commit or git push; the loop script handles commit, push, and PR creation.
-
-Execute now.
-EOF
-)
-
+    
     # 3. Boot fresh agent instance
     echo "🧠 Booting fresh agent context..."
-    hermes chat --yolo -Q -q "$PROMPT"
+    hermes chat --yolo -Q -q "You are the GEO Wiki Orchestrator running inside a Ralph Loop. \nORIENT YOURSELF: Read $WIKI_DIR/strategy.md, $WIKI_DIR/SCHEMA.md, index.md, and log.md.\nYOUR TASK: Resolve GitHub Issue #$NEXT_TASK_ID ($NEXT_TASK_URL).\nRULES:\n1. If the task requires deep coding/development, use delegate_task with acp_command='claude' (DO NOT USE legacy 3.5 models).\n2. Content Drafts: Checkout a new branch (e.g., drafts/[name]), write the file, update mkdocs.yml navigation, use gh CLI to close the issue, and then use gh pr create --fill to open a Pull Request.\n3. If the task is scraping, use your native web_search/web_extract tools and save to raw/.\n4. If it is synthesis, do it yourself and save to concepts/.\n5. Once completed, use the gh CLI to close the issue (#$NEXT_TASK_ID).\n6. Create a NEW file at docs/logs/entries/$(date +%Y-%m-%d)-issue-$NEXT_TASK_ID.md detailing your actions. Cross-reference pages using [[wikilinks]]. Do NOT edit any existing log files.\n7. IMPORTANT: You must manually stage ONLY the files you created or modified using `specific_file_path>`. DO NOT run `` or you will commit workspace garbage. The loop script will handle the commit and push.\nExecute now."
 
     # 4. Agent exits. Increment and cool down.
-
+    
     # 4.5 Auto-Commit to GitHub
     echo "📦 Committing progress to Git..."
     cd "$WIKI_DIR" || exit
-
-    git commit --author="Molty McClaw <molty@zero-shot.agency>" -m "Ralph Auto-Commit: Completed $NEXT_TASK_DESC" || true
+    
+    git commit -m "Ralph Auto-Commit: Completed $TASK_DESC" || true
     CURRENT_BRANCH=$(git branch --show-current)
     git push origin "$CURRENT_BRANCH"
-
-    # Auto-create PR if we are on a new branch
-    if [ "$CURRENT_BRANCH" != "main" ]; then
-        echo "Closes #$NEXT_TASK_ID" > /tmp/pr_body.txt
-        gh pr create --title "$NEXT_TASK_DESC" --body-file /tmp/pr_body.txt || true
-    fi
-
+    
     tasks_completed=$((tasks_completed + 1))
-
+    
     if [ $tasks_completed -lt $MAX_TASKS ]; then
         echo "⏳ Cooling down for 60 seconds before next iteration..."
         sleep 60


### PR DESCRIPTION
## Summary
- Adds the approved Day 16 Build in Public post: "Map the Citation Supply Chain".
- Applies the T4 approved Markdown artifact to `docs/blog/posts/daily-blog-day-16.md`.
- Preserves existing blog frontmatter conventions and omits `authors:` because this repo has no `docs/blog/.authors.yml`.

## Checks
- Frontmatter/content assertion passed.
- `mkdocs build --strict` failed on 82 pre-existing warnings (RoamLinks/AutoLinks missing targets, unnaved pages, existing absolute nav paths).
- `mkdocs build` passed.

## Notes
- Only one file is included in this PR.
