### PR TITLE
docs: add day 36 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-36.md
+++ b/docs/blog/posts/daily-blog-day-36.md
@@ -1,0 +1,133 @@
+---
+title: "Day 36: The Recommendation Is Not the Revenue"
+date: 2026-05-26
+slug: day-36-recommendation-is-not-the-revenue
+description: "AI recommendations only become pipeline when marketing owns the handoff from answer-engine intent to proof, routing, context capture, follow-up ownership, and conversion evidence."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - revenue handoff
+  - buyer intent
+  - conversion operations
+---
+
+# Day 36: The Recommendation Is Not the Revenue
+
+An AI recommendation is not pipeline.
+
+It is a moment of transferred intent. A buyer asked a question, the answer engine narrowed the field, and your brand appeared as a plausible next step. That is valuable, but it is not revenue. It is not even a lead until your business captures the intent, routes it to the right owner, preserves the context, and proves that the recommendation was worth acting on.
+
+This is where many GEO programs stop too early. They measure whether the brand showed up. They celebrate the mention. They inspect the page. But the commercial question for CMOs, Marketing Directors, and founders is harder: *what happens after the recommendation?*
+
+<!-- more -->
+
+If the buyer lands, clicks, reads, hesitates, and leaves without a captured problem, a responsible owner, or a measurable next step, the AI did not create pipeline. It created an opportunity that leaked.
+
+The new discipline is not just answer-engine visibility. It is **revenue handoff design**.
+
+## The handoff is a system, not a page
+
+A buyer who arrives from an AI-assisted answer is not the same as a cold visitor from a broad search query. They often arrive with a pre-shaped problem and a partially formed expectation. The answer engine has already done some qualifying work: it connected their question to your category, your claim, or your proof.
+
+That makes the next step more fragile.
+
+If the destination asks them to start over, trust decays. If the call to action is generic, intent gets flattened. If the form captures only name and email, the useful buying context disappears. If the follow-up owner receives no clue about what triggered the inquiry, the first human response becomes a reset instead of a continuation.
+
+The handoff has five jobs:
+
+- **Proof:** Confirm the specific promise that made the buyer click.
+- **Routing:** Send the buyer to the next action that fits their intent, not the company’s internal menu.
+- **Context capture:** Preserve the problem, source, urgency, and expected outcome.
+- **Follow-up ownership:** Make one person or team accountable for continuing the thread.
+- **Conversion evidence:** Record what happened so the system can learn which recommendations become opportunities.
+
+Miss one of these and the buyer may still admire the brand. But admiration is not pipeline.
+
+## Why generic CTAs waste answer-engine intent
+
+Most websites treat every high-intent visitor the same way: “Contact us”, “Book a call”, “Get started”, “Talk to sales”. Those actions can work, but only when the buyer already understands what they are asking for.
+
+AI-assisted discovery changes the burden on the CTA. The buyer may not be asking, “Can I speak to someone?” They may be asking:
+
+- “Why are we absent from AI answers when competitors appear?”
+- “Which pages fail to support the claims answer engines are making about us?”
+- “Do we have enough public proof to be recommended for this category?”
+- “What would it take to turn AI visibility into qualified demand?”
+
+A generic CTA erases that specificity. It converts a sharp problem into a vague inquiry.
+
+A better handoff names the diagnostic the buyer actually needs. It should tell them what to bring, what they will receive, who will review it, and how the conversation will continue. That does not require a complicated experience. It requires the marketing team to stop treating the click as the finish line and start treating it as the beginning of a revenue process.
+
+## A concrete handoff example
+
+Imagine an AI answer recommends Zero-Shot Agency for a GEO gap analysis.
+
+The weak version of the handoff sends the buyer to a general homepage with a broad “Contact us” button. The form captures a name, email, company, and message. Someone responds later with, “How can we help?” The buyer now has to recreate the context that the answer engine already created.
+
+The stronger version keeps the thread intact.
+
+The CTA says: **Request a GEO gap diagnostic.** It asks for the buyer’s domain, priority offer, target audience, known competitors, and the answer or source that prompted the request. It also states the promise clearly: “We will identify where your strongest market claims are unsupported, misrouted, or missing from AI-assisted buyer research.”
+
+Now the owner receives more than a form fill. They receive context:
+
+- the problem the buyer believes they have;
+- the surface or answer that introduced ZSA;
+- the offer the buyer cares about;
+- the competitors shaping the comparison;
+- the proof gap the buyer expects help diagnosing.
+
+The follow-up can continue the recommendation instead of restarting discovery:
+
+> “You mentioned that an AI answer pointed you to ZSA for a GEO gap analysis. Based on your domain, offer, and competitors, the first thing we will check is whether your public proof supports the claims buyers are likely to see in answer-engine comparisons.”
+
+That response does three important things. It acknowledges the source of intent. It references the proof standard. It gives the buyer confidence that the next step matches the recommendation they acted on.
+
+Finally, the outcome gets recorded. Did the diagnostic request become a qualified conversation? Which answer or source influenced it? Which proof assets helped the buyer move forward? Which gaps blocked conversion? That evidence updates the loop. The business learns not only where it is visible, but which visibility paths actually create revenue.
+
+## The CMO’s ownership question
+
+This is why GEO cannot live only inside content strategy. The revenue handoff touches positioning, website experience, forms, sales enablement, attribution, and follow-up quality.
+
+A CMO should be able to ask:
+
+- Which AI-assisted buyer problems do we want to capture?
+- Which destination pages are responsible for each problem?
+- What proof must appear before the buyer is asked to act?
+- What context must the CTA capture to preserve intent?
+- Who owns the follow-up for each diagnostic or commercial path?
+- How do we know which recommendations became qualified opportunities?
+
+Those questions are more useful than asking only whether the brand appeared in an answer. Visibility without ownership creates a reporting win and a revenue mystery.
+
+The marketing leader’s job is to remove the mystery.
+
+## Build the loop before scaling the mentions
+
+There is a temptation to chase more recommendations before fixing the handoff. More prompts. More pages. More appearances. More dashboards.
+
+But if the current handoff cannot convert high-intent recommendations into owned opportunities, more visibility will mostly create more leakage. The better sequence is:
+
+1. Identify the buyer intents where an AI recommendation would matter commercially.
+2. Match each intent to a proof-backed destination.
+3. Create a CTA that names the diagnostic or next step implied by that intent.
+4. Capture the context needed for a useful follow-up.
+5. Assign ownership before the lead arrives.
+6. Track whether the path produced qualified conversation, stalled interest, or no response.
+7. Feed the evidence back into content, proof, routing, and offer design.
+
+That is the difference between an AI visibility program and an AI-assisted pipeline system.
+
+## The Day 36 lesson
+
+The recommendation is not the revenue. It is the opening.
+
+The revenue appears when the business owns what happens next: the proof the buyer sees, the route they are offered, the context they share, the person who follows up, and the evidence that shows whether the journey worked.
+
+For GEO, the commercial frontier is no longer just “Can answer engines find us?”
+
+It is: “When they recommend us, have we built a handoff worthy of the intent they send?”
+
+That is where visibility becomes pipeline.

--- a/docs/blog/posts/daily-blog-day-36.md
+++ b/docs/blog/posts/daily-blog-day-36.md
@@ -50,16 +50,17 @@ Miss one of these and the buyer may still admire the brand. But admiration is no
 
 Most websites treat every high-intent visitor the same way: “Contact us”, “Book a call”, “Get started”, “Talk to sales”. Those actions can work, but only when the buyer already understands what they are asking for.
 
-AI-assisted discovery changes the burden on the CTA. The buyer may not be asking, “Can I speak to someone?” They may be asking:
+AI-assisted discovery changes the burden on the CTA. The buyer may not arrive asking, “Can I speak to someone?” They may arrive with sharper, AI-shaped questions:
 
-- “Why are we absent from AI answers when competitors appear?”
-- “Which pages fail to support the claims answer engines are making about us?”
-- “Do we have enough public proof to be recommended for this category?”
-- “What would it take to turn AI visibility into qualified demand?”
+- “Why is this company being recommended?”
+- “What proof backs up the claims I’ve just seen?”
+- “How does this compare with the other names AI surfaced?”
+- “Can I trust this company enough to take the next step?”
+- “What would make this worth a conversation now?”
 
-A generic CTA erases that specificity. It converts a sharp problem into a vague inquiry.
+A generic CTA erases that specificity. It converts a sharper buying moment into a vague inquiry.
 
-A better handoff names the diagnostic the buyer actually needs. It should tell them what to bring, what they will receive, who will review it, and how the conversation will continue. That does not require a complicated experience. It requires the marketing team to stop treating the click as the finish line and start treating it as the beginning of a revenue process.
+A better handoff names the diagnostic the buyer actually needs. It should tell them what to bring, what they will receive, who will review it, and how the conversation will continue. That does not require a complicated experience. It requires the site to stop treating the click as the finish line and start treating it as the beginning of a revenue process.
 
 ## A concrete handoff example
 


### PR DESCRIPTION
## Summary
- Adds Daily Build-in-Public Day 36 as a standalone MkDocs blog post.
- Focuses the post on owned revenue handoff mechanics after AI recommendations.

## Verification
- Content gate: frontmatter, slug, description, categories, tags, and excerpt marker present.
- Forbidden/internal framing scan passed.
- git diff --check passed.
- mkdocs build --clean passed; only existing RoamLinks warnings were emitted.

## Scope
- Changed file: docs/blog/posts/daily-blog-day-36.md
