### PR TITLE
refactor: format Explore CSS rules

### DIFF
--- a/docs/stylesheets/zsa-theme.css
+++ b/docs/stylesheets/zsa-theme.css
@@ -381,12 +381,29 @@ footer.md-footer { display: none; }
 }
 
 
-.feed-list { display: flex; flex-direction: column; gap: 1.25rem; flex-grow: 1; min-height: 0; overflow-y: auto; padding-right: 1rem; margin-bottom: 1.5rem; }
+.feed-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    flex-grow: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 1rem;
+    margin-bottom: 1.5rem;
+}
 /* Scrollbar styling for brutalist look */
-.feed-list::-webkit-scrollbar { width: 4px; }
-.feed-list::-webkit-scrollbar-track { background: var(--md-default-bg-color); }
-.feed-list::-webkit-scrollbar-thumb { background: var(--md-typeset-table-color); }
-.feed-list::-webkit-scrollbar-thumb:hover { background: var(--md-accent-fg-color); }
+.feed-list::-webkit-scrollbar {
+    width: 4px;
+}
+.feed-list::-webkit-scrollbar-track {
+    background: var(--md-default-bg-color);
+}
+.feed-list::-webkit-scrollbar-thumb {
+    background: var(--md-typeset-table-color);
+}
+.feed-list::-webkit-scrollbar-thumb:hover {
+    background: var(--md-accent-fg-color);
+}
 
 .feed-footer {
     margin-top: 1.5rem;
@@ -405,16 +422,58 @@ footer.md-footer { display: none; }
     color: var(--md-default-fg-color);
 }
 
-.feed-item { display: flex; flex-direction: column; transition: background-color 0.2s ease, color 0.2s ease; }
-.feed-item:hover .feed-title { color: var(--md-accent-fg-color); }
-.feed-date { font-family: var(--md-code-font-family); font-size: 0.75rem; color: var(--md-default-fg-color--light); margin-bottom: 0.2rem; }
-.feed-title { font-weight: 500; font-size: 0.95rem; color: var(--md-default-fg-color); transition: color 0.2s ease; }
+.feed-item {
+    display: flex;
+    flex-direction: column;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+.feed-item:hover .feed-title {
+    color: var(--md-accent-fg-color);
+}
+.feed-date {
+    font-family: var(--md-code-font-family);
+    font-size: 0.75rem;
+    color: var(--md-default-fg-color--light);
+    margin-bottom: 0.2rem;
+}
+.feed-title {
+    font-weight: 500;
+    font-size: 0.95rem;
+    color: var(--md-default-fg-color);
+    transition: color 0.2s ease;
+}
 
-.kb-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; }
-.kb-item { border: 1px solid var(--md-typeset-table-color); padding: 1.5rem; transition: transform 0.2s ease, border-color 0.2s ease; background-color: var(--md-default-bg-color); text-decoration: none; display: block; }
-.kb-item:hover { border-color: var(--md-accent-fg-color); transform: translateY(-2px); }
-.kb-item-title { font-family: var(--md-code-font-family); font-size: 0.95rem; margin-bottom: 0.5rem; color: var(--md-default-fg-color); font-weight: 600; display: block; }
-.kb-item-desc { font-size: 0.85rem; color: var(--md-default-fg-color--light); margin: 0; display: block; }
+.kb-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+.kb-item {
+    border: 1px solid var(--md-typeset-table-color);
+    padding: 1.5rem;
+    transition: transform 0.2s ease, border-color 0.2s ease;
+    background-color: var(--md-default-bg-color);
+    text-decoration: none;
+    display: block;
+}
+.kb-item:hover {
+    border-color: var(--md-accent-fg-color);
+    transform: translateY(-2px);
+}
+.kb-item-title {
+    font-family: var(--md-code-font-family);
+    font-size: 0.95rem;
+    margin-bottom: 0.5rem;
+    color: var(--md-default-fg-color);
+    font-weight: 600;
+    display: block;
+}
+.kb-item-desc {
+    font-size: 0.85rem;
+    color: var(--md-default-fg-color--light);
+    margin: 0;
+    display: block;
+}
 
 /* Explore ZSA Enhancements (Refactored to match mkdocs native UL/LI grid) */
 html body[data-md-color-scheme] .md-typeset .grid.cards.zsa-explore-container > ul {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ hooks:
   - tools/build_log.py
 
 extra_css:
-  - stylesheets/zsa-theme.css?v=11
+  - stylesheets/zsa-theme.css?v=12
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- Expands dense one-line Explore CSS rules into normal multi-line declarations.
- Preserves selector order and every targeted property/value exactly.
- Bumps the stylesheet cache-buster to `v=12` for immutable CSS cache delivery.

## Verification
- Captured the targeted Explore declarations before editing.
- Re-parsed the edited CSS with `tinycss2` and asserted declaration equivalence for:
  - `.feed-list`
  - `.feed-list::-webkit-scrollbar*`
  - `.feed-item`
  - `.feed-date`
  - `.feed-title`
  - `.kb-grid`
  - `.kb-item`
  - `.kb-item-title`
  - `.kb-item-desc`
- Asserted those targeted selectors are no longer compressed one-liners.

## Test Plan
- `git diff --check`
- Targeted Explore declaration-equivalence assertion
- `mkdocs build`

## Notes
- Formatting-only CSS refactor.
- No selector changes.
- No property/value changes.
- No HTML/template changes.
