### PR TITLE
refactor: standardize section margins

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -85,8 +85,6 @@ hero:
 **RAG (Retrieval-Augmented Generation)**
 : The architecture used by modern AI search engines to fetch external information and ground their generated answers in factual, cited sources.
 
----
-
 ## Frequently Asked Questions about GEO
 
 ??? faq "What is Generative Engine Optimization (GEO)?"

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -31,7 +31,7 @@
   {{ content_sections[0] | safe }}
 
   {% if page.meta.explore_zsa %}
-  <h2 class="zsa-section-title" style="margin-top: 4rem;">Explore ZSA</h2>
+  <h2 class="zsa-section-title">Explore ZSA</h2>
   
   <div class="grid cards zsa-explore-container">
       <ul class="zsa-explore-grid">

--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -135,6 +135,10 @@ html body[data-md-color-scheme] .md-typeset .grid.cards > ul {
     padding: 0;
     list-style: none;
 }
+/* Force consistent section spacing to match Hero and Blockquote */
+html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards {
+    margin-bottom: 4rem;
+}
 @media screen and (min-width: 1000px) {
     html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul {
         grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
## Summary
- Remove inline `style="margin-top: 4rem;"` from the `Explore ZSA` template heading
- Apply `margin-bottom: 4rem;` to `.zsa-core-cards` natively in CSS
- Remove the redundant Markdown horizontal rule between Glossary and FAQ so spacing is controlled by the Glossary block and FAQ heading rather than `dl + hr + h2`

## Verification
- `git diff --check` passes
- `mkdocs build` passes
- Headless Chrome visual QA confirms:
  - the 80px Core GEO → Explore visual gap remains intact
  - the HR between Glossary and FAQ is gone
  - Glossary → FAQ spacing is cleaner and visually consistent
