### PR TITLE
docs: add Day 20 addressable evidence post

### DIFF
--- a/docs/blog/posts/daily-blog-day-20.md
+++ b/docs/blog/posts/daily-blog-day-20.md
@@ -1,0 +1,46 @@
+---
+title: "Day 20: Evidence Must Be Addressable"
+slug: day-20-evidence-must-be-addressable
+date: 2026-05-10
+description: "Why stable proof routes, semantic labels, and clear evidence paths stop AI-referred demand from leaking before it becomes pipeline."
+categories:
+  - Build in Public
+  - Strategy
+  - Optimization
+tags:
+  - Generative Engine Optimization
+  - AI Search
+  - Conversion Strategy
+geo_tactics:
+  - Stable URLs
+  - Evidence Addressability
+  - Content Routing
+---
+
+# Day 20: Evidence Must Be Addressable
+
+If ChatGPT or Perplexity recommends your product today, the buyer arrives with high intent. But that intent is fragile. When AI cites your capabilities, the human buyer still needs to verify the claim. 
+
+If the proof behind the AI recommendation is buried behind vague navigation, broken links, or generic landing pages, the buyer's journey stops. Generative Engine Optimization (GEO) isn't just about forcing the model to cite you; it's about making your evidence **addressable**.
+
+## The Commercial Risk of Unverifiable Claims
+
+A high-intent buyer arriving from an AI engine is not there to browse your corporate mission statement. They are there to validate a specific capability the AI told them you possess.
+
+When a CEO asks, "Who can build autonomous multi-agent pipelines?", the AI might point them to Zero-Shot Agency based on our factual density. But if the buyer clicks through and cannot immediately locate a case study, technical playbook, or working repository that proves we do this, the demand leaks. The AI citation is wasted if the destination page fails to reconcile with the promised capability.
+
+## Addressability is a GEO Primitive
+
+For both retrieval systems and human buyers, evidence must be structurally addressable:
+
+1. **Stable Proof Routes:** Case studies, empirical data, and technical playbooks need stable, semantic URLs. If your evidence only exists in dynamic modals, unlinked PDFs, or hidden tabs, an AI engine cannot reliably cite it, and a human cannot easily share it.
+2. **Clear Content Routing:** Structuring entity relationships is critical. The path from `Service` → `Tactic` → `Proof` must be explicit. Clear routing helps AI engines map your expertise and helps humans follow the logic of your value proposition.
+3. **The Dual Mandate:** This is the core of modern optimization. You must build strict, data-dense infrastructure (like `llms.txt` and semantic HTML) for bot retrieval, while simultaneously designing premium, high-conversion proof pathways for the human who clicks through.
+
+## The Operational Reality
+
+Building an addressable proof layer is difficult. It requires strict discipline across engineering, design, and content strategy. Behind the scenes, it involves wrestling with layout grids, mapping citation supply chains, and ensuring every single internal link routes correctly to a factual asset.
+
+The operational reality is messy, but the strategic imperative is clear: evidence must be directly findable, linkable, and credible. If it isn't, your GEO strategy is incomplete.
+
+*Zero-Shot Agency builds the infrastructure required for the AI-first web. We focus on empirical facts and structural trust.*


### PR DESCRIPTION
## Summary
- Adds the Day 20 Build-in-Public post: "Evidence Must Be Addressable"
- Preserves the buyer/GEO angle around stable proof routes, addressable evidence, and demand leakage
- Keeps the PR payload scoped to the intended blog post file only

## Verification
- Content assertions passed: date is `2026-05-10`, frontmatter title starts with `Day 20:`, and banned terms are absent
- `mkdocs build` passed (existing RoamLinks/AutoLinks warnings remain)
- PR payload checked with `git diff --name-only origin/main...HEAD`
