### PR TITLE
docs: add Day 22 visibility measurement post

### DIFF
--- a/docs/blog/posts/daily-blog-day-22.md
+++ b/docs/blog/posts/daily-blog-day-22.md
@@ -1,0 +1,143 @@
+---
+title: "Day 22: Measure the Gap Between Visibility and Choice"
+slug: day-22-measure-visibility-choice-gap
+date: 2026-05-12
+description: "AI visibility is not a vanity ranking report. It is a commercial gap map between answer-engine mentions, buyer confidence, and the proof routes that turn recommendations into qualified conversations."
+categories:
+  - Build in Public
+  - Strategy
+  - Optimization
+tags:
+  - Generative Engine Optimization
+  - AI Search
+  - Conversion Strategy
+  - Measurement
+geo_tactics:
+  - AI Visibility Measurement
+  - Prompt Analysis
+  - Evidence Gap Mapping
+  - Proof Route Optimization
+---
+
+# Day 22: Measure the Gap Between Visibility and Choice
+
+A brand can appear in an AI answer and still lose the buyer.
+
+That is the uncomfortable measurement problem most AI visibility reports do not solve. They show whether the brand was mentioned, ranked, cited, or absent. Useful signals, but not enough. A mention is not a qualified conversation. A citation is not confidence. A shortlist position is not a decision.
+
+The commercial question is sharper:
+
+**What evidence was missing between the moment the answer engine found you and the moment the buyer needed to choose you?**
+
+That is the gap worth measuring.
+
+<!-- more -->
+
+## Visibility is only the first diagnostic
+
+AI search has made brand visibility more fragmented. A buyer might ask ChatGPT for a shortlist, compare suppliers in Claude, validate technical claims in Perplexity, then land on a service page already carrying assumptions from all three.
+
+If your company appears in that journey, the instinct is to celebrate the visibility.
+
+But a CMO, Marketing Director, or founder needs a more commercial readout. The question is not just, "Did we show up?" It is:
+
+- Which prompts made us visible?
+- Which prompts excluded us?
+- What claims did the answer engine repeat about us?
+- Which sources supported those claims?
+- Which buyer objections remained unanswered?
+- Which page should have turned the recommendation into confidence?
+
+A ranking report can tell you that the door opened. It cannot tell you whether the buyer had enough proof to walk through it.
+
+## The real gap is between mention and confidence
+
+The visibility-to-choice gap appears when an answer engine can find enough evidence to mention a brand, but not enough evidence to make the buyer comfortable choosing it.
+
+That gap can show up in several ways.
+
+The AI answer may describe the company accurately, but cite a weak or generic page. The buyer clicks, sees broad positioning instead of proof, and leaves unconvinced.
+
+The answer may surface the right capability, but the site may not route the buyer to a relevant case study, technical explanation, comparison page, or offer. The demand exists, but the proof route is broken.
+
+The model may understand the category, but not the commercial distinction. The brand appears beside competitors, yet nothing in the retrieved evidence explains why a buyer should choose one over another.
+
+Or the answer may be directionally positive but stale. The buyer arrives to validate a claim and finds old language, unclear packages, thin proof, or pages that do not match the answer they just read.
+
+None of these failures look like a total visibility failure. That is why they are easy to miss.
+
+They look like soft leakage: fewer qualified enquiries, longer sales cycles, more repeated explanation on calls, more buyers choosing the competitor whose proof was easier to verify.
+
+## What useful GEO measurement should connect
+
+Generative Engine Optimization measurement has to connect the full decision chain, not just the top of the answer.
+
+A serious AI visibility baseline should map:
+
+1. **Prompt demand:** the questions buyers actually ask when they are exploring, comparing, validating, or preparing to purchase.
+2. **Answer patterns:** whether answer engines mention the brand, how they frame it, which competitors appear beside it, and what language they use.
+3. **Citation surfaces:** the pages, third-party sources, directories, documentation, case studies, and profiles that supply the answer.
+4. **Entity claims:** the specific capabilities, categories, proof points, constraints, and outcomes attached to the brand.
+5. **On-site proof routes:** the destination paths a human can follow after the AI handoff to verify the claim and take the next step.
+
+The important part is the connection between those layers.
+
+If prompts show buyer demand for a capability, answers mention your brand, but the cited surfaces do not contain hard proof, you have an evidence-quality gap.
+
+If answers describe the right capability, but your site gives the buyer no clean path to validate it, you have a proof-route gap.
+
+If competitors are recommended with clearer outcomes, stronger case studies, or better category language, you have a differentiation gap.
+
+If the model repeats an outdated claim, you have an accuracy and risk gap.
+
+This is where measurement becomes useful. It stops being a dashboard of impressions and becomes a map of revenue leakage.
+
+## What we changed in our own thinking
+
+The shift for us is measurement discipline.
+
+We are treating AI visibility less like a scoreboard and more like a diagnostic system. The goal is not to prove that a brand appeared somewhere in an answer engine. The goal is to identify the missing evidence, unclear claims, stale surfaces, and weak proof routes that stop visibility from becoming choice.
+
+That changes the work.
+
+Instead of asking, "How do we get mentioned more often?" we ask, "Where does buyer confidence break after the mention?"
+
+Instead of measuring a citation in isolation, we inspect the route from prompt to answer, from answer to source, from source to page, and from page to next commercial action.
+
+That is a more uncomfortable audit, because it exposes gaps the marketing team can actually fix. But it is also more valuable, because it connects AI search performance to lead quality, conversion delay, data accuracy, and risk reduction.
+
+## The practical gap audit
+
+For any priority service, product, or category, run the visibility-to-choice audit.
+
+Start with the prompts that matter commercially:
+
+- "Who should we hire for this?"
+- "Which firms are credible in this category?"
+- "What are the best options for a company like ours?"
+- "How do these providers compare?"
+- "What proof exists that this company can deliver?"
+
+Then inspect what the answer engine returns.
+
+Do not stop at whether your brand appears. Capture the claims, competitors, citations, missing objections, and source quality. Then follow the buyer route manually. If the answer sends someone to your site, can they verify the exact claim without hunting? Can they see proof? Can they understand the offer? Can they take a relevant next step?
+
+If not, the measurement has done its job. It has found the commercial gap.
+
+## The point
+
+The next phase of GEO is not vanity visibility.
+
+It is evidence-led measurement: finding the gap between being visible and being chosen.
+
+Answer engines can introduce your brand to the buyer. They can summarize your claims, cite your pages, and place you into the comparison set. But they cannot manufacture confidence from weak proof. They cannot turn vague positioning into a clear business case. They cannot repair a broken proof route after the buyer arrives.
+
+That work belongs to the brand.
+
+So measure the gap. Find where the recommendation loses force. Fix the missing proof, unclear offer, stale source, or weak route.
+
+Because in AI search, the expensive failure is not always invisibility.
+
+Sometimes the answer engine already found you.
+
+The buyer just found someone easier to trust.


### PR DESCRIPTION
## Summary
- Adds Day 22 Build-in-Public post: "Measure the Gap Between Visibility and Choice"
- Frames AI visibility measurement as a commercial gap map between answer-engine mentions, buyer confidence, and proof routes
- Applies only the approved parent artifact to `docs/blog/posts/daily-blog-day-22.md`

## Verification
- Content assertion: forbidden terms absent; post matches approved parent artifact
- Payload gate: `git diff --name-only origin/main...HEAD` returns only `docs/blog/posts/daily-blog-day-22.md`
- `mkdocs build --strict` fails on existing baseline warnings (RoamLinks/AutoLinks/nav warnings)
- `mkdocs build` passes
