### PR TITLE
docs: add Build in Public Day 44 post

### DIFF
--- a/docs/blog/posts/daily-blog-day-44.md
+++ b/docs/blog/posts/daily-blog-day-44.md
@@ -1,0 +1,209 @@
+---
+title: "Day 44: Treat Answer Disagreement as a Positioning Signal"
+date: 2026-06-03
+slug: "day-44-treat-answer-disagreement-as-a-positioning-signal"
+description: "A competitive-positioning field note for CMOs and founders: when AI answers describe your company differently, diagnose the category, buyer, use-case, and comparison signals that are ambiguous in the market."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - positioning
+  - category strategy
+  - competitive intelligence
+geo_tactics:
+  - Compare how ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search surfaces describe the same company, category, buyer, use case, and alternatives.
+  - Treat disagreement between answers as a diagnostic for ambiguous positioning, not simply as a bad prompt or isolated model error.
+  - Audit whether public pages, descriptions, case examples, comparison language, and commercial metadata reinforce the same market interpretation.
+  - Prioritise fixes that reduce wrong-category, wrong-buyer, and wrong-competitor drift before producing more generic content.
+---
+
+# Day 44: Treat Answer Disagreement as a Positioning Signal
+
+When two answer engines describe your company differently, the first question should not be: "Which prompt was wrong?"
+
+The better question is:
+
+> What is ambiguous enough in the market that both answers felt plausible?
+
+That is a different kind of AI visibility conversation. It moves the work away from prompt theatre and towards commercial positioning.
+
+For a CMO, Marketing Director, or founder, answer disagreement is not just a reporting inconvenience. It can reveal whether the public market layer understands your category, your buyer, your use case, your proof hierarchy, and your competitive set.
+
+If ChatGPT, Claude, Perplexity, Gemini, or AI-assisted search surfaces give buyers different versions of who you are, that variation may be a signal that the brand is being interpreted through weak or conflicting cues.
+
+## Disagreement is not automatically failure
+
+Different systems will not always return identical summaries. They have different retrieval patterns, interfaces, source mixes, freshness constraints, and answer formats. A perfect word-for-word match across every surface is not the goal.
+
+The commercial question is more practical:
+
+Do the answers disagree in harmless ways, or do they move the buyer into a different market reality?
+
+Harmless disagreement sounds like variation in phrasing. One answer calls you an "AI visibility consultancy" while another calls you a "GEO strategy partner". The buyer still lands in the same category with the same broad expectation.
+
+Strategic disagreement is different.
+
+One answer frames you as an SEO agency. Another frames you as a content production shop. Another lists you beside software vendors. Another suggests you are mainly a web design service. The buyer now has four different starting points for evaluating you.
+
+That is not just an AI answer problem. That is a positioning problem being surfaced by AI answers.
+
+## The risk is the wrong comparison set
+
+Positioning mistakes become expensive when they change the alternatives a buyer considers.
+
+If an answer places your company in the wrong category, the buyer benchmarks you against the wrong competitors. If it describes the wrong buyer problem, the sales conversation starts with the wrong need. If it highlights low-value services before strategic ones, your offer gets compressed into commodity language.
+
+This is where AI visibility becomes a competitive issue rather than a content issue.
+
+A founder might think the company is being understood as a specialist partner for AI visibility strategy. But an answer engine might describe it as a general digital marketing agency. Another might group it with SEO tools. Another might omit the strategic offer and emphasise blog writing.
+
+Each version changes the buyer's expectations:
+
+- What does this company actually do?
+- Is it a category specialist or a generalist supplier?
+- Should I compare it with agencies, software platforms, consultants, or internal hires?
+- Is the value strategic clarity, technical implementation, content production, or reporting?
+- What kind of proof should I expect before I trust it?
+
+If those answers drift, the market does not have a stable interpretation of the business.
+
+## Use answer disagreement as a diagnostic
+
+A useful GEO baseline should not only ask whether the brand appears. It should compare how the brand is interpreted.
+
+Run the same buyer-intent question across multiple answer surfaces and look for disagreement in five areas.
+
+### 1. Category
+
+What kind of company does the answer think you are?
+
+This is the highest-leverage diagnostic because category determines the rest of the buyer's mental model. A company positioned around GEO strategy can lose value if it is repeatedly compressed into SEO, content marketing, web design, analytics, or generic AI consulting.
+
+Diagnostic questions:
+
+- Does the answer name the category you want to compete in?
+- Does it use outdated category language?
+- Does it blend you into a broader category that weakens your differentiation?
+- Does it make you sound like a vendor type you are not?
+
+If category varies wildly across answers, your public language may be leaving too much interpretive space.
+
+### 2. Buyer
+
+Who does the answer think you serve?
+
+A company can be visible and still be misdirected. If the answer describes your offer for the wrong buyer, the resulting lead may arrive with the wrong expectations or not arrive at all.
+
+Diagnostic questions:
+
+- Does the answer connect you to the right decision-maker?
+- Does it understand the commercial pain the buyer is trying to solve?
+- Does it over-index on technical users when the buying motion is executive?
+- Does it describe the offer in a way a CMO, Marketing Director, or founder would recognise as relevant?
+
+Buyer drift is often a sign that service pages, examples, titles, metadata, and case language are pointing in different directions.
+
+### 3. Use case
+
+What job does the answer think the buyer hires you to do?
+
+This matters because AI answers compress a business into a small number of use cases. If the wrong one becomes dominant, your visibility can create weaker conversations.
+
+Diagnostic questions:
+
+- Does the answer foreground the highest-value use case?
+- Does it reduce the offer to a tactical deliverable?
+- Does it describe the outcome, or only the activity?
+- Does it connect the work to pipeline, category clarity, competitive visibility, or buyer decision quality?
+
+If answer engines consistently pick the wrong use case, more content may not help. The existing public surface may need clearer prioritisation.
+
+### 4. Alternatives
+
+Who does the answer compare you with?
+
+This is one of the most commercially revealing signals. AI systems often answer buyer questions by creating shortlists, categories, or implied comparison sets. Those comparisons shape how the buyer thinks about budget, risk, proof, and urgency.
+
+Diagnostic questions:
+
+- Are you being compared with the companies you actually compete against?
+- Are irrelevant competitors appearing because your language overlaps with theirs?
+- Are you absent from comparison sets where you should be present?
+- Are you grouped with tools when you are selling strategic service, or with agencies when you are selling a different operating model?
+
+Wrong-comparison drift is a positioning issue with revenue consequences.
+
+### 5. Confidence
+
+Does the answer sound specific, or does it hedge with generic language?
+
+Generic summaries often reveal that the public evidence is thin or hard to interpret. The system may know your name but not know what to do with it.
+
+Diagnostic questions:
+
+- Does the answer use specific language about your offer?
+- Does it name a concrete buyer problem?
+- Does it explain why a buyer would choose you over alternatives?
+- Does it rely on vague phrases that could describe any agency or consultancy?
+
+Low-confidence answers tend to sound safe, interchangeable, and commercially weak.
+
+## The fix is not to chase every answer
+
+The wrong response is to treat every inconsistent answer as a one-off prompt problem.
+
+That leads to busywork: rewriting prompts, collecting screenshots, debating which surface is more accurate, and producing more undifferentiated content in the hope that the answers improve.
+
+The stronger response is to ask what public signals need to become less ambiguous.
+
+That may include:
+
+- clearer category language on core pages;
+- tighter descriptions of the buyer and buying problem;
+- examples that show the strategic use case, not just activity;
+- comparison language that names the right alternatives and tradeoffs;
+- page titles and descriptions that reinforce the commercial promise;
+- case material that shows which outcomes matter;
+- a consistent explanation of what the company is not.
+
+None of this requires pretending that answer engines follow one simple rule. It requires making the public market layer easier to interpret.
+
+## A practical readout for leaders
+
+If you are reviewing AI visibility, add an answer-disagreement section to the baseline.
+
+Do not only report:
+
+> We appeared in 6 out of 10 prompts.
+
+Report:
+
+> When we appeared, three systems placed us in the right category, two described us as a generalist provider, and one compared us with a different vendor class. The main ambiguity is category language on our service pages and the absence of clear comparison framing.
+
+That is a leadership-grade insight. It tells the team where the market interpretation is unstable and what kind of positioning work should happen next.
+
+The output should help a CMO decide:
+
+- whether the company is being understood in the intended category;
+- whether the right buyer problem is visible;
+- whether competitors are being framed accurately;
+- whether current public assets reduce or increase ambiguity;
+- whether new content, page restructuring, comparison material, or offer clarification is the next best move.
+
+## The strategic point
+
+Generative Engine Optimization is not only about being cited.
+
+It is about being interpreted correctly when a buyer asks the market for help.
+
+Answer disagreement gives you a way to inspect that interpretation. Not with panic, and not with blind faith in any single model response, but with a commercial lens.
+
+When AI systems disagree about your company, treat the disagreement as a field note from the market.
+
+It may be telling you that your category is fuzzy, your buyer is underdefined, your use case is being commoditised, or your competitors are easier to place than you are.
+
+That is not a prompt problem.
+
+That is positioning intelligence.


### PR DESCRIPTION
## Summary
- Adds Build-in-Public Day 44 post: `docs/blog/posts/daily-blog-day-44.md`
- Publishes the approved 2026-06-03 answer-disagreement-as-positioning-signal article
- Keeps the PR payload isolated to the intended post file

## Checks
- `python tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-44.md` — passed
- targeted day/date/title/slug assertion — passed
- `python -m pytest tests/test_validate_frontmatter.py` — passed (3/3)
- `mkdocs build` — passed
- `mkdocs build --strict` — failed on existing repository warnings from nav/wikilink/autolink strict-mode baseline; non-strict build passes

## Payload verification
- Branch was created from current `origin/main` in an isolated worktree.
- `git diff --name-only origin/main...HEAD` returns only `docs/blog/posts/daily-blog-day-44.md`.
