### PR TITLE
docs: add day 42 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-42.md
+++ b/docs/blog/posts/daily-blog-day-42.md
@@ -1,0 +1,166 @@
+---
+title: "Day 42: Decide Which Public Claim Gets to Be Canonical"
+date: 2026-06-01
+slug: day-42-decide-which-public-claim-gets-to-be-canonical
+description: "Why GEO teams need canonical claim decisions before publishing another asset: when two live pages can both plausibly represent the company, buyers and answer engines are forced to arbitrate the brand story."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - source of truth
+  - canonical claims
+  - buyer trust
+geo_tactics:
+  - Resolve public claim conflicts before adding new GEO assets.
+  - Assign a canonical owner and canonical page for every high-intent commercial claim.
+  - Attach proof to the page that is allowed to represent the claim.
+  - Keep machine-readable exports aligned with the canonical public story, not parallel to it.
+---
+
+# Day 42: Decide Which Public Claim Gets to Be Canonical
+
+The dangerous page is not always the stale one.
+
+Sometimes the real GEO risk is that two current-looking pages both seem authorised to explain the company, but they do not say the same thing.
+
+A service page describes one promise. A concept page frames a slightly different one. A proof page supports only part of it. A comparison page uses older category language but still feels live. A machine-readable export repeats whichever version happened to be captured last.
+
+Nothing looks obviously broken. That is the problem.
+
+Day 21 was about removing pages that should no longer teach the market. Day 42 is about deciding which surviving page has authority before another asset forks the story again.
+
+For a CMO, Marketing Director, or founder trying to build visibility in ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search, this is not editorial tidiness. It is commercial control. If the company will not decide which claim is canonical, the buyer and the answer engine are left to decide on its behalf.
+
+<!-- more -->
+
+## The hard risk is undecided authority
+
+Most content governance conversations start with age: what is stale, what is outdated, what needs refreshing, what should be retired.
+
+That matters, but it is not the only failure mode.
+
+A newer page can still create confusion if it has no clear relationship to the rest of the public corpus. The page may be accurate in isolation and destabilising in context. It may introduce a sharper phrase than the homepage, a broader promise than the proof supports, or a more precise buyer segment than the service page is ready to own.
+
+The issue is not simply whether a page is right or wrong.
+
+The issue is whether the company has decided what that page is allowed to be.
+
+Is it the canonical explanation of the offer? Is it supporting education? Is it a proof route? Is it a point-of-view piece? Is it an experiment? Is it a temporary campaign page? Is it now strong enough that the older service page should be rewritten around it?
+
+Without those decisions, a public website becomes a committee of plausible truths.
+
+Answer engines struggle with that because they are asked to synthesize from the material available. Buyers struggle with it because they arrive after a recommendation and expect the site to confirm the story, not hand them an internal debate.
+
+## Buyers should not arbitrate between two live stories
+
+The commercial failure is subtle.
+
+Imagine a founder asks ChatGPT for agencies that can help diagnose why their company is not appearing in AI answers. The answer describes a firm with a focused GEO capability and points the founder toward the site.
+
+The founder clicks through and sees several pages that all look current:
+
+- one page says the offer is an AI visibility audit;
+- another frames it as a GEO strategy sprint;
+- a concept page describes a broader content architecture engagement;
+- a proof page validates a narrow diagnostic workflow;
+- a machine-readable summary compresses the offer into language the homepage no longer uses.
+
+Any one of those pages might be defensible. Together, they ask the buyer to infer the truth.
+
+That is too much work at the exact moment confidence should be increasing. The buyer is no longer evaluating the offer. They are reconciling the company’s internal vocabulary, claim boundaries, and proof trail.
+
+High-intent buyers rarely complain about that friction. They simply slow down, ask for more reassurance, compare another option, or decide the recommendation was less credible than it first appeared.
+
+The AI handoff created momentum. Undecided authority leaked it.
+
+## Canonical does not mean one page says everything
+
+There is a bad version of source-of-truth discipline where every page becomes cautious, generic, and over-approved.
+
+That is not the goal.
+
+A healthy GEO corpus can still have essays, definitions, comparisons, case material, sales pages, technical explainers, and machine-readable exports. Different pages can serve different jobs. The point is that each job needs a declared relationship to the central claim.
+
+A canonical service page should state what the company sells. A proof page should support a defined claim, not quietly expand it. A concept page should teach the category without rewriting the offer. A comparison page should clarify differences without inventing a new positioning system. A build-in-public post can explore the operating lesson without becoming the new commercial promise by accident.
+
+This is where canonicality becomes useful for both audiences.
+
+For answer engines, it reduces ambiguity about which page deserves more weight when explaining the company. For buyers, it creates a cleaner route from recommendation to confidence: promise, explanation, proof, next step.
+
+The public corpus does not have to be small. It has to know which pages are allowed to speak with authority.
+
+## The next asset should not be allowed to fork the story
+
+Publishing is often treated as additive by default.
+
+A team sees a search opportunity, a buyer question, a competitor angle, or a new AI visibility tactic. The instinct is to create another asset. That can be the right move, but only after a source-of-truth check.
+
+Before publishing the next page, ask what claim it touches.
+
+If the claim already exists, the new asset has three possible roles:
+
+1. **Reinforce it:** repeat the canonical claim with more useful context.
+2. **Prove it:** attach evidence that makes the canonical claim easier to believe.
+3. **Change it:** update the source of truth because the stronger version now deserves authority.
+
+The third path is the one teams avoid because it creates work. If the new page is actually the better explanation, then the homepage, service page, proof route, internal links, and machine-readable summaries may need to change around it.
+
+But avoiding that work does not avoid the decision. It only hides the decision inside the corpus.
+
+That is how a company ends up with two current-looking versions of itself: one formally approved, one operationally more accurate, neither clearly canonical.
+
+For GEO, that ambiguity is expensive. It weakens entity clarity, dilutes evidence freshness, complicates internal linking, and makes answer-engine citation confidence harder to earn. For buyers, it turns a simple question — “is this the right firm?” — into a reconciliation exercise.
+
+## A canonical conflict workflow
+
+The practical fix is not a vague content cleanup. It is a conflict-resolution workflow for public claims.
+
+Start with the claims that matter commercially: what the company does, who it serves, what outcomes it can support, how the method works, and what proof exists.
+
+Then run the conflict pass:
+
+1. **Claim inventory:** list every live page or export that makes, implies, or supports the claim.
+2. **Canonical owner:** assign a human owner for the claim, not just a page owner. This is usually a CMO, founder, product marketer, or revenue leader depending on the claim.
+3. **Canonical page decision:** decide which public page is allowed to be the primary explanation.
+4. **Proof attachment:** connect the strongest evidence to that page, close enough that buyers and answer engines can see why the claim is credible.
+5. **Residual page decision:** merge, redirect, rewrite, relabel, or demote pages that split authority with the canonical page.
+6. **Machine-readable export sync:** make any supporting exports reflect the decided public story rather than preserve a parallel version.
+7. **Review trigger:** define when the claim must be reviewed again: offer change, proof change, category shift, sales objection, or a new asset that tries to restate the claim.
+
+The important move is step three. Until the canonical page is named, the rest of the corpus can keep negotiating with itself.
+
+A claim without a canonical home is not flexible. It is fragile.
+
+## The Google caveat still matters
+
+This work should not drift into markup superstition.
+
+Machine-readable artefacts can be useful as cross-agent discovery aids. They can help some non-Google systems, partner agents, or internal workflows inspect the same facts more efficiently. But they do not replace clear public pages, coherent internal linking, current evidence, or core Search quality.
+
+They should not be treated as magic markup for Google’s generative surfaces.
+
+The defensible order is simple: decide the public source of truth first, make the human-facing corpus coherent, then let supporting formats mirror that decision.
+
+If the canonical story is unresolved, exporting it faster only distributes the conflict.
+
+## The standard is confidence after the recommendation
+
+The end state is not a perfectly tidy website. No serious company has one for long.
+
+The standard is whether a high-intent buyer can move from AI recommendation to commercial confidence without becoming the judge of two competing stories.
+
+They should not have to decide whether the service page or the concept page is more current. They should not have to infer which proof supports which promise. They should not have to translate between three active names for the same offer. They should not have to wonder whether the public summary, the sales promise, and the evidence layer describe the same company.
+
+That arbitration belongs inside the business.
+
+Strong GEO is not just the discipline to publish what answer engines can find. It is the discipline to decide what answer engines and buyers should be able to treat as authoritative.
+
+Before the next asset goes live, make the harder call.
+
+Which claim is allowed to represent the company?
+
+Which page gets to be canonical?
+
+And what has to change so the rest of the public corpus stops arguing with it?


### PR DESCRIPTION
## Summary
- Adds the Day 42 build-in-public post: "Decide Which Public Claim Gets to Be Canonical".
- Applies only the approved final artifact to `docs/blog/posts/daily-blog-day-42.md`.

## Verification
- Upstream revision handoff marked `ops_ready: true` and listed reviewer issues resolved.
- `git status --short`
- `git diff --check origin/main...HEAD`
- `git diff --stat origin/main...HEAD`
- Targeted content/frontmatter and banned-term check
- `mkdocs build --strict` (fails on existing warning baseline: nav exclusions, absolute blog nav URLs, RoamLinks/AutoLinks missing-link warnings)
- `mkdocs build` (passes)

## Scope
- Intended payload: one new blog post file only.
