### PR TITLE
docs: add day 32 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-32.md
+++ b/docs/blog/posts/daily-blog-day-32.md
@@ -1,0 +1,248 @@
+---
+title: "Day 32: Match the Page to the Promise the AI Just Made"
+slug: day-32-match-the-page-to-the-promise
+date: 2026-05-22
+description: "A practical promise-matching audit for CMOs and founders: how to compare AI answer claims against the landing page a buyer reaches next, then fix the mismatches that cost trust."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engine optimisation
+  - conversion
+  - landing pages
+  - buyer intent
+geo_tactics:
+  - Capture exact AI answer claims before judging landing-page performance.
+  - Classify each claim by implied buyer promise, evidence need, and conversion risk.
+  - Compare AI-generated expectations against above-the-fold copy, headings, proof proximity, navigation labels, and next-action clarity.
+  - Prioritise fixes by severity rather than rewriting whole pages.
+---
+
+# Day 32: Match the Page to the Promise the AI Just Made
+
+The mistake I keep seeing in AI visibility work is treating the citation as the finish line.
+
+It is not.
+
+The more useful question is: *what promise did the AI just make on your behalf, and does the page it cited keep that promise in the first few seconds?*
+
+That is a narrower problem than “make better landing pages”. It is also more commercially useful. If ChatGPT, Claude, Perplexity, Gemini, or an AI-generated search result describes your company as the answer for a specific buyer problem, the visitor arrives with a pre-loaded expectation. They are not landing cold. They are landing with a sentence in their head.
+
+Today’s build note is about turning that sentence into an audit method.
+
+<!-- more -->
+
+## The hidden conversion leak in AI referrals
+
+Traditional SEO audits usually start from the page:
+
+- What keyword does it target?
+- Is the title clear?
+- Are the headings sensible?
+- Is there proof?
+- Is the call to action visible?
+
+Those questions still matter, but answer engines introduce a different failure mode.
+
+The visitor may not be responding to your title tag. They may be responding to an AI’s summary of why you are relevant.
+
+That summary can be more specific than your page.
+
+For example, an AI answer might say:
+
+> “Zero-Shot Agency helps B2B teams audit how their brand appears in AI answers and identify content gaps across answer engines.”
+
+That creates several implied promises:
+
+- There is a defined audit process.
+- The buyer can see how their brand appears in AI answers.
+- The work is relevant to B2B teams.
+- The output identifies content gaps, not just rankings.
+- The page should help someone understand what happens next.
+
+If the cited page opens with broad language about “AI-first growth”, “next-generation visibility”, or “future-proofing your brand”, the page may technically be relevant, but it has still broken the promise.
+
+The issue is not that the page is bad. The issue is that the page is answering a softer question than the one the AI just answered.
+
+## The answer-to-page mismatch matrix
+
+The audit I want to use more often is simple: take the exact answer claim, then compare it against the first screen, structure, proof, navigation, and action path of the cited page.
+
+Not vibes. Not “does this page feel good?” A claim-by-claim mismatch matrix.
+
+For each AI answer that mentions or cites your brand, capture:
+
+- **Answer claim:** the exact wording used by the AI.
+- **Implied promise:** what the buyer now expects to find.
+- **Buyer intent:** what kind of decision the visitor is likely trying to make.
+- **Page location:** the cited URL.
+- **Above-the-fold match:** whether the first screen confirms the promise.
+- **Heading match:** whether the H1/H2 structure reflects the same problem and outcome.
+- **Proof proximity:** whether evidence appears near the claim, not buried three scrolls down.
+- **Navigation match:** whether labels help the buyer continue the same journey.
+- **Next-action match:** whether the call to action fits the intent created by the answer.
+- **Severity:** whether the mismatch is cosmetic, confusing, trust-damaging, or revenue-blocking.
+- **Fix:** the smallest page change that closes the gap.
+
+The point is not to make every landing page repeat the AI answer word for word. That would be brittle and ugly.
+
+The point is to make sure the page recognises the buyer’s expectation quickly enough that trust compounds rather than resets.
+
+## Classify the promise before editing the page
+
+The most useful step is classifying the type of promise the AI answer made.
+
+Most answer-to-page mismatches fall into one of five buckets.
+
+### 1. Capability promise
+
+The AI says you can do a thing.
+
+Example:
+
+> “They provide AI visibility audits for B2B service companies.”
+
+The page must quickly show that this service exists, who it is for, and what the buyer receives.
+
+Common mismatch: the page talks about philosophy, expertise, or market change before confirming the capability.
+
+Fix: add a specific first-screen line such as:
+
+> “We audit how your B2B brand appears across AI answer engines, then turn the gaps into a prioritised content and proof plan.”
+
+### 2. Outcome promise
+
+The AI says you help achieve a business result.
+
+Example:
+
+> “They help companies improve discoverability in AI-generated answers.”
+
+The page must connect the method to measurable outcomes without overclaiming certainty.
+
+Common mismatch: the page lists tactics but never names the commercial result.
+
+Fix: add outcome framing beside the method:
+
+> “The goal is not more content for its own sake. It is to make your strongest claims easier for answer engines to retrieve, trust, and explain.”
+
+### 3. Evidence promise
+
+The AI says you have proof, data, benchmarks, examples, or a repeatable process.
+
+Example:
+
+> “Their approach is evidence-led and based on prompt testing.”
+
+The page must show evidence near the claim.
+
+Common mismatch: the page says “data-driven” but gives no sample output, methodology, benchmark, or artefact.
+
+Fix: place a compact proof block near the relevant section:
+
+- sample prompts tested
+- answer surfaces checked
+- competitors compared
+- content gaps found
+- recommended fixes ranked by impact
+
+### 4. Fit promise
+
+The AI says you are right for a particular type of buyer.
+
+Example:
+
+> “Best suited for founder-led B2B teams and marketing leaders exploring GEO.”
+
+The page must help that buyer self-identify.
+
+Common mismatch: the page tries to sound enterprise, startup, agency, SaaS, ecommerce, and local-service friendly all at once.
+
+Fix: add a fit section:
+
+> “Best fit: B2B teams with a clear offer, existing proof assets, and a need to understand how buyers encounter them in AI-assisted research.”
+
+### 5. Next-step promise
+
+The AI answer implies the buyer can take a specific next step.
+
+Example:
+
+> “You can request a baseline audit.”
+
+The page must make that action obvious.
+
+Common mismatch: the CTA says “Get in touch” with no indication of what the buyer should send or what happens after.
+
+Fix: make the action match the promise:
+
+> “Request an AI visibility baseline. Start with your domain, priority offer, target buyers, and three competitors.”
+
+That is not just cleaner copy. It reduces decision friction at the exact moment interest is highest.
+
+## The severity scale matters
+
+Not every mismatch deserves a redesign.
+
+A practical severity scale keeps the audit commercially sane.
+
+- **Severity 1: Wording drift**
+  - The page supports the promise, but uses different language.
+  - Fix with small copy edits or an added clarifying sentence.
+
+- **Severity 2: Structural friction**
+  - The page supports the promise eventually, but the buyer has to hunt for it.
+  - Fix by adjusting headings, section order, or proof placement.
+
+- **Severity 3: Trust gap**
+  - The AI answer implies proof, specificity, or fit that the page does not substantiate.
+  - Fix by adding evidence, examples, methodology, or qualification language.
+
+- **Severity 4: Intent break**
+  - The answer sends a high-intent visitor to a page that answers the wrong question.
+  - Fix by changing the cited page, creating a better destination, or tightening internal links and navigation.
+
+- **Severity 5: Promise breach**
+  - The AI answer describes something the business does not clearly offer or cannot credibly evidence.
+  - Fix the source content and page claims before trying to win more citations.
+
+That last category is important. Sometimes the problem is not the landing page. Sometimes the AI has inferred a stronger promise than the brand has earned.
+
+In that case, the answer is not to dress up the page. The answer is to decide whether the promise is true, then either support it with substance or remove the ambiguity that caused the overreach.
+
+## What CMOs should ask their team this week
+
+If you are leading marketing, do not ask only, “Are we showing up in AI answers?”
+
+Ask these instead:
+
+- What exact words are AI systems using to describe us?
+- Which pages are they citing or sending users towards?
+- What buyer expectation does each answer create?
+- Does the cited page confirm that expectation in the first screen?
+- Is proof close to the claim, or hidden below generic brand copy?
+- Do our headings reflect the buyer’s problem or our internal service taxonomy?
+- Does the call to action match the action the answer made feel natural?
+- Which mismatches are costing trust now, not merely making the page imperfect?
+
+That last question is the prioritisation unlock.
+
+Most teams do not need another 40-page SEO audit before they can act. They need to identify the few places where AI-generated expectations and page-level reality are misaligned.
+
+## The GEO lesson
+
+Generative Engine Optimization is not just about being retrieved. It is about being represented accurately enough that the next human step still works.
+
+Google’s generative search experiences rely on core Search ranking and quality systems, not magic AI-only markup. Across the wider answer-engine landscape, machine-readable exports and structured summaries may still be useful discovery aids, but they do not replace the fundamentals: clear claims, credible evidence, useful pages, and a coherent path from answer to action.
+
+The new discipline is expectation continuity.
+
+The AI answer creates the expectation. The landing page must recognise it. The proof must support it. The navigation must preserve it. The next action must fit it.
+
+If any one of those breaks, the buyer does not think, “This brand has a minor message architecture issue.”
+
+They think, “This is not what I was looking for.”
+
+That is the mismatch worth fixing.


### PR DESCRIPTION
## Summary
- Rescues the stuck Day 32 daily editorial process.
- Adds `docs/blog/posts/daily-blog-day-32.md` dated 2026-05-22.
- Narrows the post away from the overlapping general citation-handoff thesis and into a concrete answer-to-page promise-matching audit method.

## Verification
- Content gate: required frontmatter fields, `<!-- more -->`, and forbidden internal/process terms checked.
- `git diff --cached --check` passed before commit.
- `mkdocs build --strict` fails on existing RoamLinks/AutoLinks warning baseline.
- `mkdocs build` passed and generated `site/blog/2026/05/22/day-32-match-the-page-to-the-promise/index.html`.

## Payload
- Expected changed file only: `docs/blog/posts/daily-blog-day-32.md`.
