### PR TITLE
refactor: restrict hero button transitions

### DIFF
--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -307,7 +307,7 @@ html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul > li
     font-family: var(--md-code-font-family);
     font-weight: 600;
     border-radius: 0;
-    transition: all 0.2s ease;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .md-typeset .zsa-hero-actions .md-button--primary {


### PR DESCRIPTION
## Summary
- Restrict `transition: all` on hero buttons to explicitly animate only `background-color`, `color`, and `border-color`.
- Prevents the browser from unintentionally animating layout-affecting properties (like margins, padding, or transform) on hover/focus.

## Verification
- `git diff --check` passes
- `mkdocs build` passes
