### PR TITLE
docs: add day 40 evidence proximity post

### DIFF
--- a/docs/blog/posts/daily-blog-day-40.md
+++ b/docs/blog/posts/daily-blog-day-40.md
@@ -1,0 +1,167 @@
+---
+date: 2026-05-30
+slug: day-40-evidence-has-to-stay-close-to-the-claim
+title: "Day 40: Evidence Has to Stay Close to the Claim"
+description: "AI visibility only becomes commercial trust when every important claim sits near the proof, context, comparison path, and next action a buyer needs."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - evidence architecture
+  - buyer trust
+  - conversion strategy
+geo_tactics:
+  - Keep important claims close to proof, entity context, comparison language, and next actions.
+  - Reduce proof-hunting friction for buyers arriving from ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search.
+  - Treat optional machine-readable exports as discovery aids, not replacements for crawlable, coherent public evidence.
+---
+
+The fragile moment in AI search is not always the ranking.
+
+Sometimes the answer engine does its job. It names you. It cites you. It sends a buyer with intent already formed.
+
+Then the buyer lands and has to hunt.
+
+The page says the company is expert, but the proof is somewhere else. The service page makes a commercial promise, but the technical evidence lives three clicks away. The comparison language is confident, but the supporting context is buried in a blog archive. The call to action is visible, but the reason to trust it is not.
+
+That is where AI visibility turns into leakage.
+
+Today's build-in-public lesson is about proximity: the distance between a claim and the evidence that makes it believable.
+
+<!-- more -->
+
+## Visibility creates a shorter patience window
+
+A buyer arriving from ChatGPT, Claude, Perplexity, Gemini, or another answer engine is not entering the site cold.
+
+They have already seen a summary, a recommendation, or a shortlist. They are not asking, "What is this company?" from zero. They are asking, "Does this source justify why it was included?"
+
+That makes the landing experience more compressed.
+
+Traditional content can afford a little more wandering. A visitor may browse, compare sections, open the menu, and build their understanding gradually.
+
+AI-referred demand is different. The engine has pre-shaped the expectation. The page has to either confirm that expectation quickly or lose the borrowed confidence.
+
+For a CMO, Marketing Director, or founder, this is the commercial risk inside Generative Engine Optimization. Being mentioned by an AI system is useful, but it is not enough. If the visitor has to assemble the proof manually, the trust tax gets paid before the sales conversation begins.
+
+## The problem is not a lack of content
+
+Most companies do not suffer from having no evidence.
+
+They have case studies, service pages, founder narratives, product notes, pricing context, comparison pages, FAQs, technical explainers, and sales collateral.
+
+The problem is that the evidence often lives too far away from the claim it supports.
+
+A homepage says "enterprise-ready" without adjacent deployment evidence. A service page promises strategic clarity without showing the diagnostic model. A product page says "built for AI search" without exposing the entity definitions, public knowledge surface, or proof assets an answer engine can crawl and reconcile.
+
+Humans feel that gap as friction.
+
+Answer engines feel it as weak retrieval context.
+
+Both matter.
+
+GEO is not just a question of whether your content exists. It is whether the relationship between claim, proof, entity, comparison, and next action is easy to follow from the outside.
+
+## Evidence proximity is an architecture choice
+
+This is why evidence proximity has to be designed, not hoped for.
+
+A strong AI-search surface keeps important things close together:
+
+- **Claim:** What are you saying the buyer should believe?
+- **Proof:** What concrete asset, example, mechanism, or result supports it?
+- **Entity context:** Who or what is involved, and how does it connect to the rest of the brand?
+- **Comparison:** What alternative is the buyer implicitly weighing against you?
+- **Next action:** What should a qualified visitor do once confidence is high enough?
+
+When those pieces are separated across the site, every reader becomes an investigator.
+
+That includes the human buyer. It also includes the systems trying to understand whether your public content is internally consistent enough to cite with confidence.
+
+The goal is not to stuff every page with every asset. The goal is to make the evidence trail obvious.
+
+## The AI handoff needs proof, not just polish
+
+A polished page can still fail if it asks the buyer to accept too much on trust.
+
+That is especially true after an AI citation. The recommendation has already created momentum. The buyer is looking for confirmation, not a second research project.
+
+If a page says "we diagnose AI visibility gaps," the next useful thing is not a louder claim. It is a path to the diagnostic method, the questions being answered, the kind of evidence collected, the expected output, and the decision it helps the buyer make.
+
+If a page says "we build agentic workflows," the next useful thing is not a generic automation promise. It is an explanation of the operating model: what the agent does, what the human reviews, what artefacts are produced, what guardrails exist, and how success is verified.
+
+If a page says "we understand GEO," the next useful thing is a coherent public corpus that proves the understanding: concepts, entities, tools, service language, examples, and buyer-facing routes that reinforce the same model.
+
+This is not about making every page longer. It is about making the proof easier to find at the moment the buyer needs it.
+
+## Google caveat: no magic markup replaces the evidence layer
+
+It is tempting to treat AI visibility as a technical shortcut problem.
+
+Add a file. Add a schema. Chunk the page differently. Publish a machine-readable export. Wait for answer engines to notice.
+
+Those things can be useful in specific contexts, especially for non-Google agents or cross-agent discovery experiments. But they are not a substitute for the harder public-surface work.
+
+Google's AI features rely on core Search systems and quality signals. There is no safe claim that `llms.txt`, special AI markup, chunking, or over-focused structured data is required for Google AI visibility.
+
+The durable work is less magical and more operational: make the content crawlable, consistent, useful, and evidence-dense. Make the entity relationships clear. Put proof near claims. Give buyers and systems a coherent trail they can follow without private context.
+
+Optional discovery aids should help that evidence layer travel. They should not become an excuse for a weak evidence layer.
+
+## Proof-hunting is a conversion cost
+
+The commercial failure mode is not always dramatic.
+
+The buyer does not necessarily bounce because the site is bad. They bounce because the site makes them do too much unpaid labour.
+
+They have to ask:
+
+- What exactly is being claimed here?
+- Where is the proof?
+- Is this a service, a concept, a tool, or a general opinion?
+- How does this compare with the other names the AI answer surfaced?
+- What would make this worth a conversation now?
+
+Those are legitimate questions. A strong site answers them close to the claim.
+
+A weak site leaves them scattered.
+
+Every scattered answer slows the buyer down. Every extra click creates room for doubt. Every unsupported claim asks the buyer to keep trusting the recommendation without enough evidence.
+
+That is the trust tax. GEO work should reduce it.
+
+## What this changes in practice
+
+The practical audit is simple but uncomfortable.
+
+Pick a priority claim on the site and trace what sits around it.
+
+If the claim says the company is strategic, where is the strategy artefact?
+
+If the claim says the company is technical, where is the technical evidence?
+
+If the claim says the company helps with AI visibility, where are the concepts, entities, tools, examples, and methods that make that claim legible?
+
+If the claim is meant to create demand, where is the next action and why should the buyer trust it now?
+
+Then check whether those pieces are close enough for an external reader to follow. Not close enough for the internal team, who already knows the story. Close enough for a buyer who arrived from an AI answer with partial trust and limited patience.
+
+That is the standard that matters.
+
+## The takeaway
+
+Being cited is not the finish line.
+
+It is the handoff.
+
+The buyer still has to move from "the AI mentioned this company" to "I understand why this company is credible enough to speak to."
+
+That movement depends on evidence proximity: claims supported by proof, proof connected to entity context, context connected to comparison, and comparison connected to an action that makes sense.
+
+For ZSA, this is why GEO work cannot stop at visibility. The public surface has to behave like an evidence system. It has to help answer engines retrieve the right signals and help humans trust what they find.
+
+The claim gets attention.
+
+The nearby evidence earns the conversation.


### PR DESCRIPTION
## Summary
- Adds ZSA Build-in-Public Day 40: `Evidence Has to Stay Close to the Claim`
- Frames evidence proximity as the trust layer between AI citation, buyer verification, and commercial action
- Keeps Google/llms.txt caveats explicit and avoids internal repo/process framing

## Verification
- Independent reviewer gate: APPROVED
- Content assertions: frontmatter, slug/date/title, `<!-- more -->`, and forbidden-term scan
- `git diff --check`
- `python3 -m mkdocs build --clean`

## Kanban rescue note
This PR rescues the Day 40 editorial chain after the writer artifact was lost from an ephemeral scratch workspace before the researcher stage could read it.
