### PR TITLE
docs: add day 30 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-30.md
+++ b/docs/blog/posts/daily-blog-day-30.md
@@ -48,7 +48,7 @@ The obvious gap is usually phrased as an SEO or GEO problem: we are not cited, w
 
 The more useful gap is buyer-shaped.
 
-A buyer might ask ChatGPT which agency can help them improve AI search visibility. The answer might mention a few firms, summarize services, and cite pages that look credible enough to click. If the buyer lands on a page that says roughly the same generic thing as everyone else, the citation did not create trust. It created a new comparison tab.
+A buyer might ask an AI assistant which agency can help them improve AI search visibility. The answer might mention a few firms, summarize services, and cite pages that look credible enough to click. If the buyer lands on a page that says roughly the same generic thing as everyone else, the citation did not create trust. It created a new comparison tab.
 
 That is a buyer brief problem.
 

--- a/docs/blog/posts/daily-blog-day-30.md
+++ b/docs/blog/posts/daily-blog-day-30.md
@@ -1,0 +1,152 @@
+---
+date: 2026-05-20
+slug: day-30-gap-analysis-changes-the-buyer-brief
+title: "Day 30: Gap Analysis Is Only Useful When It Changes the Buyer Brief"
+description: "AI visibility gap analysis only creates commercial value when it changes what buyers can understand, trust, compare, and act on after an AI recommendation."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - buyer enablement
+  - positioning
+  - conversion
+geo_tactics:
+  - Map prompt and citation findings to buyer questions, proof gaps, and comparison pages.
+  - Treat SERP and competitor evidence as inputs to public content decisions, not as a finished dashboard.
+  - Build landing experiences that confirm the promise made by an AI citation.
+---
+
+A gap analysis is not finished when it finds the gap.
+
+For AI visibility, that is the easy part. You can run prompts, capture citations, compare competitors, tag missing proof, and produce a neat list of weak spots. Useful, but not yet commercial. The work only starts to matter when the finding changes the buyer brief: what question we answer, what proof we put in public, what comparison we make clearer, and what page a human lands on after an AI system recommends us.
+
+If the output is only a dashboard, the buyer still has the same problem. They are still trying to decide who to trust, what is different, what evidence is credible, and whether the next click will confirm or weaken the recommendation they just received.
+
+<!-- more -->
+
+## Visibility data is not the brief
+
+A lot of AI visibility work is being sold like measurement is the product.
+
+Share of voice. Prompt coverage. Citation counts. Competitor mentions. Sentiment fields. Prompt-by-prompt deltas. These are useful signals, but they are not a strategy by themselves. A CMO cannot take a red cell in a spreadsheet to market. A founder cannot send a citation count to a sales lead and expect it to answer the objection blocking the deal.
+
+The useful version of the work translates visibility data into a brief a team can act on:
+
+- Which commercial question are buyers asking before they shortlist us?
+- Which answer do AI systems currently assemble without our strongest evidence?
+- Which competitor comparison is muddy enough to slow evaluation?
+- Which proof asset is missing from the public corpus?
+- Which landing page needs to confirm the recommendation instead of making the buyer start again?
+
+That is where gap analysis moves from observation to revenue work.
+
+## The gap that matters is usually a buyer gap
+
+The obvious gap is usually phrased as an SEO or GEO problem: we are not cited, we are underrepresented, competitors appear more often, or the answer engine pulls from weaker sources.
+
+The more useful gap is buyer-shaped.
+
+A buyer might ask ChatGPT which agency can help them improve AI search visibility. The answer might mention a few firms, summarize services, and cite pages that look credible enough to click. If the buyer lands on a page that says roughly the same generic thing as everyone else, the citation did not create trust. It created a new comparison tab.
+
+That is a buyer brief problem.
+
+The public content has to help the human complete the thought that the AI system started. It needs to make the commercial case legible:
+
+- what we do in plain terms;
+- what kind of buyer problem we are best suited for;
+- what evidence supports the claim;
+- how we compare with alternatives;
+- what risk we remove;
+- what the next step should be.
+
+Prompt visibility can introduce the brand. The buyer brief converts the introduction into a reason to keep reading.
+
+## A useful analysis changes the content plan
+
+The practical test is simple: after the gap analysis, what changes?
+
+If the answer is only "we know where we rank," the work is incomplete. The better answer sounds more like this:
+
+- We need a clearer page for the buyer who asks how GEO differs from traditional SEO.
+- We need a proof asset that shows how visibility findings turn into public corpus changes.
+- We need a comparison page because competitors are being framed as interchangeable.
+- We need to rewrite the service page because the strongest claim is buried below generic positioning.
+- We need sales enablement that explains why a prompt snapshot is not enough to diagnose conversion risk.
+
+Those are public content decisions. They change what the market can retrieve, quote, compare, and trust.
+
+This is why the gap taxonomy matters only after it is mapped to action. A missing citation, weak entity association, unclear comparison, stale proof point, or unsupported claim should not sit as a label in a private report. It should become a specific change to the buyer journey.
+
+## GEO evidence has to survive the handoff to a human
+
+Answer engines compress. Buyers decompress.
+
+A model can assemble a shortlist from snippets, citations, entities, and third-party signals. But the buyer still has to evaluate the recommendation in human terms. They will click, skim, compare, forward the page internally, and ask whether the promise is credible enough to spend money on.
+
+That means AI visibility work has two jobs.
+
+First, it has to make the brand and its evidence retrievable enough to appear in the answer. Second, it has to make the post-citation experience strong enough that the human does not bounce back to the shortlist.
+
+The second job is where a lot of gap analysis gets lazy. It stops at the machine-readable finding and never asks whether the cited page can carry the commercial weight.
+
+A cited page that cannot answer the next human question is a leaky handoff. It may generate traffic, but it also generates doubt.
+
+## The evidence can stay private; the decision cannot
+
+Some of the evidence behind a good analysis should stay private. Prompt batches, raw captures, competitor notes, internal scoring, and review states are working material. They help the team make cleaner decisions, but they do not all belong in public.
+
+The public output is different. It is the rewritten page, the sharper comparison, the clearer proof asset, the stronger landing path, or the sales narrative that removes a recurring objection.
+
+That distinction matters. Publishing raw scans does not make a buyer more confident. Publishing a page that directly answers the buyer's actual question might.
+
+The internal analysis is the scaffolding. The buyer brief is the building.
+
+## This is not a special-markup shortcut
+
+There is a temptation to treat AI visibility as a technical loophole: add a file, change a format, feed the crawler, and wait for the answer engines to behave.
+
+That is not the strategy.
+
+For Google surfaces in particular, there is no serious reason to pretend that a special AI-only markup trick replaces core Search quality and ranking systems. Structured, accessible, evidence-dense content helps because it is useful content, not because it hacks around the buyer's need for trust.
+
+The same principle applies across answer engines. If the public corpus is vague, unsupported, or commercially thin, the system has less to retrieve and the buyer has less to believe.
+
+The durable work is less glamorous: make the right claims easier to find, support them with evidence, clarify the comparisons, and make the landing experience match the recommendation.
+
+## The commercial consequence is delay
+
+The cost of a weak buyer brief is not only lost visibility. It is delayed decision-making.
+
+A buyer who cannot see the difference between three shortlisted firms asks for another meeting. A founder who cannot prove the category internally parks the project. A marketing director who cannot explain the budget case waits for a safer quarter. A CMO who receives a generic AI visibility report gets more data but no sharper route to revenue.
+
+That is the practical failure mode.
+
+Gap analysis should reduce ambiguity in the buying process. It should tell the team which public assets are missing from the commercial conversation and which pages are failing to confirm the recommendation that got the buyer there.
+
+If it cannot do that, it is not yet a brief. It is inventory.
+
+## What changed in our own thinking
+
+Day 30 pushed us to treat gap analysis less like a reporting layer and more like a briefing discipline.
+
+The raw materials still matter: prompt results, citations, competitor fields, intent labels, content-gap classifications, and review notes. But the output we care about is not the raw finding. It is the decision the finding forces.
+
+Do we need a better comparison?
+
+Do we need a proof page?
+
+Do we need to answer a different buyer question?
+
+Do we need to make the landing path less generic?
+
+Do we need to give sales a clearer way to explain why AI visibility matters beyond a prompt screenshot?
+
+That is the difference between monitoring the market and changing how the market understands you.
+
+## Practical lesson
+
+For build-in-public teams, the lesson is blunt: do not let analysis become a place where buyer questions go to die.
+
+If a gap analysis does not change the buyer brief, it has not finished its job. The useful output is not the prettiest dashboard or the longest issue list. It is the public change that helps a real buyer understand why you belong on the shortlist, what proof supports the claim, and what to do next after an AI system sends them your way.


### PR DESCRIPTION
## Summary
- Adds Day 30 Build in Public post: “Gap Analysis Is Only Useful When It Changes the Buyer Brief”
- Frames AI visibility gap analysis as a buyer-brief discipline rather than a reporting dashboard
- Keeps the PR payload scoped to the single intended blog post

## Verification
- Original editorial pipeline included researcher overlap audit, reviewer gate, and writer revision/finalization before ops blocked
- Independent post-rescue review found one overly specific assistant example; follow-up commit generalized it to “an AI assistant”
- Content/frontmatter assertions passed for date, slug, title, description, categories/tags, and `<!-- more -->`
- Strict banned/internal term scan passed after follow-up
- `git diff --check` passed
- `mkdocs build --strict` attempted; blocked by existing baseline nav/RoamLinks warnings
- `mkdocs build` passed
- Verified generated output path exists: `site/blog/2026/05/20/day-30-gap-analysis-changes-the-buyer-brief/index.html`
- Cloudflare Pages passed after follow-up
