### PR TITLE
refactor: make homepage breakpoints mobile-first

### DIFF
--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -229,7 +229,7 @@ html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul > li
 */
 .zsa-hero-grid {
     display: grid;
-    grid-template-columns: 2fr 1fr;
+    grid-template-columns: 1fr;
     gap: 1px;
     background: var(--md-typeset-table-color);
     border: 1px solid var(--md-typeset-table-color);
@@ -238,12 +238,12 @@ html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul > li
 
 .zsa-panel {
     background: var(--md-code-bg-color);
-    padding: 3rem;
+    padding: 2rem;
     height: 100%;
     box-sizing: border-box;
 }
 .zsa-panel.zsa-hero-copy {
-    padding-right: 4rem;
+    padding-right: 2rem;
 }
 
 .md-typeset .zsa-hero-grid h1 {
@@ -355,9 +355,10 @@ html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul > li
     color: var(--md-default-fg-color);
 }
 
-@media (max-width: 800px) {
-    .zsa-hero-grid { grid-template-columns: 1fr; }
-    .zsa-panel { padding: 2rem; }
+@media screen and (min-width: 800px) {
+    .zsa-hero-grid { grid-template-columns: 2fr 1fr; }
+    .zsa-panel { padding: 3rem; }
+    .zsa-panel.zsa-hero-copy { padding-right: 4rem; }
 }
 /* Hide MkDocs Footer Banner */
 footer.md-footer { display: none; }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ hooks:
   - tools/build_log.py
 
 extra_css:
-  - stylesheets/zsa-theme.css?v=9
+  - stylesheets/zsa-theme.css?v=10
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- Converts the homepage hero layout to a mobile-first breakpoint model.
- Makes mobile/single-column layout the base CSS.
- Promotes the two-column hero and larger panel spacing at `screen and (min-width: 800px)`.
- Bumps the stylesheet cache-buster to `v=10` for immutable CSS cache delivery.

## Why
The current CSS effectively treats tablet as the default, then patches mobile with `max-width` and desktop with `min-width`. This PR makes the base layout small-screen-safe and layers up from there.

## Test Plan
- `git diff --check`
- CSS breakpoint assertions:
  - base hero grid is `1fr`
  - base panel padding is `2rem`
  - `min-width: 800px` restores `2fr 1fr` and `3rem`
  - no `max-width: 800px` hero override remains
- `mkdocs build`

## Notes
- Leaves PR #204 untouched/open for comparison.
- Does not change the desktop `1000px+` Core/Explore grid rules.
- Browser visual QA could not be completed in this container because Chrome cannot launch with the available sandbox setup; the change is intentionally limited and should be reviewed visually before merge.
