### PR TITLE
refactor: standardize CSS breakpoints

### DIFF
--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -142,6 +142,7 @@ html body[data-md-color-scheme] .md-typeset .grid.cards > ul {
 html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards {
     margin-bottom: 4rem;
 }
+/* Desktop breakpoint: 1000px and up */
 @media screen and (min-width: 1000px) {
     html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul {
         grid-template-columns: repeat(4, 1fr);
@@ -355,7 +356,8 @@ html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul > li
     color: var(--md-default-fg-color);
 }
 
-@media (max-width: 800px) {
+/* Mobile breakpoint: below 800px. Tablet remains 800px–999px. */
+@media screen and (max-width: 799px) {
     .zsa-hero-grid { grid-template-columns: 1fr; }
     .zsa-panel { padding: 2rem; }
 }
@@ -419,6 +421,7 @@ footer.md-footer { display: none; }
 html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > ul {
     grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
 }
+/* Desktop breakpoint: 1000px and up */
 @media screen and (min-width: 1000px) {
     html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > ul {
         grid-template-columns: 1fr 1fr;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ hooks:
   - tools/build_log.py
 
 extra_css:
-  - stylesheets/zsa-theme.css?v=9
+  - stylesheets/zsa-theme.css?v=10
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- Standardizes the mobile breakpoint to `screen and (max-width: 799px)`, leaving `800px–999px` as the tablet band.
- Keeps the existing desktop breakpoint at `screen and (min-width: 1000px)`.
- Bumps the stylesheet cache-buster to `v=10` so the CSS change is actually delivered through immutable caches.

## Test Plan
- `git diff --check`
- CSS/media-query assertions for `799px`/`1000px` breakpoint contract
- `mkdocs build`

## Notes
- This is intentionally tiny: no layout redesign, no Explore height-hack change, no one-line CSS expansion.
- Browser visual QA could not be completed in this container because Chrome fails to launch without a sandbox-compatible setup; the PR is limited to explicit media-query normalization plus the required cache-buster bump.
