### PR TITLE
docs: add day 34 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-34.md
+++ b/docs/blog/posts/daily-blog-day-34.md
@@ -1,0 +1,103 @@
+---
+title: "Day 34: AI Visibility Needs Operating Memory"
+date: 2026-05-24
+slug: day-34-ai-visibility-needs-operating-memory
+description: "A build-in-public essay on why AI visibility needs durable operating memory for claims, proof, owners, freshness, and buyer handoffs."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - operating memory
+  - evidence systems
+  - buyer trust
+---
+
+# Day 34: AI Visibility Needs Operating Memory
+
+A brand can be visible in AI answers and still lose the buyer.
+
+That sounds contradictory until you look at what happens after the recommendation. A buyer asks an answer engine for options, sees a company cited, clicks through, and starts testing the claim against the public evidence. Is the proof current? Does the page match the promise? Does the offer still exist? Is there a clear next step? Does the commercial team know what the buyer has already been told?
+
+If the answer is fuzzy, the problem is not simply content quality. It is memory.
+
+AI visibility needs operating memory: a durable layer of facts, proof, ownership, freshness, and handoff context that keeps the public story coherent after the publishing moment has passed.
+
+<!-- more -->
+
+## Visibility creates a memory problem
+
+Traditional content operations often treat publication as the finish line. A page goes live. A post is approved. A case study is added. A new claim enters the market.
+
+But generative discovery does not experience the brand as a tidy content calendar. It sees a distributed body of evidence: product pages, blog posts, service descriptions, old comparison language, case studies, profiles, interviews, documentation, and the fragments other sites repeat.
+
+That evidence is only commercially useful when it stays consistent.
+
+For CMOs, Marketing Directors, and founders, the risk is not that a model misses one perfect page. The bigger risk is that the public corpus cannot remember what the company now claims, what it can prove, who owns the promise, and what should happen when a buyer acts on the recommendation.
+
+When that memory is weak, the brand creates small contradictions:
+
+- a service page promises one outcome while a newer article frames a different offer;
+- an old proof asset supports a claim the team would now phrase more carefully;
+- a buyer-facing page asks for action without acknowledging the problem that made the buyer arrive;
+- a sales follow-up restarts discovery instead of continuing the context the buyer already has;
+- a strong claim has no visible owner, review date, or supporting evidence.
+
+None of these failures looks dramatic in isolation. Together, they make the brand harder for answer engines to describe and harder for buyers to trust.
+
+## An evidence ledger is not enough
+
+A claim ledger is useful. It shows what the brand says, where the proof lives, which gaps need work, and which pages carry the commercial story.
+
+But a ledger is still a snapshot unless it is connected to operating memory.
+
+Operating memory asks a more persistent question: *how does the business keep that evidence true over time?*
+
+A claim needs an owner. A proof asset needs a review trigger. A service page needs to know which buyer question it answers. A diagnostic offer needs a handoff path. A comparison page needs a freshness loop. A case study needs a status: current, partial, retired, or replaced.
+
+This is where AI visibility becomes operational rather than editorial.
+
+The aim is not to publish more material for its own sake. The aim is to make the public evidence layer easier to retrieve, cite, interpret, and act on because the company has a living system behind it.
+
+## What operating memory looks like
+
+Operating memory is not a giant internal wiki that nobody uses. It is a lightweight discipline for keeping commercially important claims connected to reality.
+
+It usually includes five practical habits.
+
+First, **canonical facts**. The business should know which descriptions are authoritative: who it serves, what it offers, what outcomes it can support, which terms it uses, and which proof assets matter most. If different pages tell different versions of the company, answer engines and buyers have to reconcile the conflict themselves.
+
+Second, **claim ownership**. Important public claims should not be orphaned. Someone should know why the claim exists, where it appears, what proof supports it, and when it needs review. Without ownership, stale confidence accumulates.
+
+Third, **freshness triggers**. Proof ages. Services change. Platforms add new discovery surfaces. Competitors start owning comparison terms. Operating memory defines the moments that should trigger a review: a new offer, a changed ICP, a major customer result, a product rename, a failed buyer question, a new recurring sales objection.
+
+Fourth, **handoff continuity**. If a buyer arrives through an AI recommendation, the next step should continue the thread. The destination page, call to action, form, and follow-up should preserve the problem the buyer brought with them. Otherwise the brand converts a high-intent referral into a generic enquiry.
+
+Fifth, **decision feedback**. The system should learn from what happens. Which claims get cited? Which proof assets build confidence? Which pages create confusion? Which buyer questions keep failing? Visibility should feed back into the operating layer, not sit in a dashboard detached from commercial decisions.
+
+## Why this matters for GEO
+
+Generative Engine Optimization is not only about making content crawlable or writing clearer answers. It is about making the brand legible as an entity with reliable public evidence.
+
+Answer engines need stable facts. Buyers need current proof. Commercial teams need context. Operating memory connects those needs.
+
+When the public record is coherent, retrieval becomes easier because the brand repeatedly reinforces the same claims with current support. Citation becomes more useful because the cited page fits the buyer question. Human validation becomes faster because the page, proof, and next step all point in the same direction.
+
+When memory is weak, the opposite happens. The model may still mention the brand, but the answer is more cautious, the evidence is patchier, and the buyer journey feels less trustworthy.
+
+A visibility program without operating memory tends to produce bursts of output. A visibility program with operating memory produces compounding clarity.
+
+## The Day 34 lesson
+
+The lesson from Day 34 is that AI visibility cannot depend on episodic content energy alone.
+
+Publishing creates evidence. Operating memory keeps that evidence usable.
+
+It helps the brand remember what it promised, where the proof lives, who owns the claim, when it needs review, and how the buyer should be handed to the next step. That is the difference between a public corpus that merely exists and a public corpus that can support revenue.
+
+The question is not only, “Are we visible in AI answers?”
+
+The better question is: “Can our business remember what those answers are likely to say about us, prove it publicly, keep it fresh, and continue the buyer journey without contradiction?”
+
+That is where AI visibility starts to become an operating system rather than a content sprint.


### PR DESCRIPTION
## Summary
- Adds Daily Build-in-Public Day 34 as a standalone MkDocs blog post.
- Frames operating memory as the durable state layer behind AI visibility.

## Verification
- Content gate: frontmatter, slug, description, categories, tags, and excerpt marker present.
- Forbidden/internal framing scan passed.
- git diff --check passed.
- mkdocs build --clean passed; only existing RoamLinks warnings were emitted.

## Scope
- Changed file: docs/blog/posts/daily-blog-day-34.md
