### PR TITLE
docs: add day 28 freshness trust post

### DIFF
--- a/docs/blog/posts/daily-blog-day-28.md
+++ b/docs/blog/posts/daily-blog-day-28.md
@@ -1,0 +1,146 @@
+---
+title: "Day 28: Freshness Is a Trust Signal, Not a Publishing Quota"
+date: 2026-05-18
+slug: day-28-freshness-trust-signal
+description: "Freshness only helps generative search when it keeps the evidence buyers and answer engines rely on current, specific, and trustworthy."
+categories:
+  - Build in Public
+tags:
+  - GEO
+  - AI Search
+  - Content Strategy
+  - Trust Signals
+  - Buyer Enablement
+---
+
+# Day 28: Freshness Is a Trust Signal, Not a Publishing Quota
+
+Publishing more is not the same thing as becoming more trustworthy.
+
+That distinction matters more in generative search than it ever did in traditional SEO. A stale page can mislead an answer engine. A stale comparison can delay a buyer. A stale claim can make a confident company look vague, unproven, or out of step with its own sales conversation.
+
+But a noisy publishing cadence can create the same problem from the opposite direction: more pages, more half-updated claims, more overlapping explanations, more ambiguity for the systems and humans trying to understand what the company actually does.
+
+Freshness is useful when it strengthens the evidence layer.
+
+It is waste when it only proves the calendar moved.
+
+<!-- more -->
+
+## The trust problem is not solved by posting more
+
+A lot of teams treat freshness as a volume metric. The blog needs another post. The resources page needs another asset. The comparison page needs a minor update so it looks alive.
+
+That can feel productive, but buyers do not reward activity. They reward clarity.
+
+A CMO evaluating an AI visibility partner does not care that a site has been touched recently. They care whether the public evidence still matches the offer, the market, the proof, and the conversation they are already having internally.
+
+The risk is not merely that old content underperforms. The commercial risk is that stale or ambiguous assets keep working against the sale:
+
+- offer language that no longer matches what the team actually delivers;
+- comparison pages that describe an old category while buyers are evaluating a new one;
+- claims that sound impressive but are no longer supported by current proof;
+- case-study fragments that answer last year’s objections;
+- product explanations that make sense to the founder but not to the buyer now entering through an AI-generated answer.
+
+That is revenue leakage disguised as content debt.
+
+The build-in-public lesson here is uncomfortable: keeping public evidence current is not glamorous work. It is closer to hygiene than launch theatre. You have to decide what has become stale, what needs a current proof point, and what now creates more confusion than confidence.
+
+## Answer engines need current evidence, not a content treadmill
+
+Generative Engine Optimization depends on retrieval confidence. Answer engines need to identify who you are, what you do, where your claims are supported, how you compare, and which facts are current enough to cite without increasing risk.
+
+Freshness helps when it reinforces those signals.
+
+It can improve canonicality: the strongest page says the current thing, not three similar pages saying three slightly different things.
+
+It can improve entity clarity: the company, offer, audience, and category are described consistently in the language buyers use now.
+
+It can improve comparison confidence: an answer engine can see the difference between your approach and alternatives without guessing from outdated positioning.
+
+It can improve post-citation trust: when a buyer lands after seeing an AI answer, the cited page still feels current, specific, and aligned with the problem that brought them there.
+
+That is the Dual Mandate in practice. The bot-native evidence layer has to be clear enough for machines to retrieve and summarize. The human-facing page has to be persuasive enough for a real buyer to continue the conversation once they arrive.
+
+Freshness sits between those two halves.
+
+It is not just a ranking signal. It is a trust-maintenance practice.
+
+## Freshness should update the evidence that buyers already depend on
+
+The wrong question is: “What can we publish today?”
+
+The better question is: “Which public evidence is now stale enough to create buyer or machine uncertainty?”
+
+That changes the work.
+
+Sometimes the right move is a new article because the market has shifted and the company needs a current point of view.
+
+Sometimes the right move is to update a comparison page because the buyer’s alternatives have changed.
+
+Sometimes the right move is to add recent proof to a service page because the claim has outgrown the evidence around it.
+
+Sometimes the right move is to prune an old explanation because it competes with the page buyers should trust now.
+
+And sometimes the right move is not to publish at all. It is to make the existing evidence cleaner, denser, and less contradictory.
+
+That is where freshness becomes strategic rather than performative. It stops being a quota and starts acting like risk reduction.
+
+For GEO, the useful unit is not “a new post.”
+
+The useful unit is a stale ambiguity removed from the public evidence buyers and answer engines are already using.
+
+## The Google caveat matters
+
+This is also where it is easy to drift into superstition.
+
+Freshness does not mean every page needs special AI markup. It does not mean Google requires `llms.txt`. It does not mean chunking content into artificial fragments or over-optimising structured data will magically make a brand more visible in generative results.
+
+Google’s systems still have their own crawling, indexing, ranking, and quality evaluation processes. Generative visibility is not won by pretending there is a secret markup shortcut.
+
+The more defensible approach is simpler and harder: keep the public evidence accurate, internally consistent, useful to humans, and easy for machines to interpret through normal web signals.
+
+That means clear pages. Specific claims. Current examples. Consistent entity language. Strong internal paths to the pages buyers should rely on. Proof that matches the promise.
+
+No magic.
+
+No treadmill.
+
+Just disciplined freshness where trust is most at risk.
+
+## What CMOs should check first
+
+If freshness is trust maintenance, the first review should not start with the content calendar. It should start with the assets most likely to influence revenue:
+
+- the homepage promise;
+- service and offer pages;
+- comparison and alternative pages;
+- case studies and proof assets;
+- pricing or engagement-model explanations;
+- category definitions;
+- pages that answer engines are likely to cite when describing the company.
+
+Ask five time-based questions of each:
+
+1. Does this still match what we sell now?
+2. Does this still match how buyers describe the problem today?
+3. Does this claim have current visible support?
+4. Is this still the page we would want cited as the best explanation?
+5. If an AI answer cited this page tomorrow, would the landing experience increase trust or create another objection?
+
+Those questions are more commercially useful than “How many posts did we ship this month?”
+
+## The builder reality
+
+The gritty part is that freshness work does not always look like growth work from the outside.
+
+Some days it means tightening an explanation instead of adding another one. Some days it means replacing old proof with current proof. Some days it means noticing that the sales conversation has moved faster than the website, and the site is now quietly teaching answer engines the old version of the company.
+
+That is not glamorous, but it is exactly where AI visibility is becoming operational.
+
+Brands will not win generative search because they publish constantly. They will win when their public evidence stays current enough for machines to trust, specific enough for buyers to believe, and coherent enough that both audiences reach the same conclusion.
+
+Freshness is not the quota.
+
+Trust is the quota.


### PR DESCRIPTION
## Summary
- recovers the stranded Day 28 Build-in-Public draft from the editorial Kanban workspace
- applies the overlap-audit tightening around freshness as trust maintenance
- adds the post as `docs/blog/posts/daily-blog-day-28.md`

## Verification
- frontmatter/content assertion passed
- `git diff --staged --check` passed before commit
- `mkdocs build --strict` fails on the existing warning baseline (90 warnings)
- `mkdocs build` passes
- generated route exists: `site/blog/2026/05/18/day-28-freshness-trust-signal/index.html`

## Merge note
- Intended to merge after the Day 27 post PR so the daily sequence stays chronological.
