### PR TITLE
docs: add day 46 build in public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-46.md
+++ b/docs/blog/posts/daily-blog-day-46.md
@@ -1,0 +1,192 @@
+---
+title: "Day 46: Stop Averaging the Answer Engines"
+date: 2026-06-05
+slug: "day-46-stop-averaging-the-answer-engines"
+description: "A diagnostic memo for CMOs, Marketing Directors, and founders: blended AI visibility scores can hide surface-specific failures across ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - marketing measurement
+  - executive diagnostics
+geo_tactics:
+  - Audit ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search as separate buyer-facing surfaces rather than blending them into one average score.
+  - Compare each surface on retrieval behaviour, citation visibility, recency, comparison framing, answer format, buyer expectation, and next-step fit.
+  - Prioritise surface-specific fixes when one answer engine creates a commercially material failure that the blended dashboard hides.
+  - "Keep the Google caveat clear: llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 46: Stop Averaging the Answer Engines
+
+A blended AI visibility score is comfortable because it gives leadership one number.
+
+That is also why it can be dangerous.
+
+A CMO can look at a dashboard and see that the brand is “doing well” across answer engines. The score is green. Mentions are up. Screenshots make the work feel real.
+
+But the buyer does not experience the average.
+
+The buyer asks ChatGPT for a shortlist. Or uses Claude to understand the category. Or opens Perplexity because they want citations. Or sees an AI-assisted search summary while comparing providers. Or uses Gemini inside a wider research flow. Each surface has its own interface, source mix, answer style, freshness profile, and user expectation.
+
+If the average hides that variation, it can create false confidence.
+
+A brand might score well overall while one surface misclassifies the company, another cites stale sources, another omits the brand from comparison questions, and another gives the right mention but sends the buyer towards the wrong next step.
+
+For CMOs, Marketing Directors, and founders, the question is not:
+
+> What is our AI visibility score?
+
+It is:
+
+> Which answer surface is shaping which buyer decision, and where is the commercial failure?
+
+## The average is not the market
+
+Averaging makes sense when the underlying units are similar enough to combine. Answer engines are not identical.
+
+ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search surfaces can all influence discovery, but they do not always behave like the same channel. They may retrieve different material, expose different sources, prefer different levels of caution, handle recency differently, produce different answer formats, and serve buyers at different moments in the research process.
+
+That means a single blended score can flatten the exact differences a team needs to understand.
+
+Imagine an AI visibility report that says a specialist agency has an 82% visibility score across priority prompts. That sounds strong. But the surface-level view says something else:
+
+- ChatGPT mentions the agency, but describes it as a general SEO provider.
+- Claude explains the category, but omits the agency in comparison prompts.
+- Perplexity includes the agency, yet cites an old third-party profile.
+- Gemini uses the right category language, but suggests generic education instead of evaluation.
+- AI-assisted search is broadly correct, but sends clicks to a weaker page.
+
+The average is green. The buying surfaces are not.
+
+This is where a measurement report can protect the wrong conclusion: the blended number moves up while one surface still creates a specific commercial risk.
+
+## Each surface carries a different buyer expectation
+
+The practical reason to separate answer engines is not technical neatness. It is buyer psychology.
+
+A buyer using different surfaces is often asking for different kinds of help.
+
+When they ask ChatGPT for options, they may expect a synthesised recommendation: who belongs in the market and why. If the answer puts your company in the wrong category, the buyer’s shortlist starts in the wrong place.
+
+When they use Claude, they may expect careful explanation: tradeoffs, caveats, and conceptual clarity. If the answer explains the category but never connects you to the buyer problem, visibility elsewhere does not help in that research moment.
+
+When they use Perplexity, they often care about visible grounding. The citation path matters because the interface trains the buyer to inspect sources. If the brand is mentioned but grounded in stale or thin material, the buyer may not see evidence strong enough to keep moving.
+
+When they use Gemini or an AI-assisted search summary, the answer may sit closer to classic search behaviour. The summary, visible links, and source ordering can all affect what the buyer clicks next.
+
+The job of GEO is not to make every answer identical. The job is to make the brand legible and commercially useful inside the surfaces buyers actually use.
+
+## Diagnose surface-specific failures
+
+A useful review should separate the score by answer surface before deciding what to fix.
+
+The diagnostic does not need to be complicated. For each important buyer question, record the answer surface, brand treatment, visible sources where available, comparison frame, freshness, and suggested next step.
+
+Then look for failures that only appear when the surfaces are split.
+
+### 1. Category failure
+
+The answer describes the company as the wrong kind of provider.
+
+This is one of the most expensive issues because category controls the buyer’s comparison set. A GEO strategy partner compressed into “SEO agency”, “content marketing company”, “AI consultancy”, or “web design supplier” will be judged against the wrong alternatives.
+
+If only one answer surface is doing this, the average may not look alarming. But that surface may still matter if it is where senior buyers are forming their first shortlist.
+
+The fix is not to chase that model with hacks. The fix is to inspect the public signals it may be using: page titles, service descriptions, third-party profiles, comparison pages, case language, and ambiguous category phrases.
+
+### 2. Source failure
+
+The answer is visible, but the grounding is weak.
+
+Some surfaces expose citations directly. Others make the source path less obvious. Either way, the source mix matters when buyers can inspect it or when it shapes the generated summary.
+
+A brand can be mentioned from an old directory listing, an outdated partner profile, a thin article, or a page that no longer reflects the offer. The answer may be technically true and still commercially stale.
+
+One engine may rely on current owned pages. Another may lean on older public material. Treating both as a single score hides the source problem.
+
+### 3. Comparison failure
+
+The answer includes the brand but places it beside the wrong alternatives.
+
+The question is immediate: on this surface, for this buyer query, does the comparison frame help or harm the sale?
+
+If a founder asks for agencies that help B2B companies improve visibility in AI answers, and one surface lists the brand beside generic SEO tools, content marketplaces, and unrelated software vendors, the buyer may infer the wrong level of service before ever visiting the site.
+
+A high aggregate visibility score will not show that. The surface-level comparison frame will.
+
+### 4. Recency failure
+
+The answer uses an old version of the company.
+
+This is common for teams that have repositioned, narrowed their audience, changed packages, launched a stronger offer, or published better proof. The company’s public reality has moved, but one surface still describes the previous version.
+
+Recency failures are awkward because they sound plausible: close enough that nobody flags them as wrong, but old enough to attract weaker-fit buyers or understate the current value proposition.
+
+The team should ask: if a buyer read only this answer, would they understand the company we are selling today?
+
+### 5. Next-step failure
+
+The answer gives the right mention and the wrong action.
+
+This is easy to miss because the brand appears. But a mention is only valuable if the buyer knows what to do with it.
+
+One surface might recommend educational articles when the buyer is ready to compare providers. Another might send them to a generic homepage instead of a relevant service page. Another might describe the company well, but fail to connect the answer to a commercial evaluation path.
+
+For a marketing team, this is not a model personality quirk. It is a routing problem in the buyer journey.
+
+## Decide by commercial severity, not statistical neatness
+
+Once the surfaces are split, the leadership conversation becomes more useful.
+
+The team can stop arguing about whether the blended score is good and start asking which failure deserves action.
+
+A surface-specific failure deserves attention when it affects one of four commercial outcomes:
+
+- the buyer enters the wrong category;
+- the buyer compares the company against the wrong alternatives;
+- the buyer trusts weak, stale, or misleading source material;
+- the buyer is sent towards a next step that does not match intent.
+
+That does not mean every surface variation becomes urgent work. Some differences are harmless: concision, wording, or reordered examples. A healthy GEO programme should tolerate normal variation.
+
+The point is to separate harmless variation from commercial distortion.
+
+A red issue on one buying surface can matter more than a small improvement in the overall average. If Perplexity is where buyers inspect evidence, a stale citation path may deserve priority. If ChatGPT is where buyers build shortlists, a category error there may matter more than a modest score decline elsewhere. If AI-assisted search is driving clicks to the wrong page, the visible journey may need fixing even when the summary sounds acceptable.
+
+The operating principle is simple: do not optimise the average until you understand the surface.
+
+## What to review in the next baseline
+
+A better AI visibility baseline should still include summary metrics. Leadership needs a fast way to see movement.
+
+But the summary should sit on top of a surface-level diagnostic, not replace it.
+
+For each priority buyer question, review:
+
+- which answer surfaces were checked;
+- whether the brand appeared and how prominently;
+- the category, competitors, sources, freshness, and next step;
+- whether the issue is harmless variation, watchlist material, or a commercial fix.
+
+This turns AI visibility from a vanity dashboard into a decision tool.
+
+It also prevents the team from copying the wrong playbook from one surface to another. The response to a stale citation path is different from the response to category drift. The response to a weak comparison frame is different from the response to a missing next step.
+
+And for Google-related surfaces, keep the caveat clean: there is no validated requirement that brands need llms.txt, special AI markup, arbitrary chunking, or over-focused structured data to be visible. Machine-readable exports can be useful for other agents or non-Google discovery contexts, but they should not be sold as magic switches for Google AI visibility.
+
+## The useful question is surface-specific
+
+The next time an AI visibility dashboard says the brand is improving, ask to see the split.
+
+Averages are useful for trend awareness. They are not enough for commercial diagnosis.
+
+A blended score can tell you whether the weather looks better from a distance. It cannot tell you whether one buyer-facing door is still locked.
+
+CMOs, Marketing Directors, and founders need to know where answer engines differ, which differences matter, and which surface-specific failures deserve scarce attention.
+
+That is the work.
+
+Do not average away the buyer’s actual experience.


### PR DESCRIPTION
## Summary
- Adds the approved Day 46 Build in Public post: “Stop Averaging the Answer Engines”.
- Applies a minimal YAML-safe quote around one `geo_tactics` item so the repository frontmatter validator treats it as a string.
- Keeps the PR payload isolated to `docs/blog/posts/daily-blog-day-46.md`.

## Checks
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-46.md` — passed
- targeted frontmatter/forbidden-term assertion — passed
- `python3 -m mkdocs build` — passed (with existing RoamLinks/nav warnings)

## Payload verification
- `git diff --name-only origin/main...HEAD` returns only `docs/blog/posts/daily-blog-day-46.md`
