### PR TITLE
docs: add day 41 self-reporting evidence post

### DIFF
--- a/docs/blog/posts/daily-blog-day-41.md
+++ b/docs/blog/posts/daily-blog-day-41.md
@@ -1,0 +1,183 @@
+---
+date: 2026-05-31
+slug: day-41-self-reporting-is-not-evidence
+title: "Day 41: Self-Reporting Is Not Evidence"
+description: "AI-referred buyers and answer engines do not need louder claims. They need inspectable artefacts, validators, and proof paths that survive the handoff from recommendation to trust."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - evidence operations
+  - buyer trust
+  - validator design
+geo_tactics:
+  - Replace unsupported self-descriptions with inspectable artefacts, examples, source paths, and validation signals.
+  - Help AI-referred buyers verify claims quickly enough to preserve recommendation momentum.
+  - Design public proof paths that answer engines and humans can inspect without private context.
+---
+
+A confident page can still be an unverifiable page.
+
+That distinction matters more in the AI search era than it did in the old keyword era. A buyer may arrive because ChatGPT, Claude, Perplexity, Gemini, or another answer engine has already suggested a shortlist. The first question is no longer only, "Does this vendor sound relevant?"
+
+The sharper question is: "Can I verify the recommendation quickly enough to keep trusting it?"
+
+That is where self-reporting starts to fail.
+
+Every company can say it is expert, technical, strategic, safe, fast, proven, and commercially minded. Those claims may even be true. But if the public surface only offers the summary, the buyer has to do the evidence work alone. They have to hunt for examples, infer scope, compare language across pages, check whether the company understands their problem, and decide whether the answer engine's recommendation was grounded or merely fluent.
+
+In that moment, visibility becomes fragile.
+
+<!-- more -->
+
+## The AI handoff is not a closed sale
+
+An AI-referred visitor does not arrive as a fully convinced buyer. They arrive with provisional trust.
+
+The engine has compressed a messy research process into an answer. It may have compared vendors, extracted positioning, interpreted service pages, and found signals that suggest fit. But the human still has to cross the final gap between recommendation and commitment.
+
+If the site asks them to accept a self-description without proof, that gap widens.
+
+A page that says "we understand Generative Engine Optimization" is weaker than a page that shows how the agency thinks about entity clarity, crawlable evidence, source paths, buyer journeys, and commercial risk. A page that says "we build agentic systems" is weaker than a page that explains the operating model, guardrails, review points, failure modes, and examples of the decisions those systems are built to support.
+
+The claim is the start.
+
+The artefact is the evidence.
+
+## GEO is becoming evidence operations
+
+Generative Engine Optimization is often discussed as a visibility problem: how does a brand appear in AI answers?
+
+That is part of it. But the more durable problem is evidence quality.
+
+Answer engines need public surfaces they can interpret without guesswork. Buyers need public surfaces they can trust without private context. Both groups reward the same underlying discipline: clear entities, stable pages, coherent claims, proof close enough to inspect, and validators that make the claim easier to believe.
+
+This is why the work cannot stop at sharper copy.
+
+Sharper copy can make the claim easier to read. It cannot make the claim true. It cannot show the example, define the scope, expose the comparison, or explain why the buyer should trust one interpretation over another.
+
+Evidence operations means designing the public surface so that important claims are surrounded by support:
+
+- named services that map to real buyer problems;
+- concept pages that explain the operating logic behind those services;
+- examples, screenshots, case material, or build notes where appropriate;
+- comparison language that helps buyers understand fit and trade-offs;
+- internal links that make the proof path obvious instead of accidental;
+- calls to action that match the buyer's current level of confidence.
+
+That is not just content hygiene. It is commercial infrastructure.
+
+## Self-reporting creates proof debt
+
+Proof debt builds when a company's claims move faster than its public evidence.
+
+At first, the gap is easy to ignore. The team knows the work is real. The sales calls contain the nuance. The internal documents are detailed. The founder can explain the difference between a superficial service page and the actual delivery model in five minutes.
+
+But answer engines and new buyers do not get those five minutes by default.
+
+They get the public corpus.
+
+If the public corpus mostly says "trust us," the systems have less to retrieve and the buyer has less to verify. The result is not always invisibility. Sometimes the brand still appears. The failure is that the appearance is hard to convert into confidence.
+
+That is proof debt: the unpaid work of turning internal truth into external evidence.
+
+The debt shows up as vague service pages, unsupported capability claims, thin case-study routes, missing comparison language, weak methodology pages, and CTAs that ask for a meeting before the buyer has enough reason to want one.
+
+The more AI compresses discovery, the more expensive that debt becomes.
+
+## Validators matter because summaries are cheap
+
+The web is full of fluent summaries.
+
+That creates a trust problem. If every company can publish a polished explanation of why it is credible, the explanation itself stops being enough.
+
+The useful question becomes: what validates it?
+
+A validator can be many things:
+
+- a concrete artefact that shows the work;
+- a methodology page that explains the diagnostic process;
+- a public tool or report format that makes the claim operational;
+- a comparison page that names trade-offs instead of hiding them;
+- a case example that shows constraints, decisions, and outcomes;
+- a clear source path from the claim to the supporting evidence;
+- a review or quality gate that proves the output was not accepted on self-report alone.
+
+The point is not to overwhelm the buyer with documentation. The point is to stop asking them to believe a summary without a route to verification.
+
+For answer engines, validators create stronger retrieval context. For buyers, validators reduce the emotional risk of taking the next step.
+
+## This is not a special-markup shortcut
+
+There is a technical layer to AI visibility, but it does not erase the evidence problem.
+
+Crawlability matters. Clear page structure matters. Schema can help in the right places. Optional machine-readable exports can be useful for some agentic discovery patterns outside core Google Search.
+
+But there is no responsible shortcut that says `llms.txt`, special AI markup, chunking, or over-focused structured data is required for Google AI visibility. Google's AI features rely on core Search systems and quality signals.
+
+That means the strategic standard is still public usefulness.
+
+Can the page be crawled?
+
+Can the claim be understood?
+
+Can the entity be identified?
+
+Can the evidence be inspected?
+
+Can the buyer act without needing private explanation?
+
+If those answers are weak, metadata will not rescue the commercial experience.
+
+## The buyer is checking the recommendation
+
+The most important reader is often not casually browsing.
+
+They are checking whether the recommendation they just received deserves to survive contact with reality.
+
+That makes their questions sharper:
+
+- Why was this company included?
+- What proof backs up the claim?
+- How does this compare with the other names the answer engine surfaced?
+- What does the company actually do, not just say?
+- Can I trust this enough to book a call?
+
+A page built around self-reporting leaves those questions half answered.
+
+A page built around evidence operations gives the buyer a path. It names the claim, shows the proof, explains the method, connects the entity, clarifies the comparison, and offers a next action that fits the buyer's confidence level.
+
+That does not make the sale automatic. It makes the buyer's next step less fragile.
+
+## What this changes in practice
+
+The practical audit is to separate claims from artefacts.
+
+List the strongest claims your site makes. Then, for each one, ask:
+
+- What public artefact supports this?
+- Is the artefact close enough to the claim?
+- Would an answer engine be able to associate the evidence with the entity?
+- Would a sceptical buyer understand the method, not just the promise?
+- Is there a clear route from evidence to action?
+- What would make this claim independently checkable?
+
+If the answer is mostly "we can explain it on a call," the public surface is underpowered.
+
+A sales call can deepen trust. It should not be the first place the evidence becomes visible.
+
+## The takeaway
+
+Self-reporting is not evidence.
+
+It can be the doorway into evidence, but it cannot replace it.
+
+AI-referred buyers arrive with compressed context and provisional trust. Answer engines work from public surfaces, not internal conviction. Both need more than fluent claims. They need artefacts, validators, proof paths, and page relationships that survive the handoff from recommendation to inspection.
+
+For ZSA, that is the practical edge of GEO: helping companies become not only visible, but verifiable.
+
+The companies that win the AI handoff will not be the ones with the loudest summaries.
+
+They will be the ones whose public evidence makes the recommendation easy to trust.


### PR DESCRIPTION
## Summary
- Adds ZSA Build-in-Public Day 41: `Self-Reporting Is Not Evidence`
- Frames GEO as evidence operations: inspectable artefacts, validators, proof paths, and buyer verification after AI referral
- Keeps Google/llms.txt caveats explicit and avoids internal repo/process framing

## Verification
- Independent reviewer gate: APPROVED
- Content assertions: frontmatter, slug/date/title, `<!-- more -->`, and forbidden-term scan
- `git diff --check`
- `python3 -m mkdocs build --clean`

## Kanban rescue note
This PR rescues the Day 41 editorial chain after the writer artifact was lost from an ephemeral scratch workspace before the researcher stage could read it.
