### PR TITLE
docs: add day 29 decision-grade evidence post

### DIFF
--- a/docs/blog/posts/daily-blog-day-29.md
+++ b/docs/blog/posts/daily-blog-day-29.md
@@ -1,0 +1,153 @@
+---
+date: 2026-05-19
+slug: day-29-decision-grade-evidence-beats-another-visibility-dashboard
+title: "Day 29: Decision-Grade Evidence Beats Another Visibility Dashboard"
+description: "AI visibility work becomes commercially useful when mentions, citations, and gaps are shaped into evidence that tells leaders which claim, proof asset, comparison, or page should change next."
+categories:
+  - Build in Public
+  - Strategy
+tags:
+  - Generative Engine Optimization
+  - GEO
+  - AI Visibility
+  - Evidence Architecture
+  - Decision Intelligence
+geo_tactics:
+  - Evidence Classification
+  - Prompt Share of Voice
+  - Citation Risk Mapping
+  - Post-Citation Trust
+---
+
+# Day 29: Decision-Grade Evidence Beats Another Visibility Dashboard
+
+AI visibility data is easy to collect badly.
+
+A brand appeared in three answers. A competitor appeared in seven. One platform cited the homepage. Another cited a stale article. A screenshot looked promising. A prompt looked commercially important until someone read it properly and realised no buyer would ever use it to make a purchase decision.
+
+None of that is worthless. It is just not enough.
+
+For a CMO or founder, the useful question is not, "How many times did we show up?" It is, "What decision should this evidence change?"
+
+If the evidence cannot answer that, it becomes another dashboard: interesting, defensible, and quietly disconnected from revenue.
+
+<!-- more -->
+
+## The visibility result is only the first layer
+
+Most AI visibility reporting starts with the visible surface:
+
+- which prompts were tested;
+- which platforms answered;
+- whether the brand was mentioned;
+- whether competitors appeared;
+- which sources were cited;
+- whether a page seemed to support the answer.
+
+That surface matters. Without it, teams are guessing.
+
+But the surface result rarely tells the commercial story by itself. A missing mention might be a serious shortlist problem, or it might be a low-intent prompt with no pipeline relevance. A citation might be a trust asset, or it might send buyers to a page that confirms the wrong thing. A competitor recurrence might reveal a real positioning gap, or it might simply reflect a category query where that competitor has stronger public proof.
+
+The same measurement can point to very different actions.
+
+That is why AI visibility work needs decision-grade evidence, not just visibility observations.
+
+Decision-grade evidence preserves the finding, but adds the shape a leader needs to act on it: what type of evidence it is, how confident the team should be, what commercial consequence it implies, and which public asset should change next.
+
+## Evidence needs fields, not vibes
+
+A screenshot is not a strategy.
+
+A rank is not a recommendation.
+
+A prompt Share-of-Voice number is not a content plan.
+
+Those artefacts become useful when they are classified tightly enough to support a decision. At minimum, an AI visibility finding should preserve:
+
+- **Prompt category:** category discovery, vendor comparison, proof-seeking, pricing risk, implementation doubt, internal champion enablement, or post-citation validation.
+- **Exact prompt:** the wording matters because small changes can move the answer from commercial intent to generic research.
+- **Platform and model context:** ChatGPT, Claude, Perplexity, Google AI surfaces, and other systems do not expose evidence in identical ways.
+- **Brand role:** absent, mentioned, recommended, compared, cited, misdescribed, or used as supporting context.
+- **Citation status:** no citation, weak citation, relevant citation, stale citation, competitor citation, or citation to a page that creates buyer friction.
+- **Source URL and source quality:** the page that carried the answer, whether it is canonical, whether it proves the claim, and whether a human would trust it.
+- **Competitor recurrence:** whether the same competitor keeps appearing for the same buyer problem, or whether the appearance is incidental.
+- **Limitation flags:** capture uncertainty, geography, account state, source ambiguity, platform volatility, or any reason the finding should not be overread.
+- **Commercial consequence:** revenue leakage, conversion delay, trust loss, data accuracy risk, wasted content effort, or no meaningful action.
+- **Recommended decision:** fix the claim, add proof, clarify the comparison, improve the cited page, create a better source, retest later, or stop chasing the prompt.
+
+That list looks less glamorous than a dashboard.
+
+It is also where the value is.
+
+A dashboard tells the team that something happened. A structured evidence model tells them whether the thing matters, why it matters, and what to do without turning every finding into a meeting.
+
+## Not every absence deserves a fix
+
+This is the part that protects budget.
+
+If a brand is absent from a generic prompt with weak buying intent, the right decision may be to do nothing. The market may not be leaking. The prompt may not map to a buyer journey. The answer may be informational rather than commercial. Chasing it can create content that looks active but does not reduce risk for anyone serious enough to buy.
+
+If the brand is absent from a high-intent comparison prompt where competitors keep recurring, that is different. The absence may be costing shortlist inclusion. The fix might be a clearer comparison page, stronger proof for a specific use case, or a canonical explanation of why the brand belongs in that category.
+
+If the brand appears but the cited page is weak, that is different again. The answer engine has opened the door, but the human handoff may be leaking trust. The next action is not more measurement. It is improving the page so the buyer can confirm the claim quickly.
+
+If the brand is mentioned accurately but never cited, the problem may be proof depth. The model can associate the entity with the category, but the public corpus may not give it enough stable evidence to support a citation.
+
+Those are four different decisions hiding behind a single phrase: "AI visibility issue."
+
+Without evidence shape, teams collapse them into the same reaction: publish more, test more, or panic more.
+
+## Decision rules make the work operational
+
+The point of structure is not to make the report look sophisticated. It is to make decisions repeatable.
+
+A useful evidence model should produce rules like these:
+
+- If a high-intent prompt shows recurring competitor recommendations and no brand mention, map the missing proof asset before writing new campaign copy.
+- If the brand is cited to a stale or generic page, improve the post-citation landing experience before celebrating the citation.
+- If a finding comes from a weak or uncertain capture path, mark it directional and do not use it to justify a strategic pivot.
+- If the prompt does not map to a buyer decision, deprioritise it even if the chart looks bad.
+- If the model misdescribes the company, trace the public source likely causing the confusion before adding another page.
+- If a competitor is winning because their evidence is clearer, decide whether to build a comparison asset, strengthen a proof page, or sharpen the category claim.
+
+This is where the commercial discipline enters the system.
+
+The goal is not to remove judgement. It is to stop every finding from arriving as an unlabelled alarm.
+
+A founder should be able to look at the evidence and know whether the next move is a positioning correction, a proof asset, a page improvement, a measurement retest, or a decision to ignore the noise.
+
+## GEO is evidence engineering, not just prompt monitoring
+
+Generative Engine Optimization depends on evidence that answer engines can retrieve, compare, and trust.
+
+That does not mean there is a magic markup trick that guarantees visibility. It does not mean `llms.txt`, special AI markup, chunking, or over-focused structured data is required or specially treated by Google's generative search. Assets like `llms.txt` may be useful as optional discovery aids for cross-agent and non-Google contexts, but they should not be sold as a substitute for independently validated evidence.
+
+The durable work is more grounded:
+
+- make important claims specific enough to be reused accurately;
+- connect claims to proof a machine can retrieve and a human can inspect;
+- keep canonical pages current enough to reduce misdescription;
+- label evidence limitations so weak signals do not become false certainty;
+- design the landing experience so a cited buyer finds the proof they expected.
+
+That is the Dual Mandate in practical form.
+
+The machine-facing layer needs clean evidence: prompt context, entity clarity, citation status, source quality, confidence notes, and consistent claims. The human-facing layer needs that evidence to convert into trust: a page that answers the real question, a proof asset that reduces risk, and a next step that matches the buyer's stage.
+
+If either layer is missing, the visibility win is fragile.
+
+The model may cite the brand, but the buyer may not believe the page. Or the page may be persuasive, but the model may not have enough clear evidence to retrieve it in the first place.
+
+## The real output is a safer commercial decision
+
+The best AI visibility work should make a leadership decision safer.
+
+It should tell the team when to act and when not to. It should separate a revenue leak from a measurement artefact. It should show whether the issue is a missing claim, weak proof, unclear comparison, stale source, risky citation, or irrelevant prompt. It should make the next change smaller, sharper, and easier to defend.
+
+That is more valuable than another chart of mentions.
+
+Mentions show presence. Rankings show relative appearance. Citations show one kind of retrieval path.
+
+Decision-grade evidence shows what should change because of them.
+
+That is the standard we are building toward: not more noise about AI visibility, but cleaner evidence that helps a buyer-facing team reduce uncertainty, protect trust, and choose the next commercial move with less guesswork.


### PR DESCRIPTION
## Summary
- Adds Build-in-Public Day 29: “Decision-Grade Evidence Beats Another Visibility Dashboard”
- Keeps the public angle on structured evidence, decision rules, buyer risk, and GEO evidence quality
- Rescues the Day 29 editorial pipeline after the reviewer stage stalled on model/backend availability before PR creation

## Verification
- Content assertions passed: expected date, slug, title, and excerpt marker present
- Internal/banned-term scan passed
- `git diff --cached --check` passed
- `python3 -m mkdocs build --strict` fails only on existing warning baseline
- `python3 -m mkdocs build` passes

## Payload
- `docs/blog/posts/daily-blog-day-29.md` only
