### PR TITLE
docs: add day 27 visibility gap post

### DIFF
--- a/docs/blog/posts/daily-blog-day-27.md
+++ b/docs/blog/posts/daily-blog-day-27.md
@@ -1,0 +1,123 @@
+---
+date: 2026-05-17
+slug: day-27-visibility-gap-buyer-journey
+title: "Day 27: A Visibility Gap Is Only Useful If It Changes the Buyer Journey"
+description: "AI visibility gaps are not the deliverable. The commercial value is knowing which missing proof, weak claim, or trust break is leaking buyers out of the journey."
+categories:
+  - Build in Public
+  - Strategy
+tags:
+  - Generative Engine Optimization
+  - GEO
+  - Buyer Journey
+  - AI Visibility
+  - Conversion Strategy
+geo_tactics:
+  - Evidence Gap Mapping
+  - Canonical Claim Design
+  - Post-Citation Trust
+---
+
+# Day 27: A Visibility Gap Is Only Useful If It Changes the Buyer Journey
+
+A visibility gap is not automatically a business problem.
+
+That sounds uncomfortable coming from a GEO agency, but it matters. A dashboard can show that an answer engine mentions a competitor more often. A prompt test can show that your brand is absent from a category query. A gap list can show missing pages, weak snippets, and stale facts.
+
+Useful? Yes.
+
+Commercially decisive? Only if it changes what a buyer sees, believes, compares, or does next.
+
+<!-- more -->
+
+## The Gap Is Not the Deliverable
+
+The easy version of AI visibility work is to produce findings: prompts checked, rankings noted, competitors logged, citations counted. That has diagnostic value, but it can quickly become another reporting layer while the pipeline problem remains untouched.
+
+A CMO does not need a prettier spreadsheet of absence. A founder does not need a long list of prompts where the company failed to appear. A Marketing Director does not need another weekly ritual proving that the market is noisy.
+
+They need to know which public piece of evidence is missing, which claim is too vague to be trusted, which comparison is letting a competitor become the default answer, and which step in the buyer journey is currently leaking revenue.
+
+The useful question is not just what is missing. It is which buyer decision the missing evidence is failing to support: shortlist creation, risk validation, internal champion enablement, vendor comparison, landing-page confirmation, or sales handoff.
+
+That is the line we are trying to hold as we build Zero-Shot Agency in public: a visibility gap only earns its keep when it becomes a buyer-journey intervention.
+
+## Translate Findings Into Buyer Decisions
+
+There are at least five different problems that can hide behind the phrase "AI visibility gap."
+
+One gap might mean the brand has no canonical proof asset for a high-intent use case. The fix is not more monitoring; it is a specific page, case study, benchmark, or explainer that an answer engine can retrieve and a human buyer can believe.
+
+Another gap might mean the offer is described three different ways across the public corpus. The buyer-journey consequence is ambiguity: the model cannot reconcile the company cleanly, and the buyer cannot explain the option internally with confidence. The fix is claim discipline, so the same entity, capability, audience, and outcome can be understood without forcing anyone to guess.
+
+Another gap might mean comparison material is weak. If answer engines keep recommending a competitor because their public evidence is easier to quote, the problem is not just visibility. It is a lost shortlist moment.
+
+Another gap might mean stale facts are poisoning trust. Old positioning, outdated service descriptions, or abandoned pages can create a retrieval layer that misrepresents the current business at the exact moment a buyer is trying to reduce risk.
+
+And another gap might happen after the citation. The AI sends someone to the site, but the landing experience fails to confirm the promise quickly enough. The buyer bounces, not because the model failed, but because the human handoff did.
+
+Those are different commercial problems. Treating them all as "we need better AI visibility" is too blunt.
+
+## The GEO Mechanism: Evidence That Can Be Retrieved and Reconciled
+
+Generative Engine Optimization is not magic placement. It is evidence engineering.
+
+Answer engines need public material they can retrieve, compare, and reconcile. They need stable facts, clear entity relationships, specific claims, proof that supports those claims, and pages that make the next logical buyer question easy to answer.
+
+That is why a useful gap analysis has to ask sharper questions than "did we appear?"
+
+It should ask:
+
+- What evidence would make this answer engine confident enough to cite us?
+- Which claim needs a canonical source rather than scattered copy?
+- Which buyer question is currently answered better by a competitor?
+- Which proof asset would reduce risk for a human evaluator after the AI citation?
+- Which stale or ambiguous fact could cause the model to describe us inaccurately?
+
+This is where the Dual Mandate becomes practical. The bot-native layer needs dense, structured, consistent evidence. The human-conversion layer needs that evidence to land as trust: a page that explains the offer clearly, a comparison that respects buyer doubts, a case study that proves capability, or a next step that matches intent.
+
+If either side fails, revenue leaks. The model may not cite you. Or it may cite you and still hand the buyer into a weak, confusing, unconvincing journey.
+
+## The Builder's Reality
+
+The gritty part is that this work often starts with unglamorous diagnosis.
+
+You find pages that almost say the right thing. Claims that sound impressive but are not anchored to proof. Service language that makes sense internally but does not map cleanly to how a buyer asks the market for help. Comparisons that exist in sales calls but not in public. Strong thinking trapped in private notes, unavailable to the retrieval systems shaping first impressions.
+
+None of that is a moral failure. It is normal. Most websites were built for human navigation, brand polish, and legacy search. They were not built as evidence layers for answer engines that synthesize vendor shortlists before a buyer ever lands on a homepage.
+
+The commercial opportunity is to stop treating those gaps as content chores and start treating them as buyer-journey design.
+
+If a founder is losing trust because the offer is too abstract, build the canonical explanation. If a Marketing Director is losing qualified leads because comparison queries default to competitors, build the comparison layer. If a CMO is worried about AI answers inventing or distorting the company position, retire the ambiguous claim and replace it with a sourceable one.
+
+That is the difference between a report and a revenue intervention.
+
+## What a Useful Visibility Gap Should Produce
+
+A useful AI visibility finding should end with a buyer-journey decision, not a shrug.
+
+It should tell the team which commercial moment needs to change:
+
+- Shortlist creation: build the proof asset that makes the brand credible for a high-intent category, use case, or audience.
+- Comparison: create the page, evidence, or framing that stops a competitor from becoming the easier answer to quote.
+- Risk validation: strengthen the claim that a buyer wants to believe but cannot yet verify in public.
+- Claim correction: retire confusing language that causes models or humans to misunderstand the offer.
+- Entity accuracy: update stale facts, outdated service descriptions, and ambiguous source material before they shape the wrong recommendation.
+- Post-citation handoff: improve the landing experience so the buyer can confirm the promise quickly after an AI referral.
+- Re-measurement: check the same buyer-journey leak again after the change, not as vanity monitoring but as evidence that the intervention worked.
+
+The output is not just "we are absent from the answer." The output is "the buyer cannot currently verify this claim in public, so the model cites someone else and the human has no reason to switch back."
+
+That sentence is commercially useful. It connects retrieval failure to trust failure. It gives marketing, sales, and leadership a shared object to fix.
+
+## The Standard We Are Building Toward
+
+The standard for Zero-Shot Agency is not to hand clients a pile of prompts and call it strategy.
+
+The standard is to map AI visibility gaps to the commercial journey: from the evidence an answer engine can retrieve, to the claim it can safely repeat, to the proof a buyer can inspect, to the moment where a high-intent visitor decides whether to trust the recommendation.
+
+That is the work that matters in the AI-first web.
+
+Not visibility for its own sake. Not dashboards for their own sake. Not content for its own sake.
+
+Evidence that changes the buyer journey.


### PR DESCRIPTION
## Summary
- recovers the stranded Day 27 Build-in-Public draft from the editorial Kanban workspace
- applies the overlap-audit tightening around buyer-journey interventions
- adds the post as `docs/blog/posts/daily-blog-day-27.md`

## Verification
- frontmatter/content assertion passed
- `git diff --staged --check` passed before commit
- `mkdocs build --strict` fails on the existing warning baseline (90 warnings)
- `mkdocs build` passes
- generated route exists: `site/blog/2026/05/17/day-27-visibility-gap-buyer-journey/index.html`
