### PR TITLE
docs: add day 38 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-38.md
+++ b/docs/blog/posts/daily-blog-day-38.md
@@ -1,0 +1,170 @@
+---
+title: "Day 38: Visibility Gaps Need Commercial Triage"
+date: 2026-05-28
+slug: day-38-visibility-gaps-need-commercial-triage
+description: "AI visibility audits are getting longer and cheaper. CMOs need a triage system that ranks GEO gaps by buyer stage, claim value, evidence quality, owner, effort, and commercial risk before assigning work."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - commercial triage
+  - buyer intent
+  - evidence strategy
+geo_tactics:
+  - Score visibility gaps before assigning work.
+  - Separate discovered gaps from sprint-worthy gaps.
+  - Rank issues by buyer stage, claim value, evidence quality, confidence loss, effort, and owner clarity.
+  - Use explicit defer and monitor rules so low-value audit findings do not crowd out commercial blockers.
+---
+
+# Day 38: Visibility Gaps Need Commercial Triage
+
+The next problem in AI visibility will not be a lack of findings.
+
+It will be too many findings with no decision system attached.
+
+As more teams audit how they appear in ChatGPT, ChatGPT Search, Claude, Perplexity, and Gemini, the reports will get longer. They will list missing pages, thin proof, stale claims, weak comparisons, unclear entities, inconsistent language, crawl problems, citation gaps, and pages that answer engines can find but do not seem to trust.
+
+That is useful intake. It is not yet a plan.
+
+A CMO does not need a longer queue of visibility chores. They need commercial triage: a way to decide which GEO gaps deserve action this sprint, which should be monitored, and which should be deliberately ignored for now.
+
+<!-- more -->
+
+Discovery is becoming cheap. Prioritisation is becoming the scarce skill.
+
+## The audit is the intake, not the work plan
+
+A visibility audit can surface dozens of weaknesses in a public corpus. Some will matter commercially. Some will be hygiene issues. Some will be interesting but low leverage. Some will be artefacts of the prompt set, data source, or measurement method.
+
+If every finding becomes a task, the team has not become evidence-led. It has turned evidence into noise.
+
+The better question is not only: “What did the audit find?”
+
+It is: “Which findings meet the threshold for action?”
+
+That threshold needs to be explicit. Otherwise the loudest gap wins: the easiest page to edit, the most embarrassing screenshot, the phrase that annoys the brand team, or the dashboard row that looks most urgent in isolation.
+
+Commercial triage exists to stop that from happening.
+
+## A gap needs a score before it needs an owner
+
+The simplest useful model is a six-part score.
+
+For each visibility gap, score it from 1 to 5 on:
+
+1. **Buyer stage:** Is this top-of-funnel education, active evaluation, vendor comparison, proof validation, or contact intent?
+2. **Claim value:** Does the gap affect a claim that matters to revenue, differentiation, or sales confidence?
+3. **Evidence quality:** Is there public proof that a machine can retrieve and a buyer can inspect?
+4. **Confidence loss:** If the gap remains, how likely is an answer engine or buyer to prefer a clearer competitor?
+5. **Fix effort:** Is the remedy a small metadata/content correction, a new proof asset, a page restructure, or a larger positioning decision?
+6. **Owner clarity:** Is there a named person or team who can keep the evidence current after the first fix?
+
+The exact numbers matter less than the discipline. The point is to stop treating “found by the audit” as equivalent to “worth doing now.”
+
+A simple triage row might look like this:
+
+- **Gap:** key service claim appears in AI answers, but the linked page has no recent proof.
+- **Buyer stage:** 5 — evaluation.
+- **Claim value:** 5 — core offer.
+- **Evidence quality:** 2 — assertion without specific support.
+- **Confidence loss:** 4 — competitors have clearer examples.
+- **Fix effort:** 3 — needs a proof block and stronger methodology copy.
+- **Owner clarity:** 4 — service owner can maintain it.
+- **Decision:** fix this sprint.
+
+Another row might be:
+
+- **Gap:** low-intent glossary term is phrased differently across two pages.
+- **Buyer stage:** 1 — education.
+- **Claim value:** 2 — useful but not decisive.
+- **Evidence quality:** 4 — already adequately explained.
+- **Confidence loss:** 1 — unlikely to change a shortlist.
+- **Fix effort:** 1 — small copy edit.
+- **Owner clarity:** 3 — content owner exists.
+- **Decision:** batch later.
+
+Both are real findings. Only one is commercially urgent.
+
+## Use tiers, not one giant backlog
+
+Once gaps have a score, they should not all enter the same queue.
+
+A practical GEO triage system needs tiers.
+
+**Tier 1: Fix this sprint**
+
+These are gaps close to commercial intent, important claims, competitor comparison, or proof validation. They have plausible buyer impact and a clear route to improvement. If ignored, they could weaken citation confidence, make a recommendation less persuasive, or make the buyer doubt the next step.
+
+**Tier 2: Schedule with an owner**
+
+These gaps matter, but not immediately. They may require a new case study, a service-page refresh, a better comparison asset, or coordination with sales. They should not be forgotten, but they should not steal attention from Tier 1 work.
+
+**Tier 3: Monitor**
+
+These are uncertain findings. They may appear in one prompt set but not another, affect a low-intent page, or need more evidence before action. Monitoring is not neglect. It is a decision to gather more signal before spending effort.
+
+**Tier 4: Defer deliberately**
+
+These are cosmetic, redundant, or low-commercial-risk gaps. The team should write down why they are deferred so they do not return as zombie tasks every time a new audit runs.
+
+This tiering changes the operating rhythm. A visibility report stops being a pile of possible work and becomes a portfolio of decisions.
+
+## The defer rule is as important as the fix rule
+
+Most teams are comfortable saying what they will fix. Fewer are disciplined about saying what they will not fix yet.
+
+That matters because AI visibility tooling can create an endless appetite for action. There is always another query to test, another page to refine, another entity description to tighten, another comparison to expand, another proof point to expose.
+
+Without a defer rule, the team risks mistaking motion for strategy.
+
+A useful defer rule might be:
+
+- defer if the gap is more than two stages away from a revenue moment;
+- defer if the claim is already supported elsewhere and the page is not a common destination;
+- defer if the fix would require a positioning decision the team has not made;
+- defer if the finding appears in only one weak signal and has no corroborating evidence;
+- defer if no owner can maintain the page after the first edit.
+
+That last point is important. A gap with no durable owner often becomes visibility debt again. Fixing it once may make the dashboard look better while leaving the public evidence layer fragile.
+
+Commercial triage should protect the team from that cycle.
+
+## What changes when triage comes before execution
+
+When triage comes first, the work becomes more sober.
+
+The team does not ask, “How many gaps did we close?”
+
+It asks:
+
+- Which high-value claims became easier for answer engines to understand?
+- Which buyer-stage pages became more credible after a citation?
+- Which comparison moments became less ambiguous?
+- Which stale proof assets were either refreshed or retired?
+- Which gaps were deferred with a reason instead of quietly forgotten?
+- Which owners now maintain the evidence that the audit exposed?
+
+Those questions are harder than counting fixes. They are also closer to the commercial value of GEO.
+
+Answer engines do not reward a brand because its task list was long. Buyers do not trust a company because its dashboard improved by three rows. The public corpus has to become clearer, better evidenced, easier to compare, and easier to act on in the moments that matter.
+
+Triage is how the team decides where that improvement should start.
+
+## The Day 38 lesson
+
+AI visibility work is entering its noisy phase.
+
+More tools will find more gaps. More dashboards will create more rows. More automated reports will make it easier to confuse volume with progress.
+
+The advantage will not belong to the team that reacts to every finding. It will belong to the team that can separate discovered gaps from sprint-worthy gaps.
+
+For CMOs, Marketing Directors, and founders, the question is not only: “Where are we missing from AI answers?”
+
+It is: “Which missing signals are valuable enough, risky enough, and owned enough to fix now?”
+
+That is the job of commercial triage.
+
+Discovery tells you what might be broken. Triage decides what deserves the next hour of human attention.


### PR DESCRIPTION
## Summary
- Adds the Day 38 Build-in-Public post as a single clean blog artifact.
- Rescues the blocked daily editorial PR process from the Kanban reviewer/auth crash loop.

## Verification
- Content/frontmatter gate passed.
- `git diff --check` passed.
- `mkdocs build --strict --clean` was run and failed only on the repository's existing RoamLinks/AutoLinks warning baseline.
- `mkdocs build --clean` passed locally.
- Cloudflare Pages check is tracked on the PR.

## Scope
- Expected payload: `docs/blog/posts/daily-blog-day-38.md` only.
