### PR TITLE
docs: add day 25 missing data demand post

### DIFF
--- a/docs/blog/posts/daily-blog-day-25.md
+++ b/docs/blog/posts/daily-blog-day-25.md
@@ -1,0 +1,100 @@
+---
+date: 2026-05-15
+slug: day-25-dont-confuse-missing-data-with-missing-demand
+title: "Day 25: Don't Confuse Missing Data with Missing Demand"
+description: "AI visibility baselines should protect strategy decisions by separating answer-engine access gaps, secondary citation-surface evidence, and genuine market invisibility."
+categories:
+  - Build in Public
+  - Strategy
+tags:
+  - Generative Engine Optimization
+  - GEO
+  - AI Visibility
+  - Measurement
+  - Decision Safety
+geo_tactics:
+  - Evidence Labelling
+  - Source Provenance
+  - Prompt Share of Voice
+---
+
+# Day 25: Don't Confuse Missing Data with Missing Demand
+
+A weak baseline can make a strong brand look invisible.
+
+That is the danger in AI visibility work. A founder asks whether their company appears in ChatGPT, Claude, Perplexity, or search-backed answer surfaces. A marketing leader runs a first pass. The dashboard comes back empty. The anxious conclusion is immediate: the market does not see us, the positioning must be wrong, and we need a content sprint by Monday.
+
+Maybe.
+
+But there are three very different things that can produce the same empty cell:
+
+1. the answer-engine test failed because access, setup, geography, account state, or capture conditions were wrong;
+2. the available evidence came from secondary citation surfaces rather than direct answer-engine transcripts;
+3. the brand was genuinely absent from the answers buyers are seeing.
+
+Those are not interchangeable findings. Treating them as the same result is how measurement becomes a budget hazard.
+
+<!-- more -->
+
+## A Baseline Is a Decision-Safety Layer
+
+The commercial value of an AI visibility baseline is not that it produces a neat chart. The value is that it slows down bad reactions.
+
+If a CMO sees low prompt Share-of-Voice, they need to know what kind of evidence produced that number before they change strategy. Was the model asked the right buyer-intent questions? Were the answer transcripts captured directly? Did the system only observe search results, RSS feeds, citations, or public index surfaces? Did the measurement environment fail before the answer engine ever had a fair chance to mention the brand?
+
+Each answer points to a different decision.
+
+An access failure says: fix the measurement path.
+
+Secondary citation-surface evidence says: treat the result as directional, not definitive.
+
+Direct answer-engine absence says: investigate positioning, entity clarity, source quality, and the content corpus the model can retrieve.
+
+A baseline that cannot label those differences does not protect the buyer. It gives them a false sense of certainty.
+
+## The Empty Result Is Not Always the Business Result
+
+This matters because marketing teams are under pressure to act quickly. If an AI visibility report says a competitor appears and you do not, the instinct is to rewrite pages, commission more thought leadership, or blame brand awareness.
+
+Sometimes that is right. Often, it is premature.
+
+A missing mention in a directly captured answer-engine transcript is a serious signal. A missing mention in a fallback scrape of citation or search surfaces is a weaker signal. A missing mention after a blocked or incomplete test is not market evidence at all.
+
+The discipline is to preserve that distinction in the report itself. Do not let an internal measurement limitation become an external market conclusion.
+
+For Generative Engine Optimization, this is one of the biggest differences between useful reporting and theatre. Answer-engine transcripts, citation surfaces, source retrieval paths, entity mentions, and prompt Share-of-Voice all describe different parts of the visibility system. They can inform each other, but they should not be collapsed into one undifferentiated score.
+
+## What Buyers Should Demand From GEO Reporting
+
+If you are buying or building AI visibility measurement, ask for evidence labels before you ask for recommendations.
+
+A useful baseline should tell you:
+
+- which prompts were tested and what buyer intent they represented;
+- whether the evidence came from direct answer-engine output or from a secondary search/citation surface;
+- which sources were cited, retrieved, or observed;
+- whether the brand appeared as an entity, a recommendation, a citation, or not at all;
+- where access or capture limitations may have weakened the finding;
+- what decision is safe to make from each evidence type.
+
+That last point is the commercial one.
+
+A founder does not need a vanity dashboard. A founder needs to know whether they should change positioning, create better proof assets, improve entity consistency, strengthen source coverage, or simply rerun the test with cleaner access.
+
+A Marketing Director does not need another ambiguous visibility score. They need a labelled evidence chain they can defend in a budget conversation.
+
+## The Builder's Lesson
+
+Today’s lesson is narrow, but important: label evidence before making strategy decisions.
+
+In our own visibility work, the uncomfortable part is not seeing a zero. The uncomfortable part is deciding what kind of zero it is. A zero from a secondary citation surface is not the same as a zero from a direct answer-engine transcript. A zero caused by capture friction is not the same as a zero caused by genuine market absence.
+
+That distinction keeps the work honest.
+
+GEO is going to create a lot of dashboards. Some will be useful. Many will overstate confidence because the output looks clean even when the evidence chain is messy.
+
+The better approach is less glamorous: keep provenance attached to every finding. Mark the source type. Separate direct answer evidence from fallback surfaces. Preserve the uncertainty where the measurement path is incomplete.
+
+Then, and only then, decide what to change.
+
+Because missing data is a measurement problem. Missing demand is a market problem. Confusing the two is how teams spend money solving the wrong one.


### PR DESCRIPTION
## Summary
- Adds Day 25 Build in Public post: “Don’t Confuse Missing Data with Missing Demand”
- Frames AI visibility baselines as decision-safety tools, separating direct answer-engine evidence, secondary citation-surface evidence, and measurement/access gaps

## Verification
- Frontmatter/content assertions passed
- `git diff --check` passed
- `mkdocs build --strict` fails on existing site warning baseline
- `mkdocs build` passes

## Note
The scheduled Kanban pipeline did not open this automatically because the reviewer gate task is blocked: the reviewer worker is exiting without calling `kanban_complete`/`kanban_block`, likely after auth/model re-auth prompts. This PR is the clean rescue branch from `origin/main`.
