### PR TITLE
refactor: scope core card typography

### DIFF
--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -140,18 +140,18 @@ html body[data-md-color-scheme] .md-typeset .grid.cards > ul {
         grid-template-columns: repeat(4, 1fr);
     }
 }
-html body[data-md-color-scheme] .md-typeset .grid.cards > ul > li > p {
+html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul > li > p {
     margin: 0;
     font-size: 0.95rem;
     color: var(--md-default-fg-color--light);
 }
 /* Ensure the kicker isn't bolded */
-html body[data-md-color-scheme] .md-typeset .grid.cards > ul > li > p > strong:nth-of-type(1) {
+html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul > li > p > strong:nth-of-type(1) {
     font-weight: 400;
     color: var(--md-default-fg-color--light);
 }
 /* The second bold tag inside the card is the main heading */
-html body[data-md-color-scheme] .md-typeset .grid.cards > ul > li > p > strong:nth-of-type(2) {
+html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul > li > p > strong:nth-of-type(2) {
     display: block;
     font-size: 1.15rem;
     color: var(--md-default-fg-color);


### PR DESCRIPTION
## Summary
- Scope Core GEO card paragraph typography to `.grid.cards.zsa-core-cards`
- Scope the Core card `strong:nth-of-type(...)` kicker/title rules to `.zsa-core-cards`
- Prevent future generic MkDocs card grids from inheriting Core-specific Markdown typography assumptions

## Verification
- `mkdocs build` passes
- `git diff --check` passes
- Assertions confirm the typography selectors now target `.grid.cards.zsa-core-cards`
- Headless Chrome visual QA confirms Core GEO card hierarchy remains intact and Explore ZSA still renders normally

## Notes
- This follows PR #198, which scoped the Core grid's desktop 4-column layout.
