### PR TITLE
refactor: merge zsa panel styles

### DIFF
--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -232,6 +232,8 @@ html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul > li
 .zsa-panel {
     background: var(--md-code-bg-color);
     padding: 3rem;
+    height: 100%;
+    box-sizing: border-box;
 }
 .zsa-panel.zsa-hero-copy {
     padding-right: 4rem;
@@ -357,15 +359,6 @@ footer.md-footer { display: none; }
 
 
 /* Explore ZSA Enhancements */
-
-
-
-
-
-.zsa-panel {
-    height: 100%;
-    box-sizing: border-box;
-}
 
 .panel-subtitle {
     font-family: var(--md-code-font-family);


### PR DESCRIPTION
## Summary
- Merge the duplicate `.zsa-panel` rules into one block
- Keep the existing background, padding, height, and box-sizing values unchanged
- Remove the later duplicate selector from the Explore section

## Verification
- `mkdocs build` passes
- `git diff --check` passes
- Assertion confirms there is a single standalone `.zsa-panel` block with the expected properties
- Headless Chrome visual QA confirms the homepage hero panels and Explore ZSA panels still render normally with no visible padding, height, or two-column layout regression

## Notes
- Existing MkDocs/RoamLinks warnings remain baseline noise and are unrelated to this CSS-only cleanup.
