### PR TITLE
docs: add day 37 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-37.md
+++ b/docs/blog/posts/daily-blog-day-37.md
@@ -1,0 +1,175 @@
+---
+title: "Day 37: Reduce the Risk Between the AI Answer and the Buyer’s Yes"
+date: 2026-05-27
+slug: day-37-reduce-risk-between-ai-answer-and-buyers-yes
+description: "Why AI-assisted buyers need a low-risk handoff: consistent identity, continuous claims, nearby proof, safer next steps, and material an internal champion can defend."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - buyer trust
+  - conversion strategy
+  - decision enablement
+geo_tactics:
+  - Make post-citation landing experiences reduce buyer risk.
+  - Preserve identity and claim continuity from answer engine to site.
+  - Keep proof close to the moment of buyer doubt.
+  - Design CTAs that help internal champions defend the next step.
+---
+
+# Day 37: Reduce the Risk Between the AI Answer and the Buyer’s Yes
+
+The buyer who arrives after an AI answer is not only asking, “Is this company relevant?”
+
+They are asking a quieter question: *Is it safe to believe this recommendation enough to act on it?*
+
+That distinction matters. A brand can be accurately described by ChatGPT, Claude, Perplexity, Gemini, or an AI-generated search result and still lose the buyer in the next thirty seconds. Not because the page is ugly. Not because the call to action is missing. Because the buyer cannot reduce the personal and organisational risk of taking the next step.
+
+For CMOs, Marketing Directors, and founders, that is a different design problem from visibility. It is not merely about being cited or matching a page to an answer. It is about building a handoff that lets a real person defend their interest in you.
+
+<!-- more -->
+
+## The handoff is a risk moment
+
+AI-assisted discovery compresses the shortlist. A buyer asks a specific question, receives a small set of plausible options, then opens a page with a half-formed belief already in place.
+
+That belief is fragile.
+
+The buyer may like the recommendation, but they still have to manage risk:
+
+- “Is this the same company the answer described?”
+- “Does the claim I just saw appear here in the same form?”
+- “Can I find proof without hunting?”
+- “Is the next step proportionate, or am I being pushed into a sales conversation too early?”
+- “Could I forward this to my founder, CFO, team lead, or procurement contact without embarrassment?”
+
+Those questions are not cosmetic. They decide whether curiosity becomes a defensible internal action.
+
+The commercial task is to lower the perceived risk of continuing.
+
+## Five trust signals that reduce buyer risk
+
+A useful AI-to-site handoff should make five things obvious.
+
+### 1. Identity: confirm the buyer is in the right place
+
+The first signal is basic, but often missed. The buyer needs immediate confirmation that the brand, offer, audience, and category match the answer they just saw.
+
+If the AI answer describes “a technical GEO agency for B2B service firms” and the page opens with broad language about “growth for the future of search”, the buyer has to translate. Translation creates doubt.
+
+Identity does not require robotic repetition. It requires a stable first impression:
+
+> “Zero-Shot Agency helps B2B teams understand and improve how they are represented in AI-assisted buyer research.”
+
+That sentence does not try to close the deal. It does something more important first: it tells the buyer they have not taken a wrong turn.
+
+### 2. Claim continuity: keep the same promise alive
+
+AI answers often use concise market-facing claims. Websites often drift into internal phrasing.
+
+That drift is dangerous because the buyer is comparing the answer in their head with the page in front of them. If the recommendation said “GEO gap analysis” and the site says “strategic intelligence sprint”, the offer may be the same internally, but the buyer has to solve the mapping problem alone.
+
+Continuity means the page preserves the important nouns, outcomes, and constraints from the answer:
+
+- the buyer type;
+- the problem being solved;
+- the method or diagnostic;
+- the expected output;
+- the limits of the claim.
+
+The limit matters. If the AI answer implies certainty and the page promises certainty, risk increases. Better wording says what can be assessed, improved, monitored, or evidenced without pretending any team can guarantee exact placement in every answer engine.
+
+A trustworthy handoff keeps the promise recognisable and bounded.
+
+### 3. Proof proximity: place evidence where doubt appears
+
+Buyers do not experience trust as a general brand emotion. They experience it claim by claim.
+
+If a page says “evidence-led GEO audits”, the proof should sit beside that claim, not three sections below it. If the page says “technical and commercial analysis”, the buyer should see sample inputs, outputs, criteria, or artefacts near the wording that creates the expectation.
+
+Useful proof does not have to be a giant case study. It can be compact:
+
+- a sample audit structure;
+- a list of answer surfaces checked;
+- an example of a claim-to-proof map;
+- a before-and-after excerpt;
+- a methodology note;
+- a qualification statement explaining where the method does and does not apply.
+
+The principle is simple: put evidence at the moment the buyer is most likely to wonder, “Can they actually do this?”
+
+Proof that arrives late may still be true, but it may arrive after doubt has already won.
+
+### 4. Risk-reducing calls to action: make the next step feel safe
+
+A high-commitment call to action can be correct for a buyer who is ready. It can also be too sharp for a buyer who has just discovered you through an AI answer.
+
+That buyer may need a lower-risk bridge before booking a commercial conversation.
+
+Risk-reducing CTAs are specific, bounded, and useful. They tell the buyer what to send, what they will receive, and why the step is proportionate.
+
+For example:
+
+> “Request a GEO visibility baseline. Send your domain, priority offer, target buyer, and three competitors. We will identify the claims that are easiest to verify, weakest to support, and most likely to shape AI-assisted shortlists.”
+
+That is safer than “Get started” because it names the diagnostic. It is stronger than “Contact us” because it gives the buyer a reason to act now. It also helps the internal champion explain the step: “We are not signing anything. We are asking for a baseline view of our AI visibility risk.”
+
+The CTA should reduce ambiguity before it asks for commitment.
+
+### 5. Internal-champion defensibility: give the buyer something they can carry
+
+Most B2B decisions are not made by the first person who clicks.
+
+The person who discovers you may need to forward the page, summarise the logic, ask for budget, defend the category, or explain why this deserves attention before a competitor does. If the page gives them only brand language, they have to build that case themselves.
+
+A defensible handoff gives them portable material:
+
+- a concise statement of the business risk;
+- a clear description of the method;
+- a small proof block;
+- a “what you receive” section;
+- a note on who the service is and is not for;
+- a short explanation of why AI-assisted discovery changes buyer research;
+- language that can survive being pasted into an internal message.
+
+This is where many teams underestimate the buyer. The page is not only persuading the visitor. It is equipping the visitor to persuade someone else.
+
+## The CMO question is not only “Do we show up?”
+
+A more useful leadership question is:
+
+> “When an AI answer introduces us, have we made it easy for the buyer to trust, verify, and defend the next step?”
+
+That question changes the audit.
+
+Instead of checking only rankings, mentions, or page polish, inspect the handoff for risk reduction:
+
+- Does the first screen confirm identity?
+- Are answer-level claims preserved without exaggeration?
+- Is proof close to the claim it supports?
+- Does the CTA match the buyer’s confidence level?
+- Can an internal champion forward the page with a clear reason to continue?
+- Are unsupported claims softened, substantiated, or removed?
+- Does the page help a buyer explain the opportunity in business terms?
+
+This is not about making every page longer. It is about removing the moments where the buyer has to invent confidence.
+
+## The GEO lesson
+
+Generative Engine Optimization is often discussed as a visibility challenge: can answer engines find, understand, and cite the brand?
+
+That remains important. But visibility alone does not solve buyer risk.
+
+The brands that benefit from AI-assisted discovery will be the ones that make their claims easy to recognise, easy to verify, and easy to defend. They will not force buyers to reconcile different language, search for proof, decode vague actions, or carry an unsupported recommendation into an internal conversation.
+
+The handoff should feel like a reduction in uncertainty.
+
+Identity reduces the risk of being in the wrong place. Claim continuity reduces the risk of bait-and-switch. Proof proximity reduces the risk of unsupported trust. Safer CTAs reduce the risk of premature commitment. Internal-champion material reduces the risk of the idea dying in someone else’s inbox.
+
+That is the real standard for AI-era buyer experience.
+
+Not just: “Did the answer mention us?”
+
+But: “Did the next step make the buyer safer to say yes?”


### PR DESCRIPTION
## Summary
- Adds the Day 37 Build-in-Public post as a single clean blog artifact.
- Rescues the blocked daily editorial PR process from the Kanban reviewer/auth crash loop.

## Verification
- Content/frontmatter gate passed.
- `git diff --check` passed.
- `mkdocs build --strict --clean` was run and failed only on the repository's existing RoamLinks/AutoLinks warning baseline.
- `mkdocs build --clean` passed locally.
- Cloudflare Pages check is tracked on the PR.

## Scope
- Expected payload: `docs/blog/posts/daily-blog-day-37.md` only.
