### PR TITLE
docs: add day 39 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-39.md
+++ b/docs/blog/posts/daily-blog-day-39.md
@@ -1,0 +1,159 @@
+---
+date: 2026-05-29
+slug: day-39-information-architecture-is-a-visibility-control-plane
+title: "Day 39: Information Architecture Is a Visibility Control Plane"
+description: "In GEO, public information architecture tells answer engines and buyers how claims, concepts, entities, proof, and next actions fit together before ambiguity becomes lost trust."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - information architecture
+  - evidence architecture
+  - buyer trust
+geo_tactics:
+  - Define clear page roles for claims, concepts, entities, proof, comparisons, and next actions.
+  - Use navigation labels and internal routes to reduce retrieval ambiguity and post-citation buyer friction.
+  - Connect cited pages to the proof and commercial action that match the buyer's intent.
+---
+
+A page is not useful just because it exists.
+
+That is becoming painfully obvious in AI visibility work. A brand can have the right claims somewhere, the right proof somewhere else, a few helpful explainers, a tool page, a service page, a blog archive, and a contact route — and still make both answer engines and buyers do too much interpretation.
+
+In GEO, the public corpus is not only a pile of content. It is a control plane. The structure tells ChatGPT, ChatGPT Search, Claude, Perplexity, Gemini, and AI-assisted search systems what each artefact is for. It also tells a human buyer whether the page they clicked is a definition, a proof asset, a service offer, a comparison, a product detail, or the next step.
+
+If that structure is unclear, the visibility problem does not end when the brand is mentioned. It starts again when the buyer lands and has to work out what the recommendation actually means.
+
+<!-- more -->
+
+## "We have the content somewhere" is not enough
+
+A lot of teams treat information architecture as housekeeping.
+
+The homepage says the main thing. The blog explains some topics. The product pages describe the offer. Case studies prove the work. The navigation contains a few sensible labels. Search engines will crawl it. Buyers will figure it out.
+
+That was already optimistic in traditional search. In AI-assisted buying journeys, it is weaker.
+
+A buyer does not arrive from an answer engine in the same state as someone casually browsing a website. They often arrive with a specific question already framed:
+
+- Who can help us improve AI visibility without turning it into generic SEO theatre?
+- What is GEO, and how is it different from traditional SEO?
+- Which agency has evidence that it can diagnose citation gaps and buyer trust gaps?
+- What tool or process would tell us where our public corpus is weak?
+- What should we do after an AI system recommends a competitor more confidently than us?
+
+If the answer engine sends them to a page that does not declare its role quickly, the buyer has to rebuild the context themselves. They have to infer whether the page is educational, commercial, evidential, comparative, or operational. That extra interpretation is not neutral. It is friction at the exact moment trust should be consolidating.
+
+## Page roles are part of the evidence
+
+Information architecture is usually discussed as a UX problem: can users find the right page?
+
+For GEO, it is also an evidence problem: can a machine and a buyer understand why the page exists?
+
+A useful public corpus needs distinct roles. For example:
+
+- **Concept pages** should explain a term, method, or category clearly enough to anchor understanding.
+- **Entity pages** should make a product, tool, service, or brand asset legible as a specific thing.
+- **Proof pages** should support claims with evidence, examples, methodology, constraints, or outcomes.
+- **Comparison pages** should reduce ambiguity between alternatives rather than pretending every option is interchangeable.
+- **Service pages** should connect the buyer's problem to a concrete commercial offer.
+- **Action pages** should make the next step obvious without asking the buyer to translate interest into a generic enquiry.
+
+Those roles are not cosmetic. They change what can be retrieved, cited, compared, and trusted.
+
+When every page tries to do everything, answer engines get weaker signals and buyers get weaker confirmation. A definition page that suddenly turns into a sales pitch may be less useful as a source. A proof page with vague claims may fail to carry the recommendation. A service page buried under category education may not help a CMO decide whether to book a call. A tool page with no route to proof may attract curiosity without building confidence.
+
+The structure is part of the argument.
+
+## Ambiguous architecture leaks commercial intent
+
+The commercial risk is simple: unclear page roles make high-intent buyers do comparison work the brand should have done for them.
+
+Imagine a marketing director asks Perplexity for agencies that can improve visibility in AI answer engines. The answer mentions a few firms and cites pages that look relevant. The buyer clicks one.
+
+If the destination page is a general blog post with no clear route to the service, they wonder whether the company actually does the work or merely writes about it.
+
+If it is a service page with no proof route, they wonder whether the claim is credible.
+
+If it is a tool page with no explanation of methodology, they wonder whether the output is a toy or a serious diagnostic layer.
+
+If it is a concept page with no connection to the commercial offer, they learn something useful but do not know what to do next.
+
+None of those failures require the content to be bad. They only require the architecture to be vague.
+
+This is why "we have a page on that" is not the same as "the buyer can understand, verify, and act on that claim." The first is inventory. The second is a designed visibility path.
+
+## Answer engines need disambiguation, not just density
+
+More content can make the problem worse if the structure does not keep up.
+
+A dense public corpus helps only when the relationships are clear. Answer engines need to distinguish between the claim, the definition, the proof, the entity, the comparison, and the next action. They need stable labels and coherent routes. They need enough evidence density to support useful retrieval, but also enough separation to avoid collapsing different page types into one vague brand summary.
+
+That does not mean there is a magic file or markup shortcut that guarantees inclusion in Google AI surfaces. Optional discovery aids can be useful in some cross-agent and non-Google contexts, but they do not replace the harder work: make the public evidence layer internally coherent.
+
+The durable question is not, "Have we published enough?"
+
+It is, "Can a system understand which page should answer which question, and can a buyer understand why that page deserves trust?"
+
+Good IA helps both sides. It gives machines cleaner retrieval targets. It gives humans clearer context after the citation. It reduces the chance that a brand is technically present in an answer but commercially weak at the destination.
+
+## Navigation labels are strategic promises
+
+Navigation is not just wayfinding. It is a set of promises about how the brand understands the buyer's problem.
+
+A label like "Resources" promises a library. "Proof" promises evidence. "Services" promises a commercial offer. "Concepts" promises definitions and frameworks. "Tools" promises something operational. "Compare" promises help choosing between alternatives.
+
+If the label and the page role disagree, trust drops quickly.
+
+This matters because AI-referred visitors are often arriving after a compressed recommendation. They may have seen only a short answer, a citation, a brief comparison, or a mention inside a longer research path. The site has to expand that compressed context without forcing them to start over.
+
+The best public architecture behaves like a set of routes:
+
+- from category question to concept explanation;
+- from concept explanation to proof;
+- from proof to service relevance;
+- from service relevance to comparison;
+- from comparison to next action.
+
+That is not a funnel in the old linear sense. It is a trust graph. Buyers move through it based on the question they still need answered.
+
+## The practical audit is role, route, proof, action
+
+A useful IA review for GEO does not begin with colours, menus, or sitemap aesthetics. It begins with buyer and retrieval questions.
+
+For each priority page, ask:
+
+- **Role:** Is this page clearly a concept, entity, proof asset, service page, comparison, tool, or action page?
+- **Question:** Which buyer question should this page answer better than any other page?
+- **Retrieval signal:** Which claim, term, entity, or evidence should an answer engine confidently associate with it?
+- **Proof route:** Where does the page send a sceptical buyer who wants evidence?
+- **Commercial route:** Where does the page send a ready buyer who wants to act?
+- **Boundary:** What should this page not try to do?
+
+That last question matters. A page with no boundary becomes a junk drawer. It may contain useful material, but it becomes hard to cite cleanly and hard to trust quickly.
+
+The goal is not to make every page shorter or more rigid. The goal is to make the public evidence layer easier to understand under pressure.
+
+## What changed in our own thinking
+
+Day 39 pushed us to treat information architecture less like site tidying and more like visibility governance.
+
+The work is not simply to publish more pages, add more internal links, or create a prettier navigation pattern. The work is to decide what each public artefact is allowed to mean.
+
+A concept page should not have to carry the whole sales motion. A proof asset should not hide behind a generic blog label. A tool page should not float without methodology or buyer relevance. A service page should not ask the visitor to guess which evidence supports the claim. A next action should not feel identical for someone exploring a definition and someone validating a shortlist.
+
+That is the control-plane mindset: claims, concepts, entities, proof, and actions need visible relationships.
+
+When those relationships are clear, AI visibility work becomes less fragile. The model has better public evidence to assemble. The buyer has a cleaner path from recommendation to confidence. The team has a clearer way to decide what page should change when a visibility gap appears.
+
+## Practical lesson
+
+For build-in-public teams, the lesson is blunt: do not mistake content inventory for information architecture.
+
+In AI-assisted buying journeys, the buyer often arrives with a sharper question than your navigation was designed to answer. If the page role is vague, the proof route is hidden, or the next action does not match the intent, the brand can lose trust after winning the mention.
+
+GEO is not only about being retrieved. It is about being understood after retrieval.
+
+Treat information architecture as the control plane for that understanding. Give every priority page a job. Label the route honestly. Connect claims to proof. Make the next action fit the buyer's stage. Reduce ambiguity before it becomes someone else's comparison advantage.


### PR DESCRIPTION
## Summary
- Adds the Day 39 Build-in-Public post as a single clean blog artifact.
- Rescues the blocked daily editorial PR process from the Kanban reviewer/auth crash loop.

## Verification
- Content/frontmatter gate passed.
- `git diff --check` passed.
- `mkdocs build --strict --clean` was run and failed only on the repository's existing RoamLinks/AutoLinks warning baseline.
- `mkdocs build --clean` passed locally.
- Cloudflare Pages check is tracked on the PR.

## Scope
- Expected payload: `docs/blog/posts/daily-blog-day-39.md` only.
