### PR TITLE
docs: add day 33 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-33.md
+++ b/docs/blog/posts/daily-blog-day-33.md
@@ -1,0 +1,196 @@
+---
+title: "Day 33: AI Visibility Needs an Evidence Ledger, Not a Better Memory"
+slug: day-33-ai-visibility-needs-an-evidence-ledger
+date: 2026-05-23
+description: "Why CMOs need a status-led evidence ledger that tracks claims, proof assets, public URLs, owners, gaps, duplicates, and next decisions for GEO and buyer trust."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - evidence strategy
+  - content operations
+  - buyer journey
+geo_tactics:
+  - Map each priority claim to a proof asset and public URL.
+  - Track live, pending, missing, duplicated, blocked, and stale evidence states.
+  - Assign owners and next decisions to every visibility-critical claim.
+  - Tie proof assets to buyer journey roles, not publishing cadence.
+---
+
+# Day 33: AI Visibility Needs an Evidence Ledger, Not a Better Memory
+
+Most marketing teams do not have an AI visibility problem because they lack opinions.
+
+They have an AI visibility problem because their strongest proof is scattered across decks, sales calls, case notes, private documents, half-published pages, and someone’s memory of “we covered that somewhere”.
+
+Answer engines cannot cite memory. Buyers cannot trust proof they cannot inspect. Search systems cannot reward evidence that never made it into the public corpus. The practical lesson for CMOs is simple: if a claim matters commercially, it needs a ledger.
+
+<!-- more -->
+
+Not a content calendar. Not a brand-message spreadsheet. Not a backlog of “blog ideas”.
+
+A publication and evidence ledger.
+
+One place where the team can see, claim by claim, whether the proof that supports the business is live, pending, missing, duplicated, blocked, stale, or no longer good enough.
+
+That sounds operational. It is. But it is also strategic, because AI visibility is becoming less about how often a brand publishes and more about whether the public web contains enough trustworthy, specific, current evidence for machines and humans to use.
+
+## The gap between knowing and being knowable
+
+Inside a company, everyone assumes certain things are obvious.
+
+The founder knows the strongest customer proof. Sales knows the objections that actually move deals. Delivery knows which results are repeatable. Customer success knows where the product is best and where it is still fragile. Marketing knows which claims convert.
+
+But the public corpus usually tells a weaker story.
+
+It has a homepage that says the company is “trusted”. It has service pages that describe capabilities. It has a few case studies, sometimes too polished to answer the questions buyers actually ask. It has old blogs that mention problems but do not connect them to proof. It has claims that are repeated across pages without any supporting asset.
+
+For AI visibility, that difference matters.
+
+When a buyer asks an answer engine for “best agencies for technical GEO audits”, “examples of AI search visibility work”, “how to measure brand presence in AI answers”, or “who can help us understand answer-engine citations”, the system is not reading the internal thread where the real evidence lives. It is working with what is publicly retrievable, rankable, summarisable, and citable.
+
+If your public evidence is thin, ambiguous, or fragmented, the model has less to work with. If your competitor has clearer proof mapped to the same buyer question, they become easier to mention.
+
+The commercial failure is not silence. It is being difficult to trust at the exact moment a buyer is trying to compare options.
+
+## Cadence is only useful when it exposes coverage gaps
+
+A daily publishing rhythm can create discipline, but cadence is not the strategy.
+
+Publishing every day does not automatically improve AI visibility. It can just produce a larger pile of loosely connected pages. The useful part of cadence is that it forces a team to notice what is missing.
+
+If a post makes a strategic claim, where is the proof?
+
+If the proof exists, is it public?
+
+If it is public, is it on the right page for the buyer journey?
+
+If the same claim appears in five places, which version is current?
+
+If a proof asset is blocked because legal, delivery, or customer approval is needed, who owns the next decision?
+
+That is where the ledger earns its keep. It turns publishing from a quota into an evidence audit. Every new piece either strengthens the corpus, reveals a gap, retires duplication, or shows the team where a claim is not yet supportable.
+
+For GEO, this is more valuable than simply increasing article volume. Answer engines do not need more generic commentary. Buyers do not need another conceptual explainer. They need a trail from claim to evidence to decision.
+
+## What an evidence ledger should track
+
+A useful ledger does not need to be complex. It needs to be honest.
+
+For each commercially important claim, track these fields:
+
+- **Claim:** What do we want the market to believe?
+- **Proof asset:** What evidence supports it? This could be a case study, benchmark, teardown, methodology note, comparison page, customer quote, internal experiment, product page, audit finding, or public playbook.
+- **Public URL:** Where can a buyer or answer engine inspect it?
+- **Status:** Live, pending, missing, duplicated, blocked, stale, or retired.
+- **Owner:** Who is responsible for moving the evidence state forward?
+- **Next decision:** What must happen next? Publish, revise, approve, consolidate, update, deprecate, request customer approval, or gather better evidence.
+- **Buyer journey role:** Awareness, problem framing, vendor shortlist, technical validation, commercial confidence, procurement reassurance, or post-citation conversion.
+
+That last field is easy to skip, but it is the difference between a content inventory and a growth tool.
+
+Not every proof asset has the same job. A methodology page helps a buyer understand how you think. A case study helps them believe you can deliver. A comparison page helps them shortlist. A pricing or scope note helps them decide whether to speak to you. A technical validation page helps the internal champion defend the recommendation.
+
+AI visibility work improves when those roles are explicit. Otherwise, teams publish more “proof” without knowing which buying moment it supports.
+
+## Status beats vibes
+
+The reason a ledger works is that it replaces vague confidence with observable state.
+
+A CMO should be able to ask: “Can we publicly support the claim that we are strong at AI visibility audits for B2B service brands?”
+
+The answer should not be, “Yes, I think we’ve written about that.”
+
+It should be something closer to:
+
+- **Claim:** We help B2B service brands understand and improve AI answer visibility.
+- **Proof asset:** AI Visibility Baseline service page, methodology explainer, prompt-set example, sample citation-surface audit.
+- **Public URL:** Live for service page and methodology; sample audit pending.
+- **Status:** Partially live; one missing proof asset.
+- **Owner:** Marketing lead for page, delivery lead for sample audit.
+- **Next decision:** Decide whether the sample audit can be anonymised or needs a synthetic example.
+- **Buyer journey role:** Shortlist and technical validation.
+
+That is much harder to fake. It also makes the next action obvious.
+
+Without the ledger, teams often solve the wrong problem. They commission another thought-leadership post when the real gap is a missing proof page. They rewrite the homepage when the issue is that the strongest evidence is trapped in a sales deck. They chase a fresh campaign when the buyer journey has no technical validation asset. They celebrate a new article even though it duplicates three older claims and adds no new public evidence.
+
+Status makes the work visible. Visibility makes the strategy manageable.
+
+## The GEO value is in public, connected evidence
+
+Generative engines reward what can be found, understood, and trusted. The exact mechanisms differ by surface, but the operational implication is consistent: your public materials need to make your expertise legible.
+
+That does not mean adding magic AI markup and hoping systems treat it as a shortcut. For Google’s generative search experiences, visibility still depends on core Search ranking and quality systems. Machine-readable exports can be useful for cross-agent discovery or non-Google workflows, but they do not replace strong public pages, credible evidence, and clear information architecture.
+
+The more reliable path is to make the evidence itself better.
+
+A strong evidence ledger helps because it creates internal pressure to connect the pieces:
+
+- Claims link to proof.
+- Proof links to pages.
+- Pages answer buyer questions.
+- Buyer questions map to journey stages.
+- Journey stages reveal missing assets.
+- Missing assets become decisions, not vague intentions.
+
+That is the architecture of being knowable.
+
+When answer engines summarise a market, they are more likely to use brands with clear, specific, and corroborated public evidence. When buyers land after an AI recommendation, they are more likely to convert if the page they reach proves the answer was justified.
+
+Citation is not the finish line. It is the handoff. The ledger ensures the handoff has somewhere credible to land.
+
+## A practical starting point for CMOs
+
+Start with ten claims.
+
+Not fifty. Not the whole website. Ten.
+
+Choose the claims that would matter most if an AI answer compared you against competitors tomorrow. For example:
+
+- We specialise in GEO for B2B service firms.
+- We can diagnose why a brand is absent from AI answers.
+- We understand both technical search systems and buyer conversion.
+- We use evidence-led methods rather than generic SEO advice.
+- We can turn internal expertise into public proof assets.
+
+Then audit each one against the ledger.
+
+If the status is **live**, check whether the URL is actually the best public proof.
+
+If it is **pending**, assign the next decision.
+
+If it is **missing**, stop pretending the claim is market-ready.
+
+If it is **duplicated**, consolidate the strongest version.
+
+If it is **blocked**, name the blocker and decide whether the claim should be softened until proof exists.
+
+If it is **stale**, update or retire it before an answer engine or buyer treats old evidence as current.
+
+This exercise is uncomfortable because it exposes the difference between brand ambition and public substantiation. That discomfort is useful. It stops content strategy becoming theatre.
+
+## The build-in-public lesson
+
+The last few days have reinforced a principle that applies far beyond our own publishing rhythm: systems do not improve because people remember what should exist. They improve when important claims are tracked as evidence states.
+
+For AI visibility, that means the work is not just “publish more”. It is:
+
+- Know which claims matter.
+- Know which assets prove them.
+- Know which URLs are live.
+- Know which gaps block trust.
+- Know who owns the next decision.
+- Know where each asset fits in the buyer journey.
+
+That is the difference between a content operation and an evidence operation.
+
+A content operation asks, “What are we publishing next?”
+
+An evidence operation asks, “What does the market need to believe, what proof can it inspect, and what is still missing from the public corpus?”
+
+For CMOs, Marketing Directors, and founders, the second question is now the more important one.
+
+Because in an AI-mediated buying journey, the brands that win are not necessarily the ones with the most content. They are the ones whose claims are easiest to verify, cite, and trust.


### PR DESCRIPTION
## Summary
- Adds the separate Day 33 Build-in-Public post dated 2026-05-23.
- Covers the evidence-ledger angle: tracking claims, proof assets, public URLs, status, owners, next decisions, and buyer-journey roles for AI visibility.
- Keeps this separate from Day 32 / PR #222.

## Verification
- Content gate: required frontmatter fields, `<!-- more -->`, target date, and forbidden internal/process terms checked.
- `git diff --cached --check` passed before commit.
- `mkdocs build --strict` fails on the existing RoamLinks/AutoLinks warning baseline.
- `mkdocs build` passed and generated `site/blog/2026/05/23/day-33-ai-visibility-needs-an-evidence-ledger/index.html`.

## Payload
- Expected changed file only: `docs/blog/posts/daily-blog-day-33.md`.
