### PR TITLE
docs: add Day 19 navigation qualification post

### DIFF
--- a/docs/blog/posts/daily-blog-day-19.md
+++ b/docs/blog/posts/daily-blog-day-19.md
@@ -1,0 +1,55 @@
+---
+date: 2026-05-09
+slug: day-19-navigation-qualification-layer
+title: "Day 19: Your Navigation Is the Qualification Layer"
+description: "AI search engines are pre-qualifying your buyers. If your navigation doesn't instantly confirm their intent, that citation-driven demand leaks before it becomes pipeline."
+categories:
+  - Build in Public
+  - Strategy
+tags:
+  - Generative Engine Optimization
+  - GEO
+  - Information Architecture
+  - UX
+  - Navigation
+geo_tactics:
+  - IA Structuring
+  - Evidence Routing
+  - Bot-Native Navigation
+---
+
+# Day 19: Your Navigation Is the Qualification Layer
+
+When an AI engine like ChatGPT, Claude, or Perplexity refers a user to your website, that visitor is not just browsing. They are arriving with a problem, a shortlist, and a pre-formed expectation. The AI has already done the heavy lifting of matching your brand to their need. 
+
+But what happens in the critical ten seconds after they land? If your website's navigation doesn't instantly validate the AI's recommendation and route them to the proof they need, that hard-won citation demand leaks out before it ever enters your pipeline.
+
+<!-- more -->
+
+## The Post-Citation Reality
+
+For years, marketing teams have obsessed over top-of-funnel traffic capture, treating the homepage as a billboard. But in an AI-first web, the referral dynamic has shifted. Visitors arriving via Generative Engine Optimization (GEO) are not aimless scrollers; they arrive with highly specific intent. The AI has already served as the initial filter.
+
+Your navigation is no longer just a site map—it is your **qualification layer**. 
+
+If an AI recommends your firm for "enterprise agentic workflows," and the visitor clicks through only to face a generic, buzzword-laden drop-down menu that obscures the actual services, trust evaporates. The human user, impatient and goal-oriented, needs immediate structural confirmation that they are in the right place. 
+
+## The Dual Mandate of Information Architecture
+
+This brings us back to the Dual Mandate: optimizing for both the retrieval algorithm and the human buyer. Information architecture sits right at the intersection of these two forces.
+
+**For the Bot (The Retrieval System):**
+Clean information architecture, a semantic hierarchy, and stable labels are essential for retrieval engines. Models rely on distinct content types and predictable structures to map what your brand actually does. If your navigation is convoluted, the AI struggles to confidently extract the evidence it needs to cite you in the first place. Structuring your navigation intelligently helps AI systems establish entity relationships and understand exactly which of your capabilities align with specific user queries.
+
+**For the Human (The Buyer):**
+Clear routing is the post-citation handshake. Once the bot hands the user off, the human buyer is looking for validation. They need to seamlessly transition from the AI's answer into your ecosystem. Whether it is a playbook, a case study, or a technical breakdown, your navigation must quickly funnel them toward the empirical proof that confirms the AI's recommendation. 
+
+## The Commercial Cost of Bad IA
+
+Think of navigation as a commercial gatekeeper. When a CMO or enterprise buyer searches for AI strategies, they aren't looking to decipher your internal corporate jargon. They are looking for evidence of competence.
+
+If a high-intent, AI-referred visitor cannot find the relevant case study or service offering within seconds, what is the value of that lost deal? We spend significant resources fighting for visibility in AI answer engines; failing to structure the destination is a costly unforced error. 
+
+At Zero-Shot Agency, our recent focus on refining the "Explore ZSA" experience wasn't about making things look pretty. It was a structural reinforcement. We are ensuring that our navigation choices—both semantic and visual—serve as a high-speed routing mechanism. 
+
+The lesson is straightforward: the AI may make the introduction, but your site's architecture has to close the gap. Treat your navigation as the critical qualification layer it is, and ensure that every path leads directly to the proof.


### PR DESCRIPTION
## Summary
- Adds the approved Day 19 Build-in-Public post: "Your Navigation Is the Qualification Layer".
- Frames navigation and information architecture as the post-citation qualification layer for AI-referred, high-intent buyers.
- Connects retrieval legibility and human conversion through the Dual Mandate.

## Checks
- Frontmatter/content assertions passed for date, slug, title, and `<!-- more -->` marker.
- `mkdocs build` passed. Existing repository warnings remain from nav/roamlinks/autolinks baseline.
- PR payload verified locally before push: only `docs/blog/posts/daily-blog-day-19.md` differs from `origin/main`.
