### PR TITLE
refactor: tokenize hover backgrounds

### DIFF
--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -32,6 +32,8 @@
     --md-code-bg-color: #ffffff;
     --md-typeset-table-color: #d1d5db; /* used for structural borders */
     --md-accent-fg-color: #2563eb;
+    --zsa-panel-hover-bg: #ffffff;
+    --zsa-subtle-hover-bg: rgba(128,128,128,0.05);
     
     /* Strict Typeset Colors (preventing grey tints) */
     --md-typeset-color: var(--md-default-fg-color);
@@ -50,6 +52,8 @@
     --md-code-bg-color: #161b22;
     --md-typeset-table-color: #30363d; /* used for structural borders */
     --md-accent-fg-color: #58a6ff;
+    --zsa-panel-hover-bg: #1c2128;
+    --zsa-subtle-hover-bg: rgba(128,128,128,0.05);
     
     /* Strict Typeset Colors (preventing grey tints) */
     --md-typeset-color: var(--md-default-fg-color);
@@ -124,8 +128,7 @@ html body[data-md-color-scheme] .md-typeset .grid.cards > ul > li {
     border-radius: 0;
     padding: 2rem;
 }
-body[data-md-color-scheme="default"] .md-typeset .grid.cards > ul > li:hover { background-color: #ffffff; }
-body[data-md-color-scheme="slate"] .md-typeset .grid.cards > ul > li:hover { background-color: #1c2128; }
+html body[data-md-color-scheme] .md-typeset .grid.cards > ul > li:hover { background-color: var(--zsa-panel-hover-bg); }
 
 /* Feature Card Typography Targeting */
 html body[data-md-color-scheme] .md-typeset .grid.cards > ul {
@@ -333,7 +336,7 @@ html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul > li
 .md-typeset .zsa-hero-actions .md-button:not(.md-button--primary):hover,
 .md-typeset .zsa-hero-actions .md-button:not(.md-button--primary):focus {
     border-color: var(--md-default-fg-color);
-    background-color: rgba(128,128,128,0.05);
+    background-color: var(--zsa-subtle-hover-bg);
 }
 
 .md-typeset .zsa-micro-note {


### PR DESCRIPTION
## Summary
- Add semantic hover background tokens for panel/card hover states and subtle button hover states
- Replace raw component hover background values with `var(--zsa-panel-hover-bg)` and `var(--zsa-subtle-hover-bg)`
- Preserve the existing light/dark colour values exactly

## Verification
- `git diff --check` passes
- `mkdocs build` passes
- Assertions confirm hover tokens are present and raw card-hover values are no longer used directly in component rules
- Browser computed-style check confirms the tokens resolve on the page and the secondary hero button hover uses the subtle hover token

## Notes
- This is a tokenization refactor only; no intended visual change.
