### PR TITLE
docs: add Day 21 retrieval hygiene post

### DIFF
--- a/docs/blog/posts/daily-blog-day-21.md
+++ b/docs/blog/posts/daily-blog-day-21.md
@@ -1,0 +1,134 @@
+---
+draft: false
+date: 2026-05-11
+categories:
+  - Build in Public
+  - Strategy
+  - Optimization
+tags:
+  - Generative Engine Optimization
+  - AI Search
+  - Content Strategy
+  - Retrieval Hygiene
+geo_tactics:
+  - Content Pruning
+  - Entity Consistency
+  - Evidence Graph Maintenance
+slug: day-21-prune-pages-that-teach-ai-the-wrong-thing
+title: "Day 21: Prune the Pages That Teach AI the Wrong Thing"
+description: "Stale content is not harmless archive clutter. In AI search, obsolete pages and misleading internal links can become retrieval decoys that teach answer engines the wrong version of your brand."
+---
+
+# Day 21: Prune the Pages That Teach AI the Wrong Thing
+
+Most marketing teams treat old pages as harmless.
+
+A retired service page stays live because nobody wants to break a link. A half-finished concept page remains indexed because it once felt useful. A positioning idea that the company has moved beyond still sits three clicks from the homepage, quietly connected to newer material.
+
+In traditional SEO, that might have looked like untidy housekeeping.
+
+In Generative Engine Optimization (GEO), it is more serious. Stale content is not just clutter. It is evidence. If it is visible, linked, and semantically connected, AI answer engines can retrieve it, summarize it, and use it to form an outdated picture of what your company does.
+
+That means content pruning is not a cosmetic cleanup. It is retrieval hygiene.
+
+<!-- more -->
+
+## Obsolete pages become citation decoys
+
+AI systems do not experience your website the way a buyer does.
+
+A human might land on an old page, notice the design feels dated, and mentally discount it. A retrieval system has no such instinct. It sees text, links, headings, entities, and relationships. If an obsolete page is still reachable, it can look like part of the current evidence graph.
+
+That creates a dangerous failure mode: the wrong page may still be good enough to retrieve.
+
+Not good enough to convert a buyer. Not accurate enough to represent the business. Just good enough to be pulled into a generated answer, comparison, or recommendation.
+
+For a CMO or founder, that is the uncomfortable part. Your outdated content may not be producing obvious traffic. It may not show up in your weekly analytics review. But it can still influence how ChatGPT, Claude, Perplexity, Gemini, and other answer engines understand your brand.
+
+If you leave the old version of your company online, you are asking the retrieval layer to choose between competing truths.
+
+## The evidence graph has to be maintained
+
+A GEO strategy is not just the production of new pages.
+
+It is the active maintenance of the visible evidence graph around the business: what you claim, what you prove, how those claims connect, and which routes are still valid.
+
+That graph decays unless someone tends it.
+
+Positioning changes. Offers sharpen. Proof improves. Weak concepts get retired. Internal language gets replaced by language the market actually understands. When those changes happen, the old material does not politely step aside. It keeps sending signals until it is removed, redirected, rewritten, or clearly marked as historical.
+
+This is why pruning matters.
+
+Pruning is the discipline of deciding which pages still deserve to teach the market, and which pages are now teaching the wrong lesson.
+
+A healthy evidence graph should make it easy for retrieval systems to answer basic questions with confidence:
+
+- What does this company actually do now?
+- Which capabilities are current, not experimental ghosts?
+- Which proof routes support those claims?
+- Which terms describe the business consistently across pages?
+- Which pages should no longer be treated as active evidence?
+
+If the graph cannot answer those questions cleanly, the model may improvise from whatever residue it can find.
+
+That is how hallucination risk starts: not always from the model inventing wildly, but from the company leaving contradictory source material in public.
+
+## The commercial cost is buyer confusion
+
+This sounds technical, but the buyer impact is simple.
+
+A high-intent buyer arrives from an AI recommendation expecting one version of the company. Then the site presents another.
+
+The answer engine says you specialise in a current capability. The page they find points to an old offer. The internal link trail uses retired terminology. The proof path leads to a concept that no longer matches the service. Nothing is obviously broken, but everything feels slightly misaligned.
+
+That slight misalignment is enough to leak trust.
+
+Executives do not need many reasons to postpone a conversation. In an AI-referred journey, confidence is already fragile because the buyer is validating a machine-mediated recommendation. If your own content graph contradicts itself, the buyer does not think, "This brand needs better content governance." They think, "I am not sure this is the right firm."
+
+Revenue leaks through those small moments of uncertainty.
+
+## Pruning is part of the Dual Mandate
+
+The Dual Mandate still applies: machines need clean structure; humans need confidence.
+
+Content pruning serves both sides.
+
+For retrieval systems, pruning reduces noise. It removes stale entities, weak semantic routes, and misleading internal references that can contaminate generated answers. It helps the model retrieve the current, high-signal version of the business instead of a historical fragment.
+
+For humans, pruning reduces doubt. It keeps the journey coherent after the AI handoff. The buyer should not have to reconcile three generations of positioning before deciding whether to trust you.
+
+That is why the operational work can feel deceptively small. Removing a stale page, retiring a weak concept, or cutting an obsolete internal reference does not look like a big strategic move from the outside.
+
+But in an AI-search environment, those choices shape what the market is allowed to learn from you.
+
+## The pruning test
+
+Before publishing another wave of content, run the uncomfortable audit.
+
+Look at the pages that are still live, still linked, and still readable by machines. Then ask:
+
+- Would we want an AI answer engine to use this page as evidence today?
+- Does this page describe the current business, or a previous iteration?
+- Does it reinforce our active entity language, or introduce a competing vocabulary?
+- Does it route buyers toward current proof, or strand them in an old concept?
+- If this page were summarized in a recommendation, would we be happy with the summary?
+
+If the answer is no, the page needs a decision.
+
+Update it. Consolidate it. Redirect it. Archive it. Remove it.
+
+But do not let it drift as invisible clutter, because it is not invisible to the systems forming your market's first impression.
+
+## The point
+
+Publishing is only half the work.
+
+The other half is deciding what no longer deserves to represent you.
+
+In the AI-first web, your public content estate is not just a library. It is training material for retrieval, synthesis, comparison, and recommendation. Every stale page is a possible decoy. Every obsolete term is a possible ambiguity. Every dead-end proof route is a possible leak in the buyer journey.
+
+So prune with intent.
+
+Not because tidy websites feel better.
+
+Because if you do not remove the pages that teach AI the wrong thing, you may end up optimizing the wrong version of your company.


### PR DESCRIPTION
## Summary
- Adds the Day 21 Build in Public post on content pruning as retrieval hygiene.
- Frames stale pages and obsolete internal routes as GEO evidence-graph risk for AI answer engines and buyers.
- Keeps the PR payload scoped to the single intended blog post file.

## Verification
- `git diff --name-only origin/main...HEAD` -> `docs/blog/posts/daily-blog-day-21.md` only.
- `git status --short` before commit showed only `A docs/blog/posts/daily-blog-day-21.md` staged.
- Frontmatter/content assertions passed: `date: 2026-05-11`, title begins with `Day 21:`, banned terms absent (`SearchGPT`, `ChatGPT (with browsing)`).
- `git diff --staged --check` passed.
- `mkdocs build` passed. Note: build emits existing site warnings for nav exclusions, absolute blog nav paths, and unresolved RoamLinks/AutoLinks references; no BuildError after removing the unsupported `authors: molty` field from the incoming draft.

## Payload gate
Confirmed: PR contains exactly one file, `docs/blog/posts/daily-blog-day-21.md`. No concept cleanup, CSS, config, generated files, sketches, node_modules, or unrelated local changes are included.
