### PR TITLE
docs: add Day 18 design system retrieval post

### DIFF
--- a/docs/blog/posts/daily-blog-day-18.md
+++ b/docs/blog/posts/daily-blog-day-18.md
@@ -1,0 +1,42 @@
+---
+title: "Day 18: Your Design System Is Part of Your Retrieval Strategy"
+slug: day-18-design-system-retrieval-strategy
+date: 2026-05-08
+description: "Why design governance is retrieval governance. In the AI-first web, structural rules and entity consistency are the causal mechanisms for pipeline conversion."
+categories:
+  - Build in Public
+tags:
+  - Generative Engine Optimization
+  - Design Systems
+  - Conversion Strategy
+geo_tactics:
+  - Entity Consistency
+  - Semantic Interface Design
+---
+
+# Your Design System Is Part of Your Retrieval Strategy
+
+Design systems are often treated as aesthetic rulebooks—guidelines for margin, color, and typography. But in the context of Generative Engine Optimization (GEO), design governance is retrieval governance. When an AI agent constructs an answer from your brand's digital footprint, it relies on structural clarity and semantic consistency. If your design system is fragmented, your retrieval footprint will be compromised. 
+
+For CMOs and marketing leaders, the commercial stakes are immediate: inconsistent design architecture creates fractured entity signals. A high-intent visitor referred by ChatGPT arrives expecting coherence, and if the destination system fails to match the structural rigor of the engine's summary, pipeline quality and conversion rates plummet.
+
+<!-- more -->
+
+## Governance as the Causal Mechanism
+
+A robust design system functions as a source of truth that synchronizes both bot-readable data and human-readable interfaces. This requires moving beyond visual stylesheets into hard, programmatic governance: formal `DESIGN.md` rules, stable component patterns, and enforced semantic hierarchies.
+
+When a company implements strict native structural rules, every markdown file, API documentation page, and marketing landing page shares a unified vocabulary. This entity consistency is precisely what enables large language models to accurately parse, summarize, and cite your capabilities. By treating component design and content modeling as a single governed system, you ensure that snippets, citations, and the ultimate landing experience are perfectly coherent.
+
+## The Architecture of Coherence
+
+Relying on "good design" is insufficient; enterprise AI safety demands systemic enforcement. A governed design architecture ensures:
+1. **Semantic Hierarchy:** Information is structured predictably, allowing RAG systems to map relationships between your products and your thought leadership.
+2. **Stable Entity Naming:** Consistent terminology across all digital touchpoints prevents AI engines from hallucinating competitor capabilities into your brand profile.
+3. **Predictable Components:** Native, standardized visual and textual blocks guarantee that whether a prospect reads raw markdown or a styled case study, the structural integrity of the brand is preserved.
+
+## The Conversion Imperative
+
+The execution of web development is increasingly commoditized, but structural trust remains a definitive moat. If your design system is merely a collection of CSS overrides rather than a fundamental architecture, you are leaving your AI-search visibility to chance. 
+
+High-intent AI-referred traffic demands precision. By establishing a source-of-truth design system that mandates both visual and semantic consistency, you align your brand's digital reality with the algorithms that index it. In 2026, a rigorous design system is not how you make a site look professional; it is the infrastructure that turns algorithmic citations into tangible business value.


### PR DESCRIPTION
## Summary
- Adds the approved Day 18 Build-in-Public post on design systems as retrieval strategy.
- Frames design governance as GEO infrastructure: entity consistency, semantic structure, bot-readable evidence, and human trust.
- Keeps the PR payload scoped to the single intended blog post file.

## Test Plan
- `python3` content assertions for deprecated terms, buyer relevance, and GEO relevance
- `mkdocs build`

## Payload
- `docs/blog/posts/daily-blog-day-18.md` only

Note: Removed the draft `authors: molty` frontmatter field from the approved artifact because this repository has no `docs/blog/.authors.yml`; keeping it caused `mkdocs build` to abort with `Couldn't find author 'molty'`.
