### PR TITLE
docs: add day 47 build in public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-47.md
+++ b/docs/blog/posts/daily-blog-day-47.md
@@ -1,0 +1,237 @@
+---
+title: "Day 47: Turn AI Visibility Findings Into a Sales Conversation"
+date: 2026-06-06
+slug: "day-47-turn-ai-visibility-findings-into-a-sales-conversation"
+description: "A commercial packaging note for CMOs, Marketing Directors, and founders: turn AI visibility diagnostics into the revenue risks, competitor advantages, proof gaps, and next actions that sales and leadership can actually discuss."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - sales enablement
+  - executive decision-making
+  - commercial strategy
+geo_tactics:
+  - Package answer-engine findings as buyer-facing decisions, not screenshot decks or raw visibility data.
+  - Translate ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search outputs into revenue risk, competitor advantage, proof gaps, message changes, and next actions.
+  - "Build readouts around the question: which finding changes what we say, prove, fix, or sell next?"
+  - "Keep the Google caveat clear: llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 47: Turn AI Visibility Findings Into a Sales Conversation
+
+Most AI visibility diagnostics still arrive in the wrong shape for a commercial team.
+
+They show prompts, screenshots, mentions, citations, answer snippets, competitor names, and surface-by-surface observations. Some of that detail matters. But a CMO, Marketing Director, or founder is rarely short of another report.
+
+They are short of a better sales conversation.
+
+The useful question is not only:
+
+> What did the answer engines say about us?
+
+It is:
+
+> Which finding changes what we say, prove, fix, or sell next?
+
+That is where AI visibility becomes commercially useful. ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search can expose how the market interface currently describes a brand, a category, a competitor set, a proof base, and a buying question. But the output only matters if leadership can turn that exposure into a decision.
+
+A diagnostic that stops at visibility data creates interest. A diagnostic that packages the findings into sales and board-level choices creates movement.
+
+## The report is not the commercial asset
+
+A raw AI visibility report can be impressive without being useful.
+
+It may show that the brand appears in several answers. It may show that one answer engine uses better category language than another. It may show that a competitor is mentioned more often for a priority prompt. It may show that a surface is relying on stale third-party material or sending buyers towards a weaker page.
+
+Those are valid observations. But they are not yet commercial decisions.
+
+A leadership team still has to ask:
+
+- Does this change how buyers understand the company?
+- Does this make a competitor easier to trust, compare, or shortlist?
+- Does this expose a proof gap that sales keeps having to explain manually?
+- Does this suggest that a message, page, offer, deck, or comparison point needs to change?
+- Does this deserve action now, or is it just diagnostic noise?
+
+If the report does not help answer those questions, the team gets an artefact instead of an agenda.
+
+That distinction matters because AI visibility work touches several commercial systems at once. It affects positioning, pipeline quality, sales enablement, board confidence, product language, competitor strategy, and content priority. Treating it as a standalone visibility report makes the work look narrower than it is.
+
+The better packaging is a decision memo: here is what answer engines currently imply to the market, here is the commercial risk or opportunity, and here is the conversation the leadership team should have next.
+
+## Package each finding around a buyer decision
+
+The fastest way to make a diagnostic useful is to attach each finding to the buyer decision it could influence.
+
+Not every AI answer matters equally. Some answers are top-of-funnel educational summaries. Some create shortlists. Some compare alternatives. Some explain a category. Some expose citations. Some route the buyer to a next step. A finding becomes commercially meaningful when it changes the buyer's likely interpretation or action.
+
+A raw finding sounds like this:
+
+> Perplexity cited an old third-party description in a comparison answer.
+
+A commercial finding sounds like this:
+
+> A buyer comparing GEO partners may see an outdated description before they see our current offer. That creates a sales risk: we may be evaluated against the wrong category and need either a stronger owned comparison page, an updated third-party profile, or a clearer sales follow-up that corrects the frame.
+
+The second version is easier to discuss because it names the buying moment, the commercial risk, and the likely response.
+
+The same translation can be applied across different kinds of findings:
+
+- If ChatGPT describes the company as a generic SEO agency, the issue is not wording. The issue is category compression that changes the shortlist.
+- If Claude explains the problem well but does not connect the brand to the buyer's situation, the issue is not absence alone. The issue is a missing bridge between market education and commercial relevance.
+- If Perplexity cites weak or stale sources, the issue is not only citation quality. The issue is whether visible grounding makes the company easier or harder to trust.
+- If Gemini or an AI-assisted search summary sends buyers to a generic page, the issue is not just routing. The issue is whether high-intent demand lands on the right commercial next step.
+
+This is the packaging shift: move from "what the model did" to "what the buyer may now believe or do."
+
+## Sales needs usable language, not just diagnostics
+
+AI visibility findings often reveal language gaps that sales teams feel before marketing teams can measure them.
+
+A buyer may arrive on a call with the wrong assumption because an answer engine compressed the offer into a familiar but weaker category. A founder may ask why a competitor appears more specific in comparison answers. A procurement stakeholder may repeat an outdated claim from a public profile. A CMO may ask for proof that the company solves the problem the AI answer described.
+
+Those are not abstract GEO issues. They are sales moments.
+
+A useful readout should therefore include buyer-facing language the team can actually use. For example:
+
+- "If a buyer asks why we are not just an SEO agency, use this category distinction."
+- "If a prospect mentions Competitor X, lead with this difference in decision support, not with a feature list."
+- "If the answer engine cites the old profile, acknowledge the old framing and redirect to the current offer."
+- "If the buyer asks whether this is a reporting project, explain the decision output: risks, proof gaps, competitor movement, and next actions."
+
+This does not mean turning every diagnostic into a script. It means translating answer-engine observations into language that protects the commercial conversation.
+
+Marketing can still own the public fixes. Sales still needs the bridge language while those fixes take effect.
+
+## The board needs tradeoffs, not screenshots
+
+Board-facing AI visibility work should be even more compressed.
+
+A board does not need a tour of prompts. It needs to understand whether the market is interpreting the company in a way that helps or harms the plan.
+
+A useful board-level summary might say:
+
+> Across priority buyer questions, answer engines understand the broad category but understate our strategic role. Competitors are easier to compare because they have clearer public proof around outcomes. The immediate risk is not brand absence; it is value compression. Recommended action: sharpen the offer page, add one commercial comparison asset, and update sales language around why this work affects pipeline quality rather than just visibility.
+
+That is a different readout from "we appeared in six out of ten prompts."
+
+The board version should answer four questions:
+
+1. What does the answer layer currently imply about the company?
+2. Where does that implication create revenue risk or competitive advantage?
+3. What decision does leadership need to make?
+4. What will change in the public story, sales motion, or proof base as a result?
+
+This turns AI visibility from a novelty topic into an executive operating input.
+
+The board does not need to become fluent in every answer engine. It needs confidence that the team can identify which AI-surfaced market signals are commercially material.
+
+## The strongest output is a short decision table
+
+A practical AI visibility readout can be simple.
+
+For each meaningful finding, use six fields.
+
+### 1. Finding
+
+What did the answer layer show?
+
+Keep this observable. Name the prompt family, surface, answer behaviour, competitor mention, source pattern, or next-step issue. Avoid turning the finding into a theory too early.
+
+### 2. Buyer implication
+
+What might a qualified buyer believe after seeing it?
+
+This is the commercial translation layer. The buyer may infer that the company belongs in a different category, lacks proof, serves a different audience, offers a lower-value service, or is harder to compare than a competitor.
+
+### 3. Sales conversation
+
+What should the team be ready to say?
+
+This field forces the finding out of the dashboard and into the market. If the issue is category compression, write the category distinction. If the issue is competitor advantage, write the comparison point. If the issue is proof weakness, write the claim that needs evidence.
+
+### 4. Decision needed
+
+What choice has to be made?
+
+Some findings require a content update. Others require a positioning decision, offer clarification, proof investment, third-party profile refresh, sales enablement note, or technical clean-up. The decision should be explicit enough that a team can say yes, no, or not now.
+
+### 5. Owner
+
+Who can actually move the signal?
+
+Marketing may own the page. Sales may own the deck and objection handling. Leadership may own the category choice. Product may own capability language. Technical owners may own crawlability, templates, canonical URLs, ordinary structured data where useful, and accessible public pages.
+
+For Google-related surfaces, keep the caveat intact. Do not present `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required levers for Google AI visibility. There is no magic Google AI switch in a single file. Good public information, accessible pages, coherent canonical content, technically sound pages, and useful structured data where appropriate still matter.
+
+### 6. Next action
+
+What changes now?
+
+A next action might be a service-page rewrite, a comparison asset, a proof insert, a sales note, a third-party profile update, a revised offer explanation, a stronger case example, or a decision to watch the issue until it appears in higher-intent prompts.
+
+This table does not need to be long. In fact, it should not be. Three commercially material findings are more useful than forty screenshots with no decision attached.
+
+## The diagnostic should change the first call
+
+The best test of an AI visibility baseline is whether it improves the next sales conversation.
+
+If the diagnostic says buyers are seeing the wrong category, the first call should include sharper category framing.
+
+If it says competitors are easier to understand, the first call should include a cleaner contrast.
+
+If it says answer engines surface weak proof, the first call should bring stronger evidence forward earlier.
+
+If it says buyers are being routed towards the wrong next step, the site and follow-up should make the right step obvious.
+
+If it says the company is absent from an important buying question, the team should decide whether that question belongs in the market strategy or whether it is a low-fit query that does not deserve attention.
+
+This is the commercial standard: a finding earns priority when it changes what the team says, proves, fixes, or sells next.
+
+That standard also protects the team from overreacting. Some answer changes are harmless. Some prompts are unrealistic. Some surface differences do not affect a real buying journey. Some visibility wins look good in a report but do not change pipeline quality.
+
+The discipline is not to chase every answer. The discipline is to convert the right answers into better decisions.
+
+## Make AI visibility easier to buy
+
+For many leadership teams, GEO still feels abstract until it is tied to a commercial conversation they already recognise.
+
+A founder understands category risk. A CMO understands message-market fit. A Marketing Director understands campaign priority and proof gaps. A sales leader understands objection handling, competitor framing, and pipeline quality. A board understands revenue risk, strategic clarity, and whether the company is easier or harder to buy.
+
+AI visibility becomes easier to buy when the diagnostic speaks in those terms.
+
+Not:
+
+> Here are the screenshots.
+
+But:
+
+> Here are the three findings that change the sales conversation.
+
+Not:
+
+> We need to improve our AI visibility score.
+
+But:
+
+> Buyers asking this question are being shown the wrong category, weaker proof, and a competitor with a clearer comparison frame.
+
+Not:
+
+> The model gave us a strange answer.
+
+But:
+
+> The public market layer contains enough ambiguity that this answer is plausible, and that ambiguity is affecting how buyers evaluate us.
+
+That is the packaging work.
+
+The answer engines expose the signal. The commercial team has to turn it into a decision.
+
+For CMOs, Marketing Directors, and founders, the useful output of an AI visibility baseline is not a prettier report. It is a sharper conversation: what revenue risk is visible, what competitor advantage is emerging, what proof gap is slowing trust, and what action should the team take next?
+
+If a finding cannot answer that, it belongs in the appendix.
+
+If it can, it belongs in the sales conversation.


### PR DESCRIPTION
## Summary
- Adds Day 47 Build in Public post: "Turn AI Visibility Findings Into a Sales Conversation"
- Keeps the angle focused on commercial packaging for CMOs, Marketing Directors, and founders
- Preserves the Google AI visibility caveat around llms.txt, special AI markup, arbitrary chunking, and over-focused structured data
- Quotes two `geo_tactics` list items so YAML frontmatter validates cleanly

## Checks
- Content/frontmatter assertions passed for title/date/slug, buyer/GEO relevance, forbidden terminology, Google caveat, and raw HTML
- `python tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-47.md` passed
- `python -m pytest -q tests/test_validate_frontmatter.py` passed (3 tests)
- `mkdocs build --strict` fails on existing site warnings (RoamLinks/AutoLinks/nav warnings), not this post
- `mkdocs build` passed

## Payload
- Intended one-file payload only: `docs/blog/posts/daily-blog-day-47.md`
