### PR TITLE
refactor: scope core card grid columns

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ hero:
 
 ## Core GEO Tactics to Maximize Visibility {: .zsa-section-title }
 
-<div class="grid cards" markdown>
+<div class="grid cards zsa-core-cards" markdown>
 
 -   **01 // Structure**
     **Semantic Architecture**

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -136,7 +136,7 @@ html body[data-md-color-scheme] .md-typeset .grid.cards > ul {
     list-style: none;
 }
 @media screen and (min-width: 1000px) {
-    html body[data-md-color-scheme] .md-typeset .grid.cards > ul {
+    html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul {
         grid-template-columns: repeat(4, 1fr);
     }
 }


### PR DESCRIPTION
## Summary
- Add `zsa-core-cards` to the Core GEO card grid
- Scope the desktop 4-column card-grid rule to `.grid.cards.zsa-core-cards`
- Leave generic `.grid.cards` available for future components without inheriting the forced 4-column desktop layout

## Verification
- `mkdocs build` passes
- Assertion confirms `docs/index.md` uses `class="grid cards zsa-core-cards" markdown`
- Assertion confirms CSS targets `.grid.cards.zsa-core-cards > ul`
- Headless Chrome screenshot confirms Core GEO cards still render as a 4-column desktop row and Explore ZSA remains 2-column

## Notes
- A tiny pre-existing visual offset on card 04 is also visible on the current live site before this PR, so it is not introduced by this scoped-selector change.
