### PR TITLE
docs: add Day 17 build in public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-17.md
+++ b/docs/blog/posts/daily-blog-day-17.md
@@ -1,37 +1,132 @@
 ---
-title: "Day 17: Strip the Interface Down to Trust"
-slug: day-17-strip-interface-down-to-trust
+title: "Day 17: The Citation Is Only the Handoff"
+slug: day-17-citation-is-only-the-handoff
 date: 2026-05-07
 categories:
   - Build in Public
   - Generative Engine Optimization
-  - Design
+  - Trust
 ---
 
-# Day 17: Strip the Interface Down to Trust
+# Day 17: The Citation Is Only the Handoff
 
-A slick interface is often a liability in disguise. In the past 24 hours, our repository history logged a seemingly erratic sequence: stripping experimental custom CSS from an explore module, reverting that strip, and then reapplying the strip. In parallel, we removed a bloated "expert consensus" header from a blockquote on the homepage.
+Most GEO conversations stop too early.
 
-This isn't just aesthetic churn. It is a calculated reduction of interface debt. For CMOs and founders navigating the AI-first web, interface restraint is a structural trust mechanism.
+They obsess over the citation: *Did the AI mention us? Did we appear in the answer? Did the link show up?*
 
-## The Cost of Overreach
+That matters. But it is not the finish line.
 
-Under the Dual Mandate of Generative Engine Optimization (GEO), the bot-native infrastructure gets the citation, but the human-facing UI must secure the trust. When a user lands on the site via ChatGPT, the interface has to instantly validate the AI's recommendation.
+A citation is a handoff.
 
-The instinct is often to over-design—to add custom styling, experimental modules, and heavy copy like "expert consensus" to project authority. The reality? Overreach degrades trust. Every superfluous CSS rule and hyperbolic claim introduces friction.
+The AI has done one job: it has introduced you to a high-intent human. That human arrives with a specific expectation: *the machine trusted this page enough to cite it, so I should understand why within seconds.*
 
-## Interface as Evidence Architecture
+If the page cannot cash that trust, the citation becomes a leak.
 
-By deliberately rolling back experimental CSS and tightening the homepage copy, we're not just cleaning up code. We are engineering credibility. A restrained, brutalist interface—sharp grids, native variables, zero raw HTML injection—signals confidence. It strips away the marketing noise and presents the data exactly as it is.
+## The New Conversion Problem
 
-In a landscape where AI tools summarize vast amounts of information instantly, human visitors are highly sensitized to fluff. If your interface feels bloated or your claims feel inflated, the structural trust established by the AI's citation evaporates.
+Traditional SEO trained teams to think in funnels:
 
-## The Business Value of Restraint
+- rank
+- click
+- land
+- convert
 
-Interface restraint isn't a design preference; it is a defensive business strategy. When you enforce a strict, native-variable "Technical Brutalism" over custom overrides:
+Generative engines compress the first half of that journey. The visitor may already have received a summary, a comparison, a recommendation, or a shortlist before they ever touch your site.
 
-1. **You lower interface debt:** Purging experimental CSS blocks and relying on framework variables means fewer breaking changes, seamless updates, and a faster iteration cycle.
-2. **You reduce copy overclaim risk:** Ripping out hyperbolic phrasing like "expert consensus" protects your credibility. Unsubstantiated marketing speak triggers immediate skepticism from high-intent visitors.
-3. **You build a clear evidence architecture:** A restrained, brutalist visual system strips away the noise. Presenting the data plainly proves you have nothing to hide, making the underlying evidence instantly easier to trust.
+That changes the job of the landing page.
 
-The bots want your data. The humans want your honesty. Strip the interface down to trust, and you satisfy both.
+The page no longer has to start from zero. It has to confirm the AI's recommendation.
+
+That means the first screen has to answer three questions fast:
+
+- **Am I in the right place?**
+- **Can I verify the claim that brought me here?**
+- **Do I trust this enough to take the next step?**
+
+If the answer is not obvious, the visitor leaves with more doubt than they arrived with.
+
+## Citation Creates Borrowed Trust
+
+When an AI cites you, it lends you a small amount of authority.
+
+Not infinite authority. Not guaranteed conversion. Just a moment of borrowed trust.
+
+The mistake is treating that moment like traffic.
+
+It is not traffic. It is a trust event.
+
+The visitor is not casually browsing. They are checking whether the cited source holds up under human inspection.
+
+That inspection is brutal and fast.
+
+A vague hero line breaks the spell.
+
+A generic claim breaks the spell.
+
+A page that hides the proof below five screens of positioning breaks the spell.
+
+A mismatch between what the AI said and what the page says breaks the spell.
+
+The machine can open the door. The page still has to earn the room.
+
+## What Post-Citation Trust Looks Like
+
+This is the piece most teams miss.
+
+Bot-readable structure helps you get selected. Human-readable proof helps you convert after selection.
+
+The handoff needs both.
+
+A post-citation page should make the AI's implied promise visible to the human:
+
+- **Clear claim:** Say exactly what you do, for whom, and why it matters.
+- **Immediate proof:** Put evidence near the claim, not buried in a resource hub.
+- **Specific language:** Replace category fluff with concrete mechanisms, outcomes, and constraints.
+- **Fast orientation:** Show the visitor where they are in the decision: learn, compare, validate, buy.
+- **Low-friction next step:** Give them one obvious action, not a menu of distractions.
+
+This is not about making pages prettier.
+
+It is about reducing the trust gap between machine recommendation and human commitment.
+
+## The Build-in-Public Lesson
+
+Today's work was about stripping away anything that did not support that handoff.
+
+Not because minimalism is fashionable. Because every extra ambiguity taxes trust.
+
+For GEO, the visible page has a different role than it used to. It is not just a brochure. It is the verification layer after an AI citation.
+
+The AI answer may summarize you in one sentence. Your page has to prove that sentence deserves belief.
+
+That is where revenue is won or lost.
+
+## The Practical Test
+
+Take any page you want cited by ChatGPT, Claude, Perplexity, or another generative engine.
+
+Now ask:
+
+- If an AI cited this page as evidence, would a human instantly understand why?
+- Does the page confirm the exact claim the AI is likely to make?
+- Is there proof above the fold, or just positioning?
+- Does the next step match the visitor's intent?
+- Would the page still make sense if the visitor arrived halfway through the buying journey?
+
+If not, you do not just have a conversion problem.
+
+You have a post-citation trust problem.
+
+## The Point
+
+The dual mandate still holds: machines need structure; humans need confidence.
+
+But Day 17 sharpened the second half.
+
+Being cited is not the win. It is the pass.
+
+The win happens when the human arrives, checks the source, feels the trust compound instead of collapse, and decides to move.
+
+GEO does not end at visibility.
+
+It ends at belief.

--- a/docs/blog/posts/daily-blog-day-17.md
+++ b/docs/blog/posts/daily-blog-day-17.md
@@ -1,0 +1,37 @@
+---
+title: "Day 17: Strip the Interface Down to Trust"
+slug: day-17-strip-interface-down-to-trust
+date: 2026-05-07
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+  - Design
+---
+
+# Day 17: Strip the Interface Down to Trust
+
+A slick interface is often a liability in disguise. In the past 24 hours, our repository history logged a seemingly erratic sequence: stripping experimental custom CSS from an explore module, reverting that strip, and then reapplying the strip. In parallel, we removed a bloated "expert consensus" header from a blockquote on the homepage.
+
+This isn't just aesthetic churn. It is a calculated reduction of interface debt. For CMOs and founders navigating the AI-first web, interface restraint is a structural trust mechanism.
+
+## The Cost of Overreach
+
+Under the Dual Mandate of Generative Engine Optimization (GEO), the bot-native infrastructure gets the citation, but the human-facing UI must secure the trust. When a user lands on the site via ChatGPT, the interface has to instantly validate the AI's recommendation.
+
+The instinct is often to over-design—to add custom styling, experimental modules, and heavy copy like "expert consensus" to project authority. The reality? Overreach degrades trust. Every superfluous CSS rule and hyperbolic claim introduces friction.
+
+## Interface as Evidence Architecture
+
+By deliberately rolling back experimental CSS and tightening the homepage copy, we're not just cleaning up code. We are engineering credibility. A restrained, brutalist interface—sharp grids, native variables, zero raw HTML injection—signals confidence. It strips away the marketing noise and presents the data exactly as it is.
+
+In a landscape where AI tools summarize vast amounts of information instantly, human visitors are highly sensitized to fluff. If your interface feels bloated or your claims feel inflated, the structural trust established by the AI's citation evaporates.
+
+## The Business Value of Restraint
+
+Interface restraint isn't a design preference; it is a defensive business strategy. When you enforce a strict, native-variable "Technical Brutalism" over custom overrides:
+
+1. **You lower interface debt:** Purging experimental CSS blocks and relying on framework variables means fewer breaking changes, seamless updates, and a faster iteration cycle.
+2. **You reduce copy overclaim risk:** Ripping out hyperbolic phrasing like "expert consensus" protects your credibility. Unsubstantiated marketing speak triggers immediate skepticism from high-intent visitors.
+3. **You build a clear evidence architecture:** A restrained, brutalist visual system strips away the noise. Presenting the data plainly proves you have nothing to hide, making the underlying evidence instantly easier to trust.
+
+The bots want your data. The humans want your honesty. Strip the interface down to trust, and you satisfy both.


### PR DESCRIPTION
## Summary
- Adds the Day 17 Build in Public post, "Strip the Interface Down to Trust"
- Keeps the blog plugin flow intact by adding only `docs/blog/posts/daily-blog-day-17.md`
- Removes the parent draft's `authors:` field before applying because this repo has no `docs/blog/.authors.yml`, which would break MkDocs Material blog builds

## Checks
- `python3` content assertions for date, slug, forbidden terminology, and no `authors:` field: passed
- `python3 -m mkdocs build --strict`: failed due to existing site warnings (RoamLinks/AutoLinks/nav baseline warnings), not this post
- `python3 -m mkdocs build`: passed

## Notes
- Not adding this post to `mkdocs.yml` nav; the blog plugin handles posts.
