### PR TITLE
docs: add Build in Public Day 45 post

### DIFF
--- a/docs/blog/posts/daily-blog-day-45.md
+++ b/docs/blog/posts/daily-blog-day-45.md
@@ -1,0 +1,252 @@
+---
+title: "Day 45: Make AI Visibility an Operating Rhythm, Not a Report"
+date: 2026-06-04
+slug: "day-45-make-ai-visibility-an-operating-rhythm-not-a-report"
+description: "A practical operating model for CMOs, Marketing Directors, and founders: turn AI visibility baselines into a recurring decision cadence with owners, thresholds, routes, and commercial actions."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - operating cadence
+  - marketing operations
+  - answer engines
+geo_tactics:
+  - Turn AI visibility reviews into a recurring management cadence with clear owners, thresholds, routes, and action logs.
+  - Review answer quality, source freshness, citation drift, competitor adjacency, category drift, buyer/use-case drift, canonical claim updates, and next-step routing across ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search surfaces.
+  - "Separate findings into commercial decisions: fix now, route to an owner, watch, or ignore."
+  - "Keep the Google caveat clear: llms.txt, special AI markup, arbitrary chunking, and over-focused structured-data tactics are not required switches for Google AI visibility."
+---
+
+# Day 45: Make AI Visibility an Operating Rhythm, Not a Report
+
+An AI visibility baseline gives leadership a useful map of the answer layer.
+
+It shows where the brand appears, how answer engines describe it, which sources they lean on, what competitors sit nearby, and whether the public story is current enough for a buyer making a decision.
+
+The risk is treating that map as the whole programme.
+
+ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search surfaces can each reveal how the market interface is reading the company this week. What they cannot decide is which movement matters commercially, who should respond, or when the team should come back to the same signal.
+
+That is where many GEO programmes lose momentum.
+
+A diagnostic lands. The answer layer looks important. One or two pages get updated. Then the next month arrives with no named owner, no decision threshold, and no agreed route from finding to action.
+
+For a CMO, Marketing Director, or founder, the useful question is not:
+
+> What did the baseline find?
+
+It is:
+
+> What operating rhythm turns those findings into owned decisions?
+
+## AI visibility needs a management cadence
+
+Generative Engine Optimization is not a single clean-up project. Answer engines change. Source mixes change. Competitors publish new material. Product positioning shifts. Case studies go stale. Sales teams hear new objections. Buyers start asking different questions.
+
+A brand can be correctly described in May and partially outdated in June.
+
+That does not mean the team should panic every time an answer changes. It means AI visibility needs to be managed like a lightweight operating rhythm: a recurring review that turns answer-engine movement into business decisions.
+
+The cadence does not need to be heavy. For most teams, a monthly or fortnightly review is enough at the start. The important part is that it has a structure:
+
+- which buyer questions are checked;
+- which answer surfaces are reviewed;
+- what changed since the last run;
+- whether the change matters commercially;
+- who owns the response;
+- what public asset, sales material, product page, proof point, or process needs to change;
+- when the finding should be checked again.
+
+Without that rhythm, AI visibility becomes a reporting artefact. With it, the same data becomes a management system.
+
+## The review should answer four questions
+
+A useful AI visibility meeting should not become a tour of screenshots.
+
+The team should move through four questions.
+
+### 1. What changed?
+
+Start with movement, not commentary.
+
+Did the answer quality improve or decline? Did a source disappear? Did a citation move from a strong page to a weak directory listing? Did a competitor appear beside you more often? Did the answer shift category language? Did the system start describing a different buyer, use case, or next step?
+
+Different surfaces will behave differently. ChatGPT may summarise from one mix of public signals. Claude may be more cautious in its framing. Perplexity may expose citations or grounding more directly. Gemini and AI-assisted search surfaces may blend classic search behaviour with generated summaries. The point is not to force identical answers across every system.
+
+The point is to know what materially changed.
+
+A good readout sounds like this:
+
+> In the last review, most answers described us as a GEO strategy partner for marketing leaders. This month, two surfaces still do that, but one has started grouping us with generic SEO agencies and another is pulling a stale third-party description into the summary.
+
+That is a signal a leadership team can discuss.
+
+### 2. Does it matter commercially?
+
+Not every answer change deserves action.
+
+Some changes are harmless: different phrasing, a reordered list, a mild citation variation, or a summary that is less elegant but still accurate. If every small movement becomes urgent, the cadence will collapse into noise.
+
+The operating rhythm needs commercial thresholds.
+
+A finding matters when it changes how a buyer might understand the company, evaluate the risk, compare alternatives, or choose a next step.
+
+Examples:
+
+- Category drift: the company is described as a different kind of provider.
+- Buyer drift: the answer starts speaking to a technical user when the buying motion belongs with a CMO or founder.
+- Use-case drift: the highest-value job gets replaced by a tactical deliverable.
+- Competitor adjacency: the brand appears beside companies that imply the wrong comparison set.
+- Source freshness: the answer leans on stale pages, old descriptions, thin directories, or outdated third-party profiles.
+- Citation/source drift: the visible grounding moves away from current authoritative material.
+- Claim drift: the answer repeats an old positioning line, an inaccurate capability, or a vague claim the team would not want sales to defend.
+- Next-step drift: the answer sends the buyer towards a generic action instead of the right commercial path.
+
+If the change does not affect buyer interpretation, it can be watched. If it affects buyer interpretation, it needs an owner.
+
+## Ownership is the missing layer
+
+Most AI visibility reports are written as if marketing owns every fix.
+
+That is rarely true.
+
+Some findings belong with marketing. Some belong with sales. Some belong with product. Some belong with technical owners. Some need leadership to make a positioning decision before anyone writes another page.
+
+The operating rhythm should make that routing explicit.
+
+Marketing may own category language, page titles, offer pages, comparison material, article planning, and campaign messaging.
+
+Sales may own buyer objections, qualification language, deck updates, call scripts, and the claims that repeatedly need evidence in commercial conversations.
+
+Product may own feature descriptions, roadmap-sensitive claims, integrations, use-case boundaries, and the parts of the offer that the public story keeps simplifying incorrectly.
+
+Technical owners may own crawlability, page templates, canonical URLs, documentation structure, analytics instrumentation, feeds, and schema hygiene where it genuinely supports ordinary search and site understanding.
+
+Leadership may own the decisions that cannot be delegated: which category to claim, which buyer to prioritise, which comparison set to accept, which services to stop foregrounding, and which claims are too weak to keep using.
+
+This is why the rhythm matters. It prevents AI visibility from becoming a marketing inbox where every drift signal is treated as a content request.
+
+A stronger process routes each finding to the function that can actually fix the underlying ambiguity.
+
+## A simple operating model
+
+The first version can be deliberately plain.
+
+Run the same core prompt set on a recurring schedule. Include category questions, buyer-problem questions, comparison questions, use-case questions, and buying-stage questions. Review them across the answer surfaces your buyers are likely to use.
+
+Then log each meaningful finding with five fields.
+
+### Signal
+
+What changed in the answer layer?
+
+This should be observable, not interpretive. For example: "Perplexity is now citing an old directory profile for the company description" or "Gemini describes the offer as content marketing rather than AI visibility strategy."
+
+### Commercial risk
+
+Why does this matter to the buyer journey?
+
+The answer might create the wrong comparison set, weaken the perceived value, route the buyer to the wrong page, overstate a capability, hide the strongest proof, or make the company sound interchangeable.
+
+If there is no commercial risk, mark the finding as watch or ignore.
+
+### Owner
+
+Who can change the underlying signal?
+
+Do not assign every item to "marketing" by default. Route the issue to the person or function that controls the relevant public claim, sales motion, product language, technical surface, or leadership decision.
+
+### Action
+
+What should change?
+
+This might be a service-page rewrite, a comparison page, a canonical claim update, a clearer product description, a sales enablement note, a refreshed third-party profile, a stronger case example, or a technical clean-up that helps crawlers and search systems understand the site.
+
+For Google specifically, keep the caveat intact. Do not treat `llms.txt`, special AI markup, arbitrary chunking, or hyper-specific structured-data tricks as required levers for Google AI visibility; they are not required levers for Google AI visibility. Clean technical foundations, accessible pages, clear canonical content, useful structured data where appropriate, and authoritative public information still matter. There is just no magic AI-visibility switch hiding in a single file.
+
+### Review date
+
+When will the team check whether the signal moved?
+
+Some changes should be reviewed in the next cadence. Others need more time. The point is to make follow-up explicit instead of hoping the next report remembers the previous decision.
+
+## The decision buckets
+
+A lightweight rhythm works best when it uses a small number of decision buckets.
+
+### Fix now
+
+Use this for commercially harmful findings.
+
+Wrong category. Wrong buyer. Misleading claim. Stale source supporting a critical description. Competitor adjacency that changes the buying frame. A next step that sends qualified buyers away from the right commercial path.
+
+These items need an owner and a deadline.
+
+### Route
+
+Use this when the finding is real but the right response sits outside the review group.
+
+For example, a sales team may need to confirm whether a repeated AI-generated objection matches live deals. Product may need to clarify whether a capability should be public. Leadership may need to decide whether the company wants to own a narrower category.
+
+Route means: this is not a content chore yet. It is a decision that needs the right owner.
+
+### Watch
+
+Use this for movement that may become meaningful but is not yet worth a fix.
+
+A source appears once. A competitor shows up in one low-intent prompt. A phrasing change is less strong but not wrong. A citation changes but remains credible. A surface behaves differently from the others without changing the buyer's likely understanding.
+
+Watch prevents the team from overreacting while still preserving the signal.
+
+### Ignore
+
+Use this more often than most teams expect.
+
+Ignore unrealistic prompts, vanity mentions, low-risk phrasing differences, and answer changes that no real buyer would care about. A cadence that cannot ignore noise becomes impossible to sustain.
+
+The discipline is not to chase every answer. The discipline is to make better decisions from the answer layer.
+
+## The readout leaders actually need
+
+A leadership-grade AI visibility review should be short.
+
+It should not say:
+
+> We ran prompts across five systems and collected 42 screenshots.
+
+It should say:
+
+> Three buyer-intent prompts stayed commercially healthy. Two category prompts showed mild drift. One comparison prompt created the wrong competitor set. The source issue appears to come from an outdated third-party description. Marketing owns the category-page update, sales will validate whether the competitor confusion appears in calls, and the next review will check whether the answer layer stabilises.
+
+That is the difference between a report and an operating rhythm.
+
+The first gives the team evidence.
+
+The second turns evidence into ownership.
+
+## What this changes about GEO work
+
+When AI visibility becomes a cadence, the work becomes more precise.
+
+The team stops asking broad questions like "How do we rank in AI?" and starts asking operational questions:
+
+- Which buyer questions are producing weak answers?
+- Which weak answers have commercial consequences?
+- Which public claims need to become canonical?
+- Which sources are helping or hurting the answer layer?
+- Which competitor adjacencies are useful, and which ones distort the market frame?
+- Which next steps should the answer make easier for a buyer?
+- Which team owns the fix?
+- What will we check next time?
+
+That is a healthier way to run GEO.
+
+It treats answer engines as part of the market interface, not as a novelty channel. It respects the fact that different systems behave differently without turning every variation into an emergency. It gives marketing, sales, product, technical owners, and leadership a shared way to decide what deserves action.
+
+The report is the start.
+
+The rhythm is the strategy.
+
+AI visibility only becomes commercially useful when somebody owns what happens after the baseline.


### PR DESCRIPTION
## Summary
- Adds Build in Public Day 45: Make AI Visibility an Operating Rhythm, Not a Report.
- Uses the approved final artifact only.
- Keeps the Google AI caveat intact: no claim that llms.txt, special AI markup, chunking, or over-focused structured data are required levers for Google AI visibility.

## Checks
- python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-45.md
- python3 -m py_compile tools/validate_frontmatter.py
- python3 -m mkdocs build
- content/process assertions for required GEO terms and forbidden public/process phrases

## Payload
- docs/blog/posts/daily-blog-day-45.md