### PR TITLE
docs: add day 35 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-35.md
+++ b/docs/blog/posts/daily-blog-day-35.md
@@ -1,0 +1,115 @@
+---
+title: "Day 35: Experiment Debt Becomes Visibility Debt"
+date: 2026-05-25
+slug: day-35-experiment-debt-becomes-visibility-debt
+description: "A build-in-public essay on why prototypes, draft claims, stale workflows, and internal experiments become GEO and commercial risk when they leak into the public evidence layer."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - brand governance
+  - content operations
+  - evidence hygiene
+---
+
+# Day 35: Experiment Debt Becomes Visibility Debt
+
+Every ambitious marketing team has a shelf full of experiments: landing pages that tested a sharper promise, positioning drafts that tried a new category, demo pages for a feature that never shipped, comparison pages built before the product changed, and one-off partner blurbs that made sense for a single campaign.
+
+None of those artefacts are inherently bad. Experimentation is how brands learn. The problem begins when experimental artefacts remain publicly accessible, ambiguously labelled, or close enough to production that people and machines treat them as current proof.
+
+That is when experiment debt becomes visibility debt.
+
+For CMOs, Marketing Directors, and founders, this is no longer just a content housekeeping issue. In a generative search environment, the public web is a probabilistic evidence layer. AI answer engines, sales researchers, analysts, journalists, procurement teams, and competitors all draw from fragments of published material to infer what a company does, who it serves, what it can prove, and whether it is trustworthy.
+
+If your public evidence layer mixes live proof with retired claims, test messaging, half-built demos, and stale workflows, the market may not know which version of your company to believe.
+
+<!-- more -->
+
+## The Hidden Cost of Old Experiments
+
+Traditional marketing teams are used to thinking about experiments as temporary. A page is launched, a campaign runs, the numbers are reviewed, and the team moves on. But the internet rarely moves on with you.
+
+A prototype page can remain indexed. A draft narrative can be quoted by a third-party tool. An old comparison can be copied into a sales note. A test claim can be scraped, summarized, and repeated long after the team has stopped using it.
+
+The cost is subtle because nothing has to be dramatically wrong. Visibility debt often appears as small inconsistencies:
+
+- One page says the product is built for enterprise teams; another says it is ideal for solo operators.
+- A case study describes a workflow the company no longer supports.
+- A demo screenshot shows a capability that has since been renamed or removed.
+- A founder interview uses category language the brand has abandoned.
+- A campaign page promises an outcome the sales team now phrases more carefully.
+
+Each isolated inconsistency may feel harmless. Together, they create a noisy public record. Generative systems are especially sensitive to this noise because they do not experience your brand as a carefully guided website journey. They encounter it as a distributed body of evidence.
+
+That evidence can either reinforce a clear commercial truth or blur it.
+
+## GEO Rewards Coherent Proof
+
+Generative Engine Optimization is often discussed as if it were only a publishing discipline: create clear pages, define entities, answer buyer questions, and make the brand easy to retrieve. Those things matter. But clarity is not only created by adding content. It is also created by removing, retiring, or clearly separating content that should not be treated as active evidence.
+
+A brand does not earn visibility merely by producing more material. It earns visibility by making its public proof coherent.
+
+For a buyer-facing AI answer, coherence matters more than volume. If a model or research assistant sees ten pages that confidently support the same positioning, the brand becomes easier to describe. If it sees six current pages, three outdated pages, and two experimental pages with stronger but unverified claims, the brand becomes harder to summarize without risk.
+
+That uncertainty has commercial consequences. Ambiguity can soften recommendations, weaken category association, or cause a buyer to encounter an outdated version of the offer at exactly the moment they are trying to understand the company.
+
+In other words: stale experiments are not just operational clutter. They can become friction in the buyer journey.
+
+## The Public Evidence Layer Needs Separation
+
+The answer is not to stop experimenting. Teams should test messages, build prototypes, explore new offers, and publish learning loops. The answer is to separate experiments from live proof.
+
+There are three practical categories every brand should make explicit.
+
+First: **live proof**. These are current claims, offers, case studies, product descriptions, customer segments, and points of differentiation. This material should be easy for buyers and machines to identify as authoritative.
+
+Second: **experimental material**. These are tests, prototypes, early narratives, beta pages, draft frameworks, and exploratory offers. They can be public if public learning is part of the strategy, but they should be unmistakably marked as experimental.
+
+Third: **retired artefacts**. These are pages and claims that once reflected the business but no longer do. Some should be removed. Some should be redirected. Some may deserve an archive note. What matters is that they do not compete with current proof.
+
+This separation is especially important for brands building in public. Transparency is powerful, but transparency without status labels creates confusion.
+
+## What Experiment Debt Looks Like in Practice
+
+Experiment debt usually accumulates quietly because each artefact had a valid reason to exist at the time.
+
+A marketing director launches a campaign page to test a pain-led message. A founder writes a strong essay around a category hypothesis. A product team shares a prototype to invite feedback. A sales team creates a narrow industry page for one strategic account. A content team publishes a draft framework that later evolves into something more precise.
+
+Six months later, the company has grown. The ICP has sharpened. The offer has changed. The strongest claims have become more evidence-based. But the old materials are still findable, and they still speak with the confidence of the moment in which they were created.
+
+That is the danger: experiments often sound more certain than they are.
+
+A prototype says "we help X achieve Y" because prototypes need sharpness. A landing page says "the fastest way to" because campaigns need urgency. A draft essay says "the future of the category is" because thought leadership needs conviction. None of that is irresponsible in context. It becomes risky when context disappears.
+
+GEO turns context into a strategic asset. If the status of a page is unclear, the interpretation of that page becomes someone else's job.
+
+## A Simple Governance Habit for AI Visibility
+
+The most useful habit is a periodic evidence review. Not a brand-police exercise. Not a bureaucratic approval maze. A simple review of what the public web is currently saying about the company.
+
+Ask five questions:
+
+- Is this artefact current, experimental, or retired?
+- Does it make a claim we would still defend in a sales conversation?
+- Does it describe a product, segment, or workflow that still exists?
+- Would we be comfortable if an AI answer used this as supporting evidence?
+- If a buyer found this page first, would it help or confuse the decision?
+
+Those questions convert vague content cleanup into commercial risk management. They also make GEO more durable because the brand is not merely optimizing for retrieval; it is optimizing for reliable interpretation.
+
+The highest-leverage change is often not a new page. It is a clearer boundary around the pages you already have.
+
+## The Day 35 Lesson
+
+Day 35 is a reminder that build-in-public brands need two kinds of courage. The first is the courage to publish while learning. The second is the discipline to tell the market what is live proof, what is an experiment, and what has been retired.
+
+AI visibility is not built from perfect polish. It is built from consistent, interpretable evidence. Buyers do not need a brand with no history of experimentation. They need a brand whose current promises are easy to distinguish from its learning trail.
+
+Experiment debt becomes visibility debt when old tests blur the story the market is trying to understand.
+
+The fix is simple but not passive: separate the live from the speculative, label the learning, retire the stale, and make public evidence easier to trust.
+
+That is how experimentation stays an asset instead of becoming a drag on discoverability and revenue.


### PR DESCRIPTION
## Summary
- Adds Daily Build-in-Public Day 35 as a standalone MkDocs blog post.
- Keeps the PR payload scoped to one blog file.

## Verification
- Content gate: frontmatter, slug, description, categories, tags, and excerpt marker present.
- Forbidden/internal framing scan passed.
- git diff --check passed.
- mkdocs build --clean passed; only existing RoamLinks warnings were emitted.

## Scope
- Changed file: docs/blog/posts/daily-blog-day-35.md
