### PR TITLE
refactor: remove hero accent important

### DIFF
--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -261,8 +261,8 @@ html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-core-cards > ul > li
     margin-bottom: 1.5rem;
 }
 
-.zsa-hero-accent {
-    color: var(--md-accent-fg-color) !important;
+.md-typeset .zsa-hero-grid .zsa-hero-accent {
+    color: var(--md-accent-fg-color);
     font-weight: 500;
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ hooks:
   - tools/build_log.py
 
 extra_css:
-  - stylesheets/zsa-theme.css?v=10
+  - stylesheets/zsa-theme.css?v=11
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- Removes `!important` from `.zsa-hero-accent`.
- Replaces the bare class selector with a hero-scoped selector: `.md-typeset .zsa-hero-grid .zsa-hero-accent`.
- Bumps the stylesheet cache-buster to `v=11` for immutable CSS cache delivery.

## Specificity / Cascade Verification
Tested the built homepage rather than assuming the selector would win:

- Built `site/index.html` contains the `.zsa-hero-accent` span.
- Parsed the rendered stylesheet order from the built homepage.
- Evaluated direct `color` declarations matching the hero accent element.
- Winning declaration:
  - file: `stylesheets/zsa-theme.css`
  - selector: `.md-typeset .zsa-hero-grid .zsa-hero-accent`
  - specificity: `(0, 3, 0)`
  - important: `false`
  - value: `var(--md-accent-fg-color)`

## Test Plan
- `git diff --check`
- `mkdocs build`
- Static built-page cascade/specificity assertion using `BeautifulSoup`, `tinycss2`, and `cssselect2`.
- Asserted the old `color: var(--md-accent-fg-color) !important;` declaration no longer exists.

## Notes
- No HTML/template changes.
- No visual/layout changes intended.
