### PR TITLE
ci: validate blog frontmatter shape

### DIFF
--- a/.github/workflows/frontmatter.yml
+++ b/.github/workflows/frontmatter.yml
@@ -1,0 +1,40 @@
+name: Validate Frontmatter
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**/*.md'
+      - 'tools/validate_frontmatter.py'
+      - 'tests/test_validate_frontmatter.py'
+      - '.github/workflows/frontmatter.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install validation dependencies
+        run: pip install pyyaml pytest
+
+      - name: Run validator tests
+        run: python -m pytest tests/test_validate_frontmatter.py -q
+
+      - name: Validate changed blog frontmatter
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" -- 'docs/blog/posts/*.md')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No changed blog posts to validate."
+            exit 0
+          fi
+          python tools/validate_frontmatter.py "${files[@]}"

--- a/tests/test_validate_frontmatter.py
+++ b/tests/test_validate_frontmatter.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+from tools.validate_frontmatter import validate_markdown_file
+
+
+def write_post(tmp_path: Path, frontmatter: str) -> Path:
+    post_dir = tmp_path / "docs" / "blog" / "posts"
+    post_dir.mkdir(parents=True)
+    post = post_dir / "post.md"
+    post.write_text(f"---\n{frontmatter}---\n\n# Day 99: Test Post\n", encoding="utf-8")
+    return post
+
+
+def test_rejects_mapping_inside_string_list_field(tmp_path):
+    post = write_post(
+        tmp_path,
+        """
+title: "Day 99: Test Post"
+date: 2026-06-02
+slug: "day-99-test-post"
+description: "Test description"
+categories:
+  - Build in Public
+tags:
+  - GEO
+geo_tactics:
+  - Keep the Google caveat clear: llms.txt is not magic
+""".lstrip(),
+    )
+
+    errors = validate_markdown_file(post)
+
+    assert any(
+        "geo_tactics[0] must be a string" in error and "quote list items containing ': '" in error
+        for error in errors
+    )
+
+
+def test_accepts_quoted_colon_inside_string_list_field(tmp_path):
+    post = write_post(
+        tmp_path,
+        """
+title: "Day 99: Test Post"
+date: 2026-06-02
+slug: "day-99-test-post"
+description: "Test description"
+categories:
+  - Build in Public
+tags:
+  - GEO
+geo_tactics:
+  - "Keep the Google caveat clear: llms.txt is not magic"
+""".lstrip(),
+    )
+
+    assert validate_markdown_file(post) == []
+
+
+def test_rejects_missing_required_blog_string_fields(tmp_path):
+    post = write_post(
+        tmp_path,
+        """
+title: "Day 99: Test Post"
+categories:
+  - Build in Public
+""".lstrip(),
+    )
+
+    errors = validate_markdown_file(post)
+
+    assert "missing required field: date" in errors
+    assert "missing required field: slug" in errors
+    assert "missing required field: description" in errors

--- a/tools/validate_frontmatter.py
+++ b/tools/validate_frontmatter.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Validate Markdown YAML frontmatter shape for the ZSA MkDocs site.
+
+This intentionally checks schema shape, not just YAML parseability. YAML accepts
+unquoted list items containing ``: `` as mappings, which can silently turn a
+frontmatter list of strings into a mixed list of strings and dictionaries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+BLOG_REQUIRED_FIELDS = {
+    "title": str,
+    "date": (str,),
+    "slug": str,
+    "description": str,
+}
+
+STRING_LIST_FIELDS = (
+    "categories",
+    "tags",
+    "geo_tactics",
+)
+
+
+def _type_name(expected: Any) -> str:
+    if isinstance(expected, tuple):
+        return " or ".join(t.__name__ for t in expected)
+    return expected.__name__
+
+
+def load_frontmatter(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    """Return parsed frontmatter and validation errors for extraction/parsing."""
+    text = path.read_text(encoding="utf-8")
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return None, ["missing YAML frontmatter block"]
+
+    try:
+        parsed = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as exc:
+        return None, [f"invalid YAML frontmatter: {exc}"]
+
+    if parsed is None:
+        return {}, []
+    if not isinstance(parsed, dict):
+        return None, [f"frontmatter must be a mapping, got {type(parsed).__name__}"]
+    return parsed, []
+
+
+def validate_markdown_file(path: Path) -> list[str]:
+    """Validate one Markdown file's frontmatter and return human-readable errors."""
+    data, errors = load_frontmatter(path)
+    if data is None:
+        return errors
+
+    is_blog_post = "docs/blog/posts" in path.as_posix() or path.parent.as_posix().endswith("blog/posts")
+
+    if is_blog_post:
+        for field, expected_type in BLOG_REQUIRED_FIELDS.items():
+            if field not in data:
+                errors.append(f"missing required field: {field}")
+                continue
+            if field == "date":
+                # PyYAML may parse YYYY-MM-DD as datetime.date. MkDocs accepts it,
+                # so only reject obviously structured values here.
+                if isinstance(data[field], (list, dict)):
+                    errors.append(f"{field} must be a scalar date, got {type(data[field]).__name__}")
+            elif not isinstance(data[field], expected_type):
+                errors.append(
+                    f"{field} must be {_type_name(expected_type)}, got {type(data[field]).__name__}"
+                )
+
+    for field in STRING_LIST_FIELDS:
+        if field not in data:
+            continue
+        value = data[field]
+        if not isinstance(value, list):
+            errors.append(f"{field} must be list[str], got {type(value).__name__}")
+            continue
+        for index, item in enumerate(value):
+            if not isinstance(item, str):
+                errors.append(
+                    f"{field}[{index}] must be a string, got {type(item).__name__}; "
+                    "quote list items containing ': '"
+                )
+
+    return errors
+
+
+def iter_markdown_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(sorted(p for p in path.rglob("*.md") if ".git" not in p.parts))
+        elif path.suffix == ".md":
+            files.append(path)
+    return files
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate Markdown frontmatter schema shape.")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[Path("docs/blog/posts")],
+        help="Markdown files or directories to validate (default: docs/blog/posts)",
+    )
+    args = parser.parse_args(argv)
+
+    failures: list[str] = []
+    for path in iter_markdown_files(args.paths):
+        for error in validate_markdown_file(path):
+            failures.append(f"{path}: {error}")
+
+    if failures:
+        print("Frontmatter validation failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("Frontmatter validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a `tools/validate_frontmatter.py` schema-shape validator for Markdown YAML frontmatter.
- Add tests that catch the exact colon-in-list issue where YAML silently parses a list item as a mapping.
- Add a PR workflow that validates changed `docs/blog/posts/*.md` files before merge.

## Notes
- The workflow validates changed blog posts rather than every historical post, so existing older posts with incomplete metadata do not block this guardrail from landing.
- The validator still supports manual full-directory checks when the archive is ready for stricter cleanup.

## Test Plan
- [x] `python3 -m py_compile tools/validate_frontmatter.py`
- [x] `python3 -m pytest tests/test_validate_frontmatter.py -q`
- [x] YAML parse check for `.github/workflows/frontmatter.yml`
- [x] `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-42.md`
- [x] `mkdocs build`
