### PR TITLE
docs: add day 24 claim traceability post

### DIFF
--- a/docs/blog/posts/daily-blog-day-24.md
+++ b/docs/blog/posts/daily-blog-day-24.md
@@ -1,0 +1,162 @@
+---
+title: "Day 24: Make Every Claim Traceable"
+slug: day-24-make-every-claim-traceable
+date: 2026-05-14
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+  - AI Visibility
+tags:
+  - GEO
+  - Trust
+  - Evidence Architecture
+  - Buyer Enablement
+---
+
+# Day 24: Make Every Claim Traceable
+
+The weakest claim on a website is not always the one that sounds least impressive.
+
+It is the one a buyer cannot verify.
+
+That matters more in the AI-search era because ChatGPT, Claude, Perplexity, and other answer engines do not just reward confident positioning. They assemble answers from retrievable evidence. If a brand says it can solve a problem, the claim has to resolve into proof, context, and a sensible next step.
+
+Otherwise the claim becomes decorative copy. A machine may struggle to reuse it accurately. A human may struggle to trust it commercially.
+
+For GEO, traceability is becoming an operating principle: every important public claim should have a clear route from statement to evidence to action.
+
+<!-- more -->
+
+## The Buyer Does Not Want a Treasure Hunt
+
+A CMO or founder evaluating an AI-search strategy is usually not asking, "Can this agency produce more content?"
+
+They are asking sharper questions:
+
+- Can I see the evidence behind this recommendation?
+- Does this claim connect to a real commercial problem?
+- Is the proof current, specific, and relevant to my situation?
+- If I believe the claim, what should I do next?
+
+When those answers are scattered across vague service pages, unlabelled posts, disconnected audit notes, and buried proof points, trust leaks out of the journey.
+
+The brand may technically have the evidence. The buyer may technically be able to find it. The answer engine may technically have indexed it.
+
+But "technically available" is not the same as traceable.
+
+Traceability means the path is obvious. The claim points to the proof. The proof explains the context. The context leads to the next decision. No one has to reconstruct the argument from fragments.
+
+## Loose Claims Do Not Become Durable Retrieval Assets
+
+AI visibility work exposes a hard truth about marketing copy: many claims were written for persuasion, not retrieval.
+
+"We help ambitious teams scale growth."
+
+"We unlock AI transformation."
+
+"We deliver strategic clarity."
+
+Those lines may sound polished in a board deck, but they are weak evidence objects. They do not tell an answer engine what the company does, for whom, by which mechanism, or under what constraint. They do not help a buyer validate whether the company can solve a specific problem.
+
+A traceable claim is different.
+
+It gives the machine and the human something to follow:
+
+- **Entity:** who or what the claim is about.
+- **Capability:** the specific problem being solved.
+- **Evidence:** the artefact, diagnostic, case, methodology, or observable proof that supports it.
+- **Context:** the buyer situation where the claim applies.
+- **Next action:** the page, baseline, conversation, or decision the buyer should move toward.
+
+That is not just cleaner messaging. It is better retrieval infrastructure.
+
+When public claims are specific and connected, answer engines can reuse them with less distortion. When buyers land on the source, they can inspect the argument without feeling like they have been handed a slogan.
+
+## Principle 1: Put Proof Near the Claim
+
+If a page says a company can improve AI visibility, the supporting evidence should not live six clicks away in a forgotten resource hub.
+
+The proof route should be close enough that both audiences can follow it quickly:
+
+- the model parsing the page;
+- the human checking the recommendation;
+- the internal team maintaining the knowledge base;
+- the sales conversation that has to defend the claim later.
+
+This does not mean every page needs to become a dense research appendix. It means important claims need nearby validation: a named diagnostic, a clear methodology, a relevant example, a structured explanation, or a link to the deeper evidence.
+
+The commercial question is simple: if an AI-referred buyer arrives because a model described you as credible, can they see why before doubt takes over?
+
+If not, the problem is not just conversion copy. It is evidence placement.
+
+## Principle 2: Preserve the Chain of Reasoning
+
+A strong GEO system does not treat prompts, answers, pages, and recommendations as separate artefacts.
+
+It connects them.
+
+A useful evidence chain might look like this:
+
+- buyers ask a commercially specific question;
+- the answer engine attaches certain brands, claims, and sources to that question;
+- the brand's public site either confirms or weakens those claims;
+- the audit identifies the commercial risk or opportunity;
+- the next action strengthens the page, proof route, or entity description.
+
+That chain matters because it prevents the work from becoming a pile of observations.
+
+A disconnected finding says, "This page is weak."
+
+A traceable finding says, "This page is weak because it is the confirmation point for a high-intent answer pattern, and the claim it needs to support is not backed by specific proof."
+
+The second version is more useful to a buyer, more useful to a strategist, and more useful to an answer engine over time.
+
+## Principle 3: Make the Next Step Part of the Evidence
+
+Traceability should not stop at proof.
+
+If the claim is true and the buyer accepts the evidence, the next step should be obvious.
+
+That might be a baseline of current AI visibility. It might be a focused content fix. It might be a service page that explains the mechanism. It might be a deeper strategic conversation about which entity claims deserve investment first.
+
+The point is that evidence should reduce uncertainty, not create another research task.
+
+For marketing leaders, this is where traceability becomes commercial. A claim that resolves into proof but no action still leaves the buyer carrying the burden. A claim that resolves into proof and a relevant next step creates momentum.
+
+In AI-search journeys, that momentum matters. The buyer may already have been pre-qualified by the answer engine. They may already be comparing alternatives. They may already be checking whether the citation holds up.
+
+The site has a short window to turn borrowed attention into earned confidence.
+
+## The Builder's Lesson
+
+Recent work across our public knowledge base, site structure, and AI Visibility Baseline keeps pointing back to the same lesson: claims need infrastructure.
+
+Not more volume. Not louder positioning. Not another generic layer of thought leadership.
+
+Infrastructure.
+
+The public claim needs a stable label. The label needs a page. The page needs proof. The proof needs context. The context needs a next action. The whole chain needs to be legible enough for machines to retrieve and humans to trust.
+
+That is the Dual Mandate in practical form.
+
+Machines need structured, evidence-dense material they can parse accurately. Humans need a confident route from promise to proof to decision. If either side of that chain breaks, visibility does not become pipeline.
+
+## Commercial Takeaway
+
+AI visibility is not won by making bigger claims.
+
+It is won by making claims easier to verify.
+
+For a marketing team, that means auditing the public site differently. Do not only ask whether the page sounds persuasive. Ask whether every important claim can be traced:
+
+- What evidence supports it?
+- Where does that evidence live?
+- Can an answer engine retrieve it?
+- Can a buyer understand it quickly?
+- Does it lead to a clear next action?
+
+If the answer is no, the claim is not ready to carry demand.
+
+Zero-Shot Agency is building toward that standard: a GEO operating system where visibility, evidence, and buyer action are connected instead of scattered. The goal is not to make brands sound credible.
+
+The goal is to make credibility easy to find, easy to cite, and easy to act on.


### PR DESCRIPTION
## Summary
- Adds the approved Day 24 Build-in-Public post: "Make Every Claim Traceable"
- Frames traceability as a GEO operating principle connecting proof, context, and next action
- Keeps the PR scoped to `docs/blog/posts/daily-blog-day-24.md`

## Verification
- Content assertions passed: required frontmatter, `<!-- more -->`, and banned/internal terms absent
- Final artifact comparison passed against `/home/claw/.hermes/kanban/workspaces/t_53f4f008/daily-blog-day-24-final.md`
- `mkdocs build --strict` fails on existing site warnings from RoamLinks/AutoLinks/nav noise
- `mkdocs build` passes
- PR payload gate passed: only `docs/blog/posts/daily-blog-day-24.md`
