### PR TITLE
docs: add day 26 corpus governance post

### DIFF
--- a/docs/blog/posts/daily-blog-day-26.md
+++ b/docs/blog/posts/daily-blog-day-26.md
@@ -1,0 +1,157 @@
+---
+title: "Day 26: Own the Evidence Before AI Interprets the Brand"
+slug: "day-26-own-the-evidence-before-ai-interprets-the-brand"
+date: 2026-05-16
+description: "AI-mediated buyer journeys make corpus governance a commercial responsibility: decide which pages, claims, and definitions are allowed to represent the company."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - content governance
+  - evidence architecture
+  - brand strategy
+geo_tactics:
+  - canonical source mapping
+  - claim governance
+  - cross-functional message control
+  - buyer journey evidence design
+---
+
+A company does not have one public message. It has a public corpus.
+
+The homepage, product pages, service pages, case studies, founder essays, sales decks that become PDFs, partner blurbs, help docs, bios, comparison pages, and old campaign copy all participate in how the market understands the business.
+
+In an AI-mediated buyer journey, that corpus matters more than most teams admit. Buyers no longer encounter the company only through the page marketing intended them to read first. They may arrive after an assistant has summarized a category, compared vendors, extracted a claim, or framed the company in language the buyer did not get from the website directly.
+
+That does not mean the company controls the answer. It means the company has to govern the evidence.
+
+The commercial question is simple: which public claims are allowed to represent us?
+
+<!-- more -->
+
+## Corpus governance is message control
+
+Most positioning work happens in rooms: leadership workshops, product marketing reviews, sales enablement calls, launch planning, investor updates. The output is usually a refined narrative.
+
+Then the narrative meets the corpus.
+
+A product page says one thing. A sales deck says it another way. A blog post introduces a useful phrase that the team never formally adopted. A case study proves a narrow outcome, but the homepage turns it into a broader promise. A founder post captures the strategic direction better than the current service page. The customer-facing truth becomes distributed across assets with different owners.
+
+This is not just an editorial problem. It is commercial message control.
+
+If marketing, product, sales, and leadership do not agree on which pages and claims are canonical, the market is left to reconcile the differences. So are the AI systems that summarize, compare, and explain companies during research.
+
+A governed corpus gives both humans and machines a clearer route to the intended meaning of the business.
+
+## Canonicality is a trust signal
+
+“Canonical” can sound like a technical word. In this context, it is a trust word.
+
+When a buyer wants the truth about the company, where should that truth live?
+
+A strong evidence layer makes the answer obvious:
+
+- The core positioning page defines the company in current language.
+- Product or service pages explain what is actually sold.
+- Proof pages show which outcomes the company can credibly support.
+- Thought-leadership pages extend the point of view without changing the promise.
+- Sales and marketing assets point back to the same claims instead of inventing parallel versions.
+
+This structure does not guarantee that an AI system will describe the company exactly as intended. It does reduce ambiguity in the public material available for interpretation.
+
+For buyers, canonicality creates a different kind of confidence. They can move from summary to website to proof without feeling that every page is asking them to believe a slightly different company.
+
+## The real owner is not “content”
+
+It is tempting to assign corpus governance to content marketing because the artifacts look like content.
+
+That is usually too narrow.
+
+The corpus contains commercial commitments. It includes what the company claims to do, who it claims to serve, which outcomes it implies, which category language it uses, and which proof it presents. Those decisions affect pipeline quality, sales conversations, analyst perception, partner fit, and customer expectations.
+
+A CMO or founder should treat the public corpus as a source-of-truth system, not a publishing backlog.
+
+That does not mean every page needs executive review. It means the company needs a clear operating model for public evidence:
+
+- Who owns the primary definition of the company?
+- Which page is the canonical explanation of each offer?
+- Which claims require proof before they can be used publicly?
+- Which customer outcomes can sales repeat without softening or exaggerating them?
+- Which category terms are strategic, and which ones create confusion?
+- Which pages should be treated as supporting evidence rather than primary positioning?
+
+Without those decisions, teams improvise. With them, the corpus becomes a coordinated commercial asset.
+
+## Claims need permission
+
+The most important governance unit is not the page. It is the claim.
+
+A claim can be a sentence on a homepage, a phrase in a demo deck, a line in a case study, or a definition in a blog post. Some claims are descriptive: what the product does. Some are comparative: why it is different. Some are evidentiary: what result it has produced. Some are strategic: how the company wants the category to be understood.
+
+Each type needs a different standard of permission.
+
+A descriptive claim should match the current product or service reality. A comparative claim should be specific enough to defend. An evidentiary claim should point to proof. A strategic claim should be consistent enough that the market can learn it through repetition.
+
+This is where GEO becomes less about clever optimization and more about discipline. Public evidence teaches. If the company repeatedly publishes the same claim in the same relationship to the same proof, it gives buyers and AI systems a steadier pattern to interpret. If every team rewrites the promise in isolation, the pattern weakens.
+
+The question is not “Can we say this?”
+
+The better question is “Should this claim be allowed to represent the company?”
+
+## A practical source-of-truth model
+
+For a growing company, the governance model does not need to be complicated. It needs to be explicit.
+
+Start with four layers.
+
+**1. Company truth**
+
+The canonical explanation of what the company is, who it serves, what problem it solves, and why it exists. This is usually owned by the founder, CEO, or CMO.
+
+**2. Offer truth**
+
+The canonical explanation of each product, service, package, or engagement model. Product and revenue leaders should share ownership here because the claim must match both delivery reality and sales motion.
+
+**3. Proof truth**
+
+The approved evidence that supports commercial claims: customer stories, metrics, testimonials, research, demos, examples, and references. This layer should define what can be repeated publicly and what requires qualification.
+
+**4. Point-of-view truth**
+
+The company’s interpretation of the market: category beliefs, strategic language, enemy statements, predictions, and educational frameworks. This is where thought leadership can be useful without becoming a second positioning system.
+
+Once these layers exist, content decisions get easier. A new page either reinforces a source of truth, extends it, or challenges it. If it challenges it, the team has to decide whether the page is wrong or the source of truth has changed.
+
+That is governance.
+
+## What changes for the buyer journey
+
+AI-mediated discovery compresses the distance between research, comparison, and validation. A buyer may form an opinion before they ever fill out a form. They may ask for a shortlist, then inspect the public evidence to decide whether the recommendation feels credible.
+
+At that moment, the corpus has to do more than attract attention. It has to hold together.
+
+The buyer should be able to answer:
+
+- What does this company actually do?
+- Is the promise consistent across pages?
+- Which claims are supported by proof?
+- Does the sales language match the public language?
+- Is the company’s point of view clear enough to remember?
+
+A well-governed corpus helps the buyer keep moving. It removes unnecessary interpretation work. It makes the company easier to explain internally. It gives champions cleaner language to repeat.
+
+That is the commercial value of canonicality.
+
+## The operating question for Day 26
+
+The useful question is not whether the company has enough content.
+
+It is whether the company knows which public evidence is allowed to speak for it.
+
+For Zero-Shot Agency, this is the center of the work: helping companies design public evidence systems that make them easier for buyers and AI systems to understand. Not by chasing every possible mention, and not by treating visibility as a trick, but by making the company’s claims, proof, and point of view coherent enough to travel.
+
+A brand cannot control every summary that appears in an AI-mediated journey.
+
+It can control whether its own corpus gives the market a clear version to work from.


### PR DESCRIPTION
## Summary
- Adds Day 26 Build in Public post: “Own the Evidence Before AI Interprets the Brand”
- Reworks the stranded corpus draft after reviewer feedback into a distinct post about corpus governance, canonical claims, and commercial message control

## Review
- Initial ghost draft: `CHANGES_REQUESTED` because it overlapped Day 21 pruning/retrieval-hygiene themes
- Revised Day 26 draft: reviewer verdict `APPROVED`

## Verification
- Content/frontmatter assertions passed
- `git diff --check` passed
- `mkdocs build --strict` fails on existing site warning baseline
- `mkdocs build` passes
