### PR TITLE
fix: generate Explore ZSA blog links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,17 +5,6 @@ hide:
   - navigation
   - toc
 explore_zsa:
-  recent_posts:
-    - title: "Day 17: The Citation Is Only the Handoff"
-      url: "blog/posts/daily-blog-day-17/"
-    - title: "Day 16: Map the Citation Supply Chain"
-      url: "blog/posts/daily-blog-day-16/"
-    - title: "Day 15: The Context Window Is Not a Control Plane"
-      url: "blog/posts/daily-blog-day-15/"
-    - title: "Day 14: When Agents Write the Code: Managing Subagent Driven Development"
-      url: "blog/posts/daily-blog-day-14/"
-    - title: "Day 13: The Hallucination Defense - Protecting Your Brand Identity from AI Drift"
-      url: "blog/posts/daily-blog-day-13/"
   sections:
     - title: "Strategy and Playbook"
       description: "Our core methodology for AI-first visibility."

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -38,7 +38,7 @@
           <li class="zsa-explore-panel">
               <h3 class="panel-subtitle">Recent Transmissions</h3>
               <div class="feed-list">
-                  {% for post in page.meta.explore_zsa.recent_posts[:5] %}
+                  {% for post in config.extra.recent_posts[:5] %}
                   <a href="{{ post.url | url }}" class="feed-item">
                       <span class="feed-date">LOG // {{ post.title.split(':')[0] if ':' in post.title else 'TRANS' }}</span>
                       <span class="feed-title">{{ post.title.split(':', 1)[1].strip() if ':' in post.title else post.title }}</span>

--- a/tools/blog_hook.py
+++ b/tools/blog_hook.py
@@ -1,40 +1,82 @@
 import re
+from datetime import datetime
 from pathlib import Path
 
-def on_config(config, **kwargs):
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*", re.DOTALL)
+FIELD_RE = r"^{field}:\s*[\"']?(.*?)[\"']?\s*$"
+
+
+def _frontmatter_value(content, field):
+    frontmatter_match = FRONTMATTER_RE.match(content)
+    if not frontmatter_match:
+        return None
+
+    match = re.search(
+        FIELD_RE.format(field=re.escape(field)),
+        frontmatter_match.group(1),
+        flags=re.MULTILINE,
+    )
+    return match.group(1).strip() if match else None
+
+
+def _slug_from_title(title):
+    slug = title.lower()
+    slug = re.sub(r"[^a-z0-9\s\-]", "", slug)
+    slug = re.sub(r"[\s\-]+", "-", slug).strip("-")
+    return slug
+
+
+def _parse_post(file):
+    content = file.read_text(encoding="utf-8")
+    title = _frontmatter_value(content, "title")
+    date_raw = _frontmatter_value(content, "date")
+
+    if not title or not date_raw:
+        return None
+
+    slug = _frontmatter_value(content, "slug") or _slug_from_title(title)
+    date_part = date_raw.split()[0]
+    sort_date = datetime.fromisoformat(date_raw)
+
+    return {
+        "title": title,
+        "date": date_raw,
+        "sort_date": sort_date,
+        "url": f"/blog/{date_part.replace('-', '/')}/{slug}/",
+    }
+
+
+def _get_posts():
     blog_dir = Path("docs/blog/posts")
+    if not blog_dir.exists():
+        return []
+
     posts = []
-    if blog_dir.exists():
-        for file in blog_dir.glob("*.md"):
-            content = file.read_text(encoding="utf-8")
-            title_match = re.search(r'^title:\s*["\']?(.*?)["\']?$', content, flags=re.MULTILINE)
-            date_match = re.search(r'^date:\s*([\d-]+).*?$', content, flags=re.MULTILINE)
-            if title_match and date_match:
-                title = title_match.group(1)
-                date_str = date_match.group(1)
-                
-                # Read explicitly defined slug from frontmatter
-                slug_match = re.search(r'^slug:\s*(.*?)$', content, flags=re.MULTILINE)
-                if slug_match:
-                    slug = slug_match.group(1).strip()
-                else:
-                    slug = title.lower()
-                    slug = re.sub(r'[^a-z0-9\s\-]', '', slug)
-                    slug = re.sub(r'[\s\-]+', '-', slug).strip('-')
-                
-                url = f"/blog/{date_str.replace('-', '/')}/{slug}/"
-                posts.append({"title": title, "date_str": date_match.group(0), "url": url})
-    
-    # Sort descending based on exact date string
-    posts.sort(key=lambda x: x["date_str"], reverse=True)
-    top_3 = posts[:3]
-    
-    for item in config.get('nav', []):
-        if 'Blog' in item:
-            new_nav = [{"View All Posts": "blog/index.md"}]
-            for p in top_3:
-                new_nav.append({p["title"]: p["url"]})
-            item['Blog'] = new_nav
+    for file in blog_dir.glob("*.md"):
+        post = _parse_post(file)
+        if post:
+            posts.append(post)
+
+    return sorted(posts, key=lambda post: post["sort_date"], reverse=True)
+
+
+def on_config(config, **kwargs):
+    posts = _get_posts()
+
+    config.setdefault("extra", {})
+    config["extra"]["recent_posts"] = [
+        {"title": post["title"], "date": post["date"], "url": post["url"]}
+        for post in posts[:5]
+    ]
+
+    for item in config.get("nav", []):
+        if "Blog" in item:
+            item["Blog"] = [{"View All Posts": "blog/index.md"}]
+            item["Blog"].extend(
+                {post["title"]: post["url"]}
+                for post in posts[:3]
+            )
             break
-            
+
     return config


### PR DESCRIPTION
## Summary
- Generate recent blog post metadata in `tools/blog_hook.py`
- Render Explore ZSA recent posts from `config.extra.recent_posts`
- Remove hardcoded raw `blog/posts/...` homepage URLs from `docs/index.md`

## Verification
- `python3 -m py_compile tools/blog_hook.py`
- `python3 -m mkdocs build --clean`
- Verified built homepage feed links point to existing dated blog plugin URLs
- `python3 -m mkdocs build --strict` still fails on the repo's existing warning baseline (RoamLinks/AutoLinks/nav notices), not this fix
