### PR TITLE
docs: add day 23 audit actionability post

### DIFF
--- a/docs/blog/posts/daily-blog-day-23.md
+++ b/docs/blog/posts/daily-blog-day-23.md
@@ -1,0 +1,139 @@
+---
+title: "Day 23: Make the Audit Easy to Act On"
+slug: day-23-make-the-audit-easy-to-act-on
+date: 2026-05-13
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+  - AI Visibility
+tags:
+  - AI Visibility Baseline
+  - GEO
+  - Buyer Enablement
+  - Diagnostics
+---
+
+# Day 23: Make the Audit Easy to Act On
+
+A visibility audit is not valuable because it contains a lot of observations.
+
+It becomes valuable when a busy buyer can look at it and understand what is leaking, why it matters, and what should be fixed first.
+
+That distinction matters for AI visibility work. ChatGPT, Claude, and Perplexity can surface a brand in dozens of different ways: category answers, comparison prompts, recommendation lists, cited pages, summaries, entity descriptions, and proof-seeking follow-ups. If the diagnostic simply hands all of that back as a pile of signals, it has not reduced uncertainty. It has moved the mess from the model into the buyer's lap.
+
+If the baseline cannot be understood and acted on by a busy CMO or founder, it is not a baseline. It is telemetry.
+
+<!-- more -->
+
+## The Audit Is Part of the Product
+
+There is a temptation in technical diagnostic work to prove seriousness by exposing everything.
+
+Every prompt. Every answer. Every source. Every missing claim. Every uncertain entity relationship. Every page that might help. Every page that might confuse the retrieval system. Every caveat.
+
+Some of that belongs in the work. Not all of it belongs in the first buyer experience.
+
+The first job of an AI Visibility Baseline is not to overwhelm the buyer with how complicated the ecosystem is. They already know the ecosystem is messy. That is why the diagnostic exists.
+
+The first job is to turn scattered AI-search evidence into a decision path:
+
+- where the brand is visible;
+- where it is absent;
+- where it is mentioned but not trusted;
+- where an unanswered buying question is slowing the journey;
+- where the evidence is too weak for either a model or a human to verify;
+- where the next fix is likely to create the most commercial leverage.
+
+The audit's job is not to prove how much was measured; it is to decide what the buyer needs to see first.
+
+That is a different standard from a research dump. It asks the audit to do synthesis, not just collection.
+
+## Buyers Do Not Buy Raw Complexity
+
+A CMO does not need to start with every prompt variant.
+
+A founder does not need a wall of evidence before they understand whether the company has an AI visibility problem.
+
+A marketing director does not need a taxonomy lesson before they can see that the brand is being excluded from high-intent answers, misdescribed in comparisons, or routed through weak confirmation pages.
+
+They need a clear map of commercial leakage.
+
+That leakage can show up in several ways:
+
+- **Revenue leakage:** the brand is missing from prompts where buyers are already asking for category recommendations.
+- **Decision delay:** the brand appears, but the next step is not obvious enough for a buyer to keep moving.
+- **Lead loss:** competitors are being recommended because their evidence is easier for models to retrieve and easier for humans to verify.
+- **Priority confusion:** the company can see symptoms across prompts, pages, and claims, but cannot tell which gap deserves attention first.
+- **Risk:** the model is learning an incomplete or stale version of the company because the public evidence is fragmented.
+
+Those are business problems, not reporting artefacts.
+
+The diagnostic has to make them visible without forcing the buyer to reverse-engineer the evidence chain themselves.
+
+## GEO Needs Evidence, But Evidence Needs Shape
+
+Generative Engine Optimization is not just getting mentioned by ChatGPT, Claude, or Perplexity.
+
+Mentions are only one layer. The harder question is whether the answer engine can connect a brand to clear entity claims, retrieve proof for those claims, and surface a useful page when a human wants to verify the recommendation.
+
+A useful diagnostic still needs rigorous evidence. It should know what buyers ask, which answers appear, which claims get attached to the brand, which sources support those claims, and where the human goes after the AI handoff.
+
+But the buyer-facing output should not present those layers as another measurement taxonomy.
+
+It should compress the evidence into a decision view:
+
+- **Severity:** how much the issue could affect qualified demand, trust, or conversion.
+- **Priority:** whether the fix belongs in the first sprint, the next improvement cycle, or the backlog.
+- **Commercial implication:** which buying question, objection, or revenue path is being weakened.
+- **Confidence:** how strong the evidence is, and where the finding needs more validation.
+- **Recommended next action:** the specific claim, page, structure, or proof asset that should change.
+
+That is where the audit becomes operational. It preserves the evidence chain, but it does not ask the buyer to assemble the strategy from a spreadsheet.
+
+## The Baseline Should Lower First-Call Friction
+
+The best diagnostic does not make the first commercial conversation heavier.
+
+It makes the conversation sharper.
+
+Instead of spending the call trying to explain what AI visibility means, the baseline should give both sides a shared operating picture:
+
+- here is how the market is asking for this category;
+- here is how answer engines currently describe the brand;
+- here is where competitors are easier to retrieve;
+- here is where the buyer journey stalls after the AI handoff;
+- here is the smallest credible sequence of fixes.
+
+A useful baseline should group findings into **Now / Next / Later**, with each item showing the prompt cluster, commercial implication, evidence link, and recommended fix.
+
+That turns the call from a vague discovery session into a prioritisation conversation.
+
+The buyer can challenge the evidence. The agency can explain the trade-offs. Both sides can talk about commercial action instead of drowning in optional inputs.
+
+This is especially important for AI visibility because the surface area is still unfamiliar to many leadership teams. If the diagnostic starts by demanding too much from them, it creates its own adoption problem.
+
+The baseline should not require the buyer to become an AI retrieval specialist before they can make a decision.
+
+## The Builder's Lesson
+
+The build-in-public lesson today is simple: the audit output is not a neutral container.
+
+It shapes whether the buyer trusts the work.
+
+A messy audit says, "Here is everything we found."
+
+An actionable baseline says, "Here is the decision path. Here is the evidence. Here is the order of attack."
+
+That difference is not cosmetic. It is commercial.
+
+AI visibility work lives between two audiences: the machines that need structured, retrievable evidence, and the humans who need a clear reason to act. The diagnostic has to respect both. It must be rigorous enough that the claims can be traced back to prompt, answer, source, entity, and page evidence. It must also be clear enough that a decision-maker can see the next move without reading a research appendix.
+
+The point is not to hide complexity.
+
+The point is to package complexity into a decision system.
+
+## Commercial Takeaway
+
+If your AI visibility audit gives buyers more data but no clearer route to action, it is not reducing risk. It is creating another layer of interpretation work.
+
+A commercially useful baseline should show where visibility is leaking, where proof is weak, and which fixes deserve priority. That is what turns GEO from an abstract visibility exercise into a buyer-ready operating plan.


### PR DESCRIPTION
## Summary
- Adds the Day 23 Build-in-Public post: “Make the Audit Easy to Act On”
- Frames AI visibility diagnostics as decision tools, not data dumps
- Keeps the PR payload scoped to the approved blog post only

## Checks
- Content assertions passed: frontmatter, excerpt marker, buyer relevance, GEO relevance, Now / Next / Later example, banned terms absent, internal repo mechanics absent
- `python3 -m mkdocs build --strict` failed due to 90 pre-existing MkDocs/RoamLinks/AutoLinks warnings unrelated to this post
- `python3 -m mkdocs build` passed
- `git diff --name-only origin/main...HEAD` shows only `docs/blog/posts/daily-blog-day-23.md`
