### PR TITLE
feat: Explore ZSA Floating Panels

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,22 +6,16 @@ hide:
   - toc
 explore_zsa:
   recent_posts:
-    - title: "Day 14: Automated Evaluation"
-      url: "/blog/day-14/"
-    - title: "Day 13: The Orchestrator Pattern"
-      url: "/blog/day-13/"
-    - title: "Day 12: Tool Use Boundaries"
-      url: "/blog/day-12/"
   sections:
     - title: "Strategy and Playbook"
       description: "Our core methodology for AI-first visibility."
-      url: "/strategy/"
+      url: "strategy/"
     - title: "Concepts"
       description: "Mental models and architectural patterns."
-      url: "/concepts/"
+      url: "concepts/"
     - title: "Tools"
       description: "Open-source tools and CLIs."
-      url: "/tools/"
+      url: "tools/"
 created: 2026-04-22
 updated: 2026-04-29
 type: concept

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,16 @@ hide:
   - toc
 explore_zsa:
   recent_posts:
+    - title: "Day 17: The Citation Is Only the Handoff"
+      url: "blog/posts/daily-blog-day-17/"
+    - title: "Day 16: Map the Citation Supply Chain"
+      url: "blog/posts/daily-blog-day-16/"
+    - title: "Day 15: The Context Window Is Not a Control Plane"
+      url: "blog/posts/daily-blog-day-15/"
+    - title: "Day 14: When Agents Write the Code: Managing Subagent Driven Development"
+      url: "blog/posts/daily-blog-day-14/"
+    - title: "Day 13: The Hallucination Defense - Protecting Your Brand Identity from AI Drift"
+      url: "blog/posts/daily-blog-day-13/"
   sections:
     - title: "Strategy and Playbook"
       description: "Our core methodology for AI-first visibility."

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -33,25 +33,30 @@
   {% if page.meta.explore_zsa %}
   <h2 class="zsa-section-title" style="margin-top: 4rem;">Explore ZSA</h2>
   
-  <p><strong>Recent Transmissions</strong></p>
-  <ul>
-    {% for post in page.meta.explore_zsa.recent_posts %}
-    <li><a href="{{ post.url | url }}">{{ post.title }}</a></li>
-    {% endfor %}
-  </ul>
+  <div class="grid cards zsa-explore-grid">
+      <div class="zsa-panel">
+          <h3 class="panel-subtitle">Recent Transmissions</h3>
+          <div class="feed-list">
+              {% for post in page.meta.explore_zsa.recent_posts %}
+              <a href="{{ post.url | url }}" class="feed-item">
+                  <span class="feed-date">LOG // {{ post.title.split(':')[0] if ':' in post.title else 'TRANS' }}</span>
+                  <span class="feed-title">{{ post.title.split(':', 1)[1].strip() if ':' in post.title else post.title }}</span>
+              </a>
+              {% endfor %}
+          </div>
+      </div>
 
-  <p style="margin-top: 3rem;"><strong>Knowledge Base</strong></p>
-  <div class="grid cards">
-    <ul>
-      {% for section in page.meta.explore_zsa.sections %}
-      <li>
-        <a href="{{ section.url | url }}">
-          <strong>{{ section.title }}</strong><br>
-          {{ section.description }}
-        </a>
-      </li>
-      {% endfor %}
-    </ul>
+      <div class="zsa-panel">
+          <h3 class="panel-subtitle">Knowledge Base</h3>
+          <div class="kb-grid">
+              {% for section in page.meta.explore_zsa.sections %}
+              <a href="{{ section.url | url }}" class="kb-item">
+                  <span class="kb-item-title">{{ section.title }}</span>
+                  <span class="kb-item-desc">{{ section.description }}</span>
+              </a>
+              {% endfor %}
+          </div>
+      </div>
   </div>
   {% endif %}
 

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -33,34 +33,36 @@
   {% if page.meta.explore_zsa %}
   <h2 class="zsa-section-title" style="margin-top: 4rem;">Explore ZSA</h2>
   
-  <div class="grid cards zsa-explore-grid">
-      <div class="zsa-panel">
-          <h3 class="panel-subtitle">Recent Transmissions</h3>
-          <div class="feed-list">
-              {% for post in page.meta.explore_zsa.recent_posts[:5] %}
-              <a href="{{ post.url | url }}" class="feed-item">
-                  <span class="feed-date">LOG // {{ post.title.split(':')[0] if ':' in post.title else 'TRANS' }}</span>
-                  <span class="feed-title">{{ post.title.split(':', 1)[1].strip() if ':' in post.title else post.title }}</span>
-              </a>
-              {% endfor %}
+  <div class="grid cards zsa-explore-container">
+      <ul class="zsa-explore-grid">
+          <li class="zsa-explore-panel">
+              <h3 class="panel-subtitle">Recent Transmissions</h3>
+              <div class="feed-list">
+                  {% for post in page.meta.explore_zsa.recent_posts[:5] %}
+                  <a href="{{ post.url | url }}" class="feed-item">
+                      <span class="feed-date">LOG // {{ post.title.split(':')[0] if ':' in post.title else 'TRANS' }}</span>
+                      <span class="feed-title">{{ post.title.split(':', 1)[1].strip() if ':' in post.title else post.title }}</span>
+                  </a>
+                  {% endfor %}
 
-          </div>
-          <div class="feed-footer">
-              <a href="{{ 'blog/' | url }}" class="feed-all-link">View Full Log &rarr;</a>
-          </div>
-      </div>
+              </div>
+              <div class="feed-footer">
+                  <a href="{{ 'blog/' | url }}" class="feed-all-link">View Full Log &rarr;</a>
+              </div>
+          </li>
 
-      <div class="zsa-panel">
-          <h3 class="panel-subtitle">Knowledge Base</h3>
-          <div class="kb-grid">
-              {% for section in page.meta.explore_zsa.sections %}
-              <a href="{{ section.url | url }}" class="kb-item">
-                  <span class="kb-item-title">{{ section.title }}</span>
-                  <span class="kb-item-desc">{{ section.description }}</span>
-              </a>
-              {% endfor %}
-          </div>
-      </div>
+          <li class="zsa-explore-panel">
+              <h3 class="panel-subtitle">Knowledge Base</h3>
+              <div class="kb-grid">
+                  {% for section in page.meta.explore_zsa.sections %}
+                  <a href="{{ section.url | url }}" class="kb-item">
+                      <span class="kb-item-title">{{ section.title }}</span>
+                      <span class="kb-item-desc">{{ section.description }}</span>
+                  </a>
+                  {% endfor %}
+              </div>
+          </li>
+      </ul>
   </div>
   {% endif %}
 

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -37,12 +37,16 @@
       <div class="zsa-panel">
           <h3 class="panel-subtitle">Recent Transmissions</h3>
           <div class="feed-list">
-              {% for post in page.meta.explore_zsa.recent_posts %}
+              {% for post in page.meta.explore_zsa.recent_posts[:5] %}
               <a href="{{ post.url | url }}" class="feed-item">
                   <span class="feed-date">LOG // {{ post.title.split(':')[0] if ':' in post.title else 'TRANS' }}</span>
                   <span class="feed-title">{{ post.title.split(':', 1)[1].strip() if ':' in post.title else post.title }}</span>
               </a>
               {% endfor %}
+
+          </div>
+          <div class="feed-footer">
+              <a href="{{ 'blog/' | url }}" class="feed-all-link">View Full Log &rarr;</a>
           </div>
       </div>
 

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -361,18 +361,6 @@ footer.md-footer { display: none; }
     align-items: stretch;
 }
 
-.zsa-explore-grid > .zsa-panel {
-    min-height: 0;
-    height: 100%;
-}
-
-.zsa-explore-grid .zsa-panel {
-    display: flex;
-    flex-direction: column;
-    min-height: 0;
-    max-height: 100%;
-}
-
 .zsa-panel {
     height: 100%;
     box-sizing: border-box;
@@ -391,7 +379,7 @@ footer.md-footer { display: none; }
 }
 
 
-.feed-list { display: flex; flex-direction: column; gap: 1.25rem; flex-grow: 1; min-height: 0; overflow-y: auto; padding-right: 1rem; margin-bottom: 1.5rem; }
+.feed-list { display: flex; flex-direction: column; gap: 1.25rem; max-height: 350px; overflow-y: auto; padding-right: 1rem; }
 /* Scrollbar styling for brutalist look */
 .feed-list::-webkit-scrollbar { width: 4px; }
 .feed-list::-webkit-scrollbar-track { background: var(--md-default-bg-color); }

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -361,6 +361,14 @@ footer.md-footer { display: none; }
     align-items: stretch;
 }
 
+.zsa-explore-grid > .zsa-panel:first-child {
+    display: flex;
+    flex-direction: column;
+    height: 0;
+    min-height: 100%;
+}
+
+
 .zsa-panel {
     height: 100%;
     box-sizing: border-box;
@@ -379,7 +387,7 @@ footer.md-footer { display: none; }
 }
 
 
-.feed-list { display: flex; flex-direction: column; gap: 1.25rem; max-height: 350px; overflow-y: auto; padding-right: 1rem; }
+.feed-list { display: flex; flex-direction: column; gap: 1.25rem; flex-grow: 1; min-height: 0; overflow-y: auto; padding-right: 1rem; margin-bottom: 1.5rem; }
 /* Scrollbar styling for brutalist look */
 .feed-list::-webkit-scrollbar { width: 4px; }
 .feed-list::-webkit-scrollbar-track { background: var(--md-default-bg-color); }

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -426,3 +426,16 @@ footer.md-footer { display: none; }
 .zsa-explore-grid .zsa-panel {
     padding: 2rem;
 }
+
+/* Align Explore grid exterior margins and gaps with Core Tactics cards */
+html body[data-md-color-scheme] .md-typeset .zsa-explore-grid {
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+@media screen and (min-width: 1000px) {
+    html body[data-md-color-scheme] .md-typeset .zsa-explore-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -429,6 +429,7 @@ footer.md-footer { display: none; }
 
 /* Align Explore grid exterior margins and gaps with Core Tactics cards */
 html body[data-md-color-scheme] .md-typeset .zsa-explore-grid {
+    display: grid;
     gap: 1rem;
     margin: 0;
     padding: 0;

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -421,3 +421,8 @@ footer.md-footer { display: none; }
 .kb-item:hover { border-color: var(--md-accent-fg-color); transform: translateY(-2px); }
 .kb-item-title { font-family: var(--md-code-font-family); font-size: 0.95rem; margin-bottom: 0.5rem; color: var(--md-default-fg-color); font-weight: 600; display: block; }
 .kb-item-desc { font-size: 0.85rem; color: var(--md-default-fg-color--light); margin: 0; display: block; }
+
+/* Align Explore panels padding with Core Tactics cards */
+.zsa-explore-grid .zsa-panel {
+    padding: 2rem;
+}

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -378,7 +378,31 @@ footer.md-footer { display: none; }
     padding-bottom: 0.75rem;
 }
 
-.feed-list { display: flex; flex-direction: column; gap: 1.25rem; }
+
+.feed-list { display: flex; flex-direction: column; gap: 1.25rem; max-height: 350px; overflow-y: auto; padding-right: 1rem; }
+/* Scrollbar styling for brutalist look */
+.feed-list::-webkit-scrollbar { width: 4px; }
+.feed-list::-webkit-scrollbar-track { background: var(--md-default-bg-color); }
+.feed-list::-webkit-scrollbar-thumb { background: var(--md-typeset-table-color); }
+.feed-list::-webkit-scrollbar-thumb:hover { background: var(--md-accent-fg-color); }
+
+.feed-footer {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px dashed var(--md-typeset-table-color);
+    text-align: right;
+}
+.feed-all-link {
+    font-family: var(--md-code-font-family);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    color: var(--md-accent-fg-color);
+    transition: color 0.2s ease;
+}
+.feed-all-link:hover {
+    color: var(--md-default-fg-color);
+}
+
 .feed-item { display: flex; flex-direction: column; transition: background-color 0.2s ease, color 0.2s ease; }
 .feed-item:hover .feed-title { color: var(--md-accent-fg-color); }
 .feed-date { font-family: var(--md-code-font-family); font-size: 0.75rem; color: var(--md-default-fg-color--light); margin-bottom: 0.2rem; }

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -384,7 +384,7 @@ footer.md-footer { display: none; }
 }
 
 
-.feed-list { display: flex; flex-direction: column; gap: 1.25rem; flex-grow: 1; overflow-y: auto; padding-right: 1rem; margin-bottom: 1.5rem; }
+.feed-list { display: flex; flex-direction: column; gap: 1.25rem; flex-grow: 1; min-height: 0; overflow-y: auto; padding-right: 1rem; margin-bottom: 1.5rem; }
 /* Scrollbar styling for brutalist look */
 .feed-list::-webkit-scrollbar { width: 4px; }
 .feed-list::-webkit-scrollbar-track { background: var(--md-default-bg-color); }

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -421,8 +421,3 @@ footer.md-footer { display: none; }
 .kb-item:hover { border-color: var(--md-accent-fg-color); transform: translateY(-2px); }
 .kb-item-title { font-family: var(--md-code-font-family); font-size: 0.95rem; margin-bottom: 0.5rem; color: var(--md-default-fg-color); font-weight: 600; display: block; }
 .kb-item-desc { font-size: 0.85rem; color: var(--md-default-fg-color--light); margin: 0; display: block; }
-
-/* Align Explore panels padding with Core Tactics cards */
-.zsa-explore-grid .zsa-panel {
-    padding: 2rem;
-}

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -423,12 +423,15 @@ html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > 
     html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > ul {
         grid-template-columns: 1fr 1fr;
     }
+    
+    /* Only apply the height hack when panels are side-by-side */
+    html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > ul > li.zsa-explore-panel:first-child {
+        height: 0;
+        min-height: 100%;
+    }
 }
 html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > ul > li.zsa-explore-panel {
     display: flex;
     flex-direction: column;
 }
-html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > ul > li.zsa-explore-panel:first-child {
-    height: 0;
-    min-height: 100%;
-}
+

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -361,10 +361,16 @@ footer.md-footer { display: none; }
     align-items: stretch;
 }
 
+.zsa-explore-grid > .zsa-panel {
+    min-height: 0;
+    height: 100%;
+}
+
 .zsa-explore-grid .zsa-panel {
     display: flex;
     flex-direction: column;
     min-height: 0;
+    max-height: 100%;
 }
 
 .zsa-panel {

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -354,3 +354,38 @@ html body[data-md-color-scheme] .md-typeset .grid.cards > ul > li > p > strong:n
 footer.md-footer { display: none; }
 
 
+
+
+/* Explore ZSA Enhancements */
+.zsa-explore-grid {
+    align-items: stretch;
+}
+
+.zsa-panel {
+    height: 100%;
+    box-sizing: border-box;
+}
+
+.panel-subtitle {
+    font-family: var(--md-code-font-family);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--md-accent-fg-color);
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    border-bottom: 1px solid var(--md-typeset-table-color);
+    padding-bottom: 0.75rem;
+}
+
+.feed-list { display: flex; flex-direction: column; gap: 1.25rem; }
+.feed-item { display: flex; flex-direction: column; transition: background-color 0.2s ease, color 0.2s ease; }
+.feed-item:hover .feed-title { color: var(--md-accent-fg-color); }
+.feed-date { font-family: var(--md-code-font-family); font-size: 0.75rem; color: var(--md-default-fg-color--light); margin-bottom: 0.2rem; }
+.feed-title { font-weight: 500; font-size: 0.95rem; color: var(--md-default-fg-color); transition: color 0.2s ease; }
+
+.kb-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; }
+.kb-item { border: 1px solid var(--md-typeset-table-color); padding: 1.5rem; transition: transform 0.2s ease, border-color 0.2s ease; background-color: var(--md-default-bg-color); text-decoration: none; display: block; }
+.kb-item:hover { border-color: var(--md-accent-fg-color); transform: translateY(-2px); }
+.kb-item-title { font-family: var(--md-code-font-family); font-size: 0.95rem; margin-bottom: 0.5rem; color: var(--md-default-fg-color); font-weight: 600; display: block; }
+.kb-item-desc { font-size: 0.85rem; color: var(--md-default-fg-color--light); margin: 0; display: block; }

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -426,16 +426,3 @@ footer.md-footer { display: none; }
 .zsa-explore-grid .zsa-panel {
     padding: 2rem;
 }
-
-/* Align Explore grid exterior margins and gaps with Core Tactics cards */
-html body[data-md-color-scheme] .md-typeset .zsa-explore-grid {
-    gap: 1rem;
-    margin: 0;
-    padding: 0;
-    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-}
-@media screen and (min-width: 1000px) {
-    html body[data-md-color-scheme] .md-typeset .zsa-explore-grid {
-        grid-template-columns: 1fr 1fr;
-    }
-}

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -361,6 +361,11 @@ footer.md-footer { display: none; }
     align-items: stretch;
 }
 
+.zsa-explore-grid .zsa-panel {
+    display: flex;
+    flex-direction: column;
+}
+
 .zsa-panel {
     height: 100%;
     box-sizing: border-box;
@@ -379,7 +384,7 @@ footer.md-footer { display: none; }
 }
 
 
-.feed-list { display: flex; flex-direction: column; gap: 1.25rem; max-height: 350px; overflow-y: auto; padding-right: 1rem; }
+.feed-list { display: flex; flex-direction: column; gap: 1.25rem; flex-grow: 1; overflow-y: auto; padding-right: 1rem; margin-bottom: 1.5rem; }
 /* Scrollbar styling for brutalist look */
 .feed-list::-webkit-scrollbar { width: 4px; }
 .feed-list::-webkit-scrollbar-track { background: var(--md-default-bg-color); }

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -357,16 +357,9 @@ footer.md-footer { display: none; }
 
 
 /* Explore ZSA Enhancements */
-.zsa-explore-grid {
-    align-items: stretch;
-}
 
-.zsa-explore-grid > .zsa-panel:first-child {
-    display: flex;
-    flex-direction: column;
-    height: 0;
-    min-height: 100%;
-}
+
+
 
 
 .zsa-panel {
@@ -421,3 +414,21 @@ footer.md-footer { display: none; }
 .kb-item:hover { border-color: var(--md-accent-fg-color); transform: translateY(-2px); }
 .kb-item-title { font-family: var(--md-code-font-family); font-size: 0.95rem; margin-bottom: 0.5rem; color: var(--md-default-fg-color); font-weight: 600; display: block; }
 .kb-item-desc { font-size: 0.85rem; color: var(--md-default-fg-color--light); margin: 0; display: block; }
+
+/* Explore ZSA Enhancements (Refactored to match mkdocs native UL/LI grid) */
+html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > ul {
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+@media screen and (min-width: 1000px) {
+    html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > ul {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > ul > li.zsa-explore-panel {
+    display: flex;
+    flex-direction: column;
+}
+html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > ul > li.zsa-explore-panel:first-child {
+    height: 0;
+    min-height: 100%;
+}

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -429,7 +429,6 @@ footer.md-footer { display: none; }
 
 /* Align Explore grid exterior margins and gaps with Core Tactics cards */
 html body[data-md-color-scheme] .md-typeset .zsa-explore-grid {
-    display: grid;
     gap: 1rem;
     margin: 0;
     padding: 0;

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -364,6 +364,7 @@ footer.md-footer { display: none; }
 .zsa-explore-grid .zsa-panel {
     display: flex;
     flex-direction: column;
+    min-height: 0;
 }
 
 .zsa-panel {


### PR DESCRIPTION
Implements the approved 'Floating Panels' layout for the Explore ZSA section.

- Uses standard `.zsa-section-title` for the main header.
- Side-by-side floating `.zsa-panel` cards using `.grid.cards` with `align-items: stretch` so they have equal height.
- Stack cleanly into a column on mobile viewports.
- Recent Transmissions properly distinct as a feed log, Knowledge base distinct as an inner grid.
