### PR TITLE
docs: add day 43 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-43.md
+++ b/docs/blog/posts/daily-blog-day-43.md
@@ -16,7 +16,7 @@ geo_tactics:
   - Build an answer-quality scorecard across ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search surfaces.
   - Track share-of-answer, buyer-problem fit, claim accuracy, competitor adjacency, citation quality, source freshness, answer volatility, and commercial actionability.
   - Treat one-off prompt screenshots as examples, not as evidence of durable visibility.
-  - Keep the Google caveat clear: llms.txt, special AI markup, chunking, and narrow structured-data tricks are not magic requirements for AI visibility.
+  - "Keep the Google caveat clear: llms.txt, special AI markup, chunking, and narrow structured-data tricks are not magic requirements for AI visibility."
 ---
 
 # Day 43: Measure the Answer, Not Just the Mention

--- a/docs/blog/posts/daily-blog-day-43.md
+++ b/docs/blog/posts/daily-blog-day-43.md
@@ -1,0 +1,178 @@
+---
+title: "Day 43: Measure the Answer, Not Just the Mention"
+date: 2026-06-02
+slug: "day-43-measure-the-answer-not-just-the-mention"
+description: "A practical measurement note for CMOs and founders: AI visibility should be judged by answer quality, buyer usefulness, competitive framing, source quality, freshness, and next-step fit — not by a single mention screenshot."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer quality
+  - measurement
+  - competitive intelligence
+geo_tactics:
+  - Build an answer-quality scorecard across ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search surfaces.
+  - Track share-of-answer, buyer-problem fit, claim accuracy, competitor adjacency, citation quality, source freshness, answer volatility, and commercial actionability.
+  - Treat one-off prompt screenshots as examples, not as evidence of durable visibility.
+  - Keep the Google caveat clear: llms.txt, special AI markup, chunking, and narrow structured-data tricks are not magic requirements for AI visibility.
+---
+
+# Day 43: Measure the Answer, Not Just the Mention
+
+Most AI visibility reports are still too binary.
+
+They ask: "Did the answer mention us?"
+
+That is a useful first check, but it is not a useful management system. A buyer can see your brand name in an AI answer and still walk away with the wrong problem, the wrong category frame, the wrong comparison set, or the wrong next step.
+
+For a CMO, Marketing Director, or founder, the sharper question is:
+
+> Would this answer move a qualified buyer in the right direction?
+
+That is the difference between visibility as a screenshot and visibility as a commercial signal.
+
+## A mention is not the same as a useful answer
+
+A brand mention can be flattering and strategically useless at the same time.
+
+If an answer engine lists your company beside irrelevant competitors, describes your product using an outdated positioning line, cites weak or stale sources, or sends the buyer towards a generic next step, the screenshot may look positive while the buyer journey gets worse.
+
+The mistake is treating AI visibility like an on/off rank check.
+
+Generative Engine Optimization needs a richer telemetry layer because answer engines do not only return links. They produce a narrative. They choose the category. They decide which buyer problem matters. They compress claims, tradeoffs, evidence, and competitors into a few paragraphs.
+
+That means the measurement unit is not just "presence".
+
+The measurement unit is answer quality.
+
+## The answer-quality scorecard
+
+A practical GEO baseline should score answers across a small set of business-facing dimensions.
+
+Not every team needs a complex dashboard on day one. But every team needs enough structure to separate meaningful signals from noisy prompt runs.
+
+Start with these fields.
+
+### 1. Share of answer
+
+How often does your brand appear for the prompts that matter?
+
+This is the closest metric to traditional visibility, but it should be treated as the entry point, not the finish line. Track whether you are mentioned across ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search surfaces. Track whether the mention appears early, late, conditionally, or only in long lists.
+
+A buried appearance in a generic list is not the same as being framed as a relevant option for the buyer's stated problem.
+
+### 2. Buyer-problem fit
+
+Does the answer choose the right problem?
+
+This is where many visibility reports become misleading. The answer may mention your brand, but attach it to a low-value or outdated use case. For example, an agency that should be evaluated for AI visibility strategy may be described as a generic SEO provider, a content shop, or a web design supplier.
+
+The score should ask whether the answer understands the commercial job the buyer is trying to solve.
+
+If the buyer problem is wrong, the mention is weak.
+
+### 3. Claim accuracy
+
+Are the claims current, specific, and commercially safe?
+
+Answer engines often compress public information into confident summaries. That can help when your public story is clear. It can hurt when old positioning, vague service pages, third-party snippets, or half-remembered descriptions get blended into the answer.
+
+Score whether the answer states what you actually do, who you serve, and why you are credible. Mark claims that are stale, exaggerated, too generic, or attached to the wrong service line.
+
+The goal is not to force every answer into approved copy. The goal is to spot when the market-facing narrative is drifting.
+
+### 4. Competitor adjacency
+
+Who are you placed next to, and what does that imply?
+
+AI answers do not just mention competitors. They build a comparison frame.
+
+Being placed next to enterprise platforms, specialist agencies, freelance consultants, publishers, or unrelated software vendors tells the buyer what category the answer engine thinks you belong in. Sometimes that adjacency is useful. Sometimes it quietly moves you into the wrong buying set.
+
+Measure whether competitor comparisons are accurate, commercially helpful, and aligned with how a real buyer would shortlist options.
+
+A visibility win beside the wrong competitors can become a positioning problem.
+
+### 5. Citation and source quality
+
+What is the answer relying on?
+
+For surfaces that expose citations or source paths, score whether the answer is grounded in current, authoritative, and relevant material. A mention supported by an old directory page, thin aggregator snippet, or stale article should not receive the same quality score as an answer grounded in the brand's strongest public explanation.
+
+This does not mean every answer needs to cite your site directly. It means the visible source mix should be good enough that a buyer would not be misled by it.
+
+Citation quality is especially useful because it tells the marketing team where the public record is helping and where it is creating drag.
+
+### 6. Freshness
+
+Is the answer using the current version of the company?
+
+AI visibility can lag behind reality. A team may update positioning, launch a sharper offer, publish stronger supporting material, or narrow its audience, while answer engines continue to describe an older version of the business.
+
+Freshness should be scored separately from accuracy because an answer can be technically true and still commercially stale.
+
+The question is not only "is this wrong?" It is also "is this still the story we want buyers to hear?"
+
+### 7. Next-step fit
+
+What does the answer suggest the buyer should do next?
+
+Some AI answers mention a company but fail to create a useful path forward. They may recommend broad research, generic vendor comparison, or unrelated evaluation criteria. Others give the buyer a practical next step: inspect a service page, compare a specific capability, ask about implementation, or review a relevant case.
+
+Score whether the answer's recommended next action matches the buyer's stage and the company's commercial motion.
+
+A good answer should reduce confusion, not just increase awareness.
+
+## Volatility matters more than any single screenshot
+
+One prompt result is not a baseline.
+
+It is a sample.
+
+A useful measurement loop runs prompt sets across multiple surfaces, repeats them over time, and tracks volatility. If your brand appears once and disappears three days later, that is not the same signal as a stable pattern. If the competitor frame changes dramatically between prompt variants, that tells you the market narrative is unstable. If citations swing between strong sources and weak aggregators, that tells you the public record is not yet consistent enough.
+
+This is where GEO measurement becomes operational rather than performative.
+
+The point is not to collect impressive screenshots. The point is to identify which findings deserve action.
+
+## What to ignore
+
+A good scorecard should also protect the team from chasing noise.
+
+Ignore isolated mentions that do not recur across meaningful prompts. Ignore flattering answers that attach you to the wrong buyer problem. Ignore prompt variants that no real buyer would ask. Ignore vanity comparisons that have no commercial consequence. Ignore Google-specific optimisation claims that depend on unsupported requirements.
+
+In particular, do not build a strategy around llms.txt, special AI markup, arbitrary chunking tactics, or over-focused structured data work as if they were Google AI visibility requirements. Clean technical foundations, clear content, crawlable pages, and authoritative public information still matter, but there is no magic AI-visibility switch hidden in a single file or markup trick.
+
+The scorecard should make this easier. It should tell the team which gaps are worth fixing and which screenshots are just noise.
+
+## The operating cadence
+
+For most teams, the first useful cadence is simple.
+
+Once a month, run a defined prompt set across the answer surfaces your buyers are likely to use. Include category prompts, problem-aware prompts, competitor-comparison prompts, and buying-stage prompts. Score the answers using the same dimensions each time.
+
+Then split findings into three buckets:
+
+1. Fix now: wrong category, wrong buyer problem, misleading claim, harmful competitor frame, stale source.
+2. Watch: unstable answer, weak citation mix, inconsistent next step, minor phrasing drift.
+3. Ignore: one-off mention, unrealistic prompt, vanity inclusion, low-commercial-risk omission.
+
+This turns AI visibility from a mood board into a management routine.
+
+It also changes the work marketing teams assign. Instead of asking writers to "make us appear more in AI," the team can ask for a specific correction: clarify the buyer problem on a service page, strengthen a comparison page, update a dated claim, publish a better category explanation, or remove ambiguity from the public story.
+
+## The business question
+
+The market is going to produce more AI visibility reports, more prompt dashboards, and more screenshots of answer engines mentioning brands.
+
+Some of that will be useful. Much of it will be decorative.
+
+The business question is not whether an AI system can be prompted into saying your name.
+
+The business question is whether the answer a buyer receives is accurate, current, competitively useful, commercially actionable, and pointed towards the right next step.
+
+That is what CMOs and founders should measure.
+
+Measure the answer, not just the mention.


### PR DESCRIPTION
## Summary
- Adds Day 43 Build in Public post: "Measure the Answer, Not Just the Mention"
- Publishes the approved measurement note on answer-quality scoring for AI visibility
- Keeps PR payload isolated to the intended blog post file

## Checks
- Frontmatter/content assertions passed for title, date, slug, categories/tags, required GEO concepts, and banned terms/frames
- Python hook/tool syntax check passed via py_compile
- `python3 -m mkdocs build` passed
- `python3 -m mkdocs build --strict` failed only on existing site warnings (unlinked nav/RoamLinks/absolute nav URL warnings), while non-strict build passed

## Payload
- `docs/blog/posts/daily-blog-day-43.md`
