### PR TITLE
docs: add daily blog day 48

### DIFF
--- a/docs/blog/posts/daily-blog-day-48.md
+++ b/docs/blog/posts/daily-blog-day-48.md
@@ -1,0 +1,245 @@
+---
+title: "Day 48: Decide What Not to Teach the Market"
+date: 2026-06-07
+slug: "day-48-decide-what-not-to-teach-the-market"
+description: "A decision framework for CMOs, Marketing Directors, and founders: stop stale, duplicate, ambiguous, or internal public artefacts from teaching answer engines and buyers the wrong commercial story."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - content governance
+  - marketing leadership
+  - answer engines
+geo_tactics:
+  - Create a deliberate do-not-teach lane for stale, duplicate, ambiguous, internal, or low-confidence public artefacts before producing more GEO content.
+  - Decide whether each weak artefact should be retired, redirected, rewritten, noindexed or kept private, preserved as an internal source, or assigned an owner and canonical page.
+  - Review ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search exposure for wrong-category, wrong-offer, wrong-proof, and wrong-next-step signals.
+  - "Keep the Google caveat clear: llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 48: Decide What Not to Teach the Market
+
+Buyers do not judge a company from the content calendar. They judge it from the public evidence they can find, the answer layer that summarises that evidence, the competitor comparison it creates, and the sales conversation that follows. A stale page can therefore cost more than traffic. It can make the company look like the wrong category of provider, send a serious buyer towards the wrong next step, force sales to correct basic assumptions, and reduce leadership confidence in the market story.
+
+Most GEO conversations start with an additive instinct.
+
+Publish clearer pages. Add stronger proof. Explain the category better. Create comparison assets. Make the offer easier for ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search surfaces to understand.
+
+That work matters. But it is not the whole job.
+
+A company can publish better material and still leave old, duplicate, vague, or internal-facing artefacts in public view. Those weaker pages may look harmless because nobody is actively promoting them. They may sit outside the main navigation, survive from an old campaign, live in forgotten folders, or appear only through search, links, feeds, scraped mirrors, third-party references, or answer-engine retrieval.
+
+The market does not care whether the page is strategically current.
+
+If it is public, it can still teach.
+
+For CMOs, Marketing Directors, and founders, the practical GEO question is not only:
+
+> What should we publish next?
+
+It is:
+
+> What should we stop teaching the market?
+
+## The public corpus includes the pages you forgot
+
+Buyers and answer engines do not share a leadership team's internal map of what counts as current.
+
+A team may know that an old services page is no longer the real offer. It may know that a campaign landing page was written for a different audience. It may know that a draft-like explainer was never meant to carry the category. It may know that a historical description is technically accurate but commercially misleading now.
+
+The buyer does not know that.
+
+An answer engine does not know that in the way your team does. It may infer category, offer, proof, audience, competitors, and next steps from whatever public material appears accessible, repeated, linked, recent enough, or semantically plausible.
+
+That creates a specific failure mode: the company thinks it has moved on, but the public corpus still contains enough old signal for the market to describe the previous version.
+
+The result is not always a dramatic hallucination. Often it is worse because it sounds almost right:
+
+- the company is described as a lower-value category;
+- the current offer is compressed into an old service line;
+- a buyer is sent towards education when they are ready to evaluate;
+- a proof point is missing because the answer found an older page first;
+- a comparison frame includes competitors that no longer reflect the desired market;
+- a sales follow-up starts by undoing confusion rather than advancing intent.
+
+That is pipeline leakage before sales sees the lead.
+
+## More content does not fix contradictory content
+
+A common response to weak AI visibility is to produce more public material.
+
+More explainers. More thought leadership. More case studies. More service pages. More comparison content. More machine-readable exports for non-Google agents or other discovery contexts where they are genuinely useful.
+
+Those assets can help. But they do not automatically neutralise old public signals.
+
+If the new page says the company helps leadership teams build GEO strategy, while an old page says the company writes SEO blog content, the answer layer may not choose the better story. It may blend them. If one page says the offer is strategic and another says the offer is tactical, a buyer may interpret the company as tactical. If several old pages repeat a weaker phrase, one new page may not be enough to overcome the pattern.
+
+This is why negative publishing discipline matters.
+
+GEO is not only about making the right information available. It is also about reducing the authority of the wrong information.
+
+That does not mean deleting content indiscriminately. Deletion can break links, lose useful search equity, remove helpful context, or erase a page that still serves a narrow audience. The point is not to make the site smaller by reflex.
+
+The point is to decide what each artefact is allowed to teach.
+
+## Create a do-not-teach lane
+
+A useful content governance process should include a lane for material that should not keep shaping the market story.
+
+That lane can be simple. During a GEO review, separate questionable public artefacts into six decisions.
+
+### 1. Keep and strengthen
+
+Some pages are directionally right but underpowered.
+
+They describe the correct offer, audience, or category, but lack proof, specificity, buyer language, or next-step clarity. These should stay public and get stronger. They are not dangerous; they are incomplete.
+
+The decision is to improve them rather than replace them with another asset elsewhere. Assign an owner, name the canonical page they support, and make the fix visible enough that the team can tell when the page has stopped being a weak signal.
+
+### 2. Rewrite
+
+Some pages sit in the right place but teach the wrong version.
+
+They may use dated positioning, name an old buyer, overemphasise a service the company no longer wants to lead with, or describe a capability in language that creates the wrong comparison set.
+
+Rewrite these when the URL, context, and demand are still useful but the message is stale. The page remains part of the public corpus, but its teaching role changes.
+
+### 3. Redirect
+
+Some pages have value as paths, but not as destinations.
+
+An old campaign page, legacy offer page, thin article, or outdated explainer may still receive links or search visits. If it no longer deserves to educate the market directly, redirect it to a current page that answers the same underlying buyer need better.
+
+This protects buyers from the wrong next step while preserving a cleaner route through the site.
+
+### 4. Retire, noindex, or keep private
+
+Some artefacts should not keep functioning as public evidence.
+
+Internal scaffolding, draft strategy notes, temporary planning documents, unapproved language, old positioning explorations, and operational checklists may be useful to the team but dangerous as market signals. They can contain half-decisions, abandoned phrases, or context that makes sense internally and misleads externally.
+
+The decision here is not one-size-fits-all. Retire the page when it no longer has a useful role. Noindex it when it must remain accessible for a limited audience but should not be encouraged as a discovery surface. Keep it private when the material is really an internal source rather than public content.
+
+If a buyer or answer engine can find it, it is no longer just internal material. It is teaching the market.
+
+### 5. De-emphasise without pretending it disappeared
+
+Some material is still useful, but only in a limited context.
+
+A detailed reference page, partner-specific note, event page, or niche explainer might not be wrong. It may simply be too narrow, too technical, or too easy to misread as a primary market signal.
+
+In those cases, the decision may be to keep it accessible for people who need it while removing it from prominent navigation, hubs, or internal linking patterns that imply strategic importance.
+
+This is a careful choice. Hidden does not mean invisible. If a page remains public, it may still be discoverable. The question is whether the team wants to reduce its prominence without pretending it has disappeared.
+
+### 6. Update the owner and canonical page
+
+Some weak artefacts persist because nobody owns them.
+
+The page may be acceptable on its own, but unclear in relation to the current proposition. It may point to the wrong service page. It may repeat old language because no team has been made responsible for keeping it aligned.
+
+For these, the decision is operational: name the owner, name the canonical page, and decide what role the artefact plays. If it cannot be tied to a current canonical story, it should not keep freelancing as public evidence.
+
+## Score artefacts by buyer risk
+
+The do-not-teach lane becomes easier when the team uses commercial risk rather than personal preference.
+
+For each questionable artefact, ask five questions.
+
+### What category could this teach?
+
+Would the page make the company sound like the wrong kind of provider?
+
+This is the highest-risk failure because category controls the comparison set. A strategic GEO partner described through old SEO, content production, web design, or generic AI consultancy language may be evaluated against cheaper, broader, or less relevant alternatives.
+
+If the page teaches the wrong category, rewrite, redirect, retire, or make it private before publishing more assets that fight against it.
+
+### What offer could this teach?
+
+Does the page make an old service look like the current commercial centre?
+
+Legacy pages often preserve offers that made sense at the time: audits, workshops, technical fixes, campaign support, content packages, one-off reports. If the current offer is a higher-level strategy, operating model, or decision programme, those older pages can pull buyers towards the wrong buying motion.
+
+The issue is not whether the old offer ever existed. The issue is whether the company wants the market to keep learning it now.
+
+### What proof could this teach?
+
+Does the artefact understate the evidence base?
+
+A weak case snippet, thin testimonial page, old results claim, or generic proof section can become the visible grounding for a buyer's trust. If stronger proof exists elsewhere, the weak artefact may make the company look less credible than it is.
+
+Do not let obsolete proof become the easiest proof to find.
+
+### What next step could this teach?
+
+Where would a buyer go after reading it?
+
+A page can be factually acceptable and commercially harmful if it routes the buyer to the wrong action. It may invite them to read more when they need to compare. It may point them towards a generic contact form when a specific service path would be better. It may encourage a tactical request when the right sale is a strategic conversation.
+
+For AI-assisted search and answer surfaces that expose links or suggest next actions, this matters. The answer may not only describe the company; it may influence the buyer's route.
+
+### What confidence could this imply?
+
+Does the artefact look more authoritative than it should?
+
+Some pages are dangerous because they appear official. A polished but outdated page can carry more weight than a messy draft. A page with a confident title, strong metadata, or repeated internal links may look like a current canonical signal even when the team considers it old.
+
+If an artefact looks authoritative, it should be held to an authoritative standard.
+
+## Do not confuse machine-readable with market-ready
+
+Machine-readable exports and structured content can be useful in the right contexts.
+
+They may help non-Google agents, internal workflows, partner systems, documentation consumers, or other discovery paths understand the shape of a site. They can also make teams more disciplined about what their content says.
+
+But they are not a substitute for public judgement.
+
+For Google-related AI visibility, do not treat `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required switches. There is no single file that makes Google understand the company correctly. Accessible pages, coherent public information, technically sound implementation, useful ordinary structured data where appropriate, and strong canonical content still matter.
+
+The deeper lesson is this: making information easier for machines to consume can amplify both the good and the bad.
+
+If the public corpus contains stale or contradictory artefacts, exporting, indexing, summarising, or repackaging it more neatly may simply distribute the confusion faster.
+
+Govern the source before celebrating the feed.
+
+## The leadership decision is permission
+
+A do-not-teach lane works because it turns content clean-up into a leadership decision.
+
+Instead of asking, "Should we tidy this page?" the team asks:
+
+> Are we willing for this artefact to keep teaching buyers and answer engines who we are?
+
+That question changes the discussion.
+
+A founder may tolerate an imperfect blog post. They may not tolerate a page that makes the company look like the wrong category. A CMO may postpone a full site rewrite. They may still decide that an old campaign page should redirect because it pulls high-intent visitors into an obsolete offer. A Marketing Director may keep a technical explainer live while removing it from a hub that makes it look like a core proposition.
+
+The decision is not cosmetic. It is permission.
+
+Every public artefact has one of three states:
+
+- we are happy for this to teach the market;
+- we are temporarily tolerating this, with a named owner and fix;
+- we do not want this teaching the market anymore.
+
+If a team cannot place an artefact into one of those states, the artefact is governing the story by default.
+
+## Negative publishing discipline is a GEO advantage
+
+The companies that win in answer surfaces will not only be the companies that publish the most.
+
+They will be the companies that make their public story easier to infer correctly.
+
+That means stronger canonical pages, better proof, clearer comparison language, and more useful buyer education. It also means retiring, rewriting, redirecting, noindexing, de-emphasising, privatising, or re-owning the artefacts that teach the wrong lesson.
+
+This is less glamorous than a new campaign. It is also more commercially mature.
+
+A buyer does not experience your content strategy. They experience the public evidence they can find, the answer layer that summarises it, and the sales conversation that follows.
+
+If stale artefacts are still teaching the market, more content may only add another voice to the argument.
+
+Before asking what to publish next, ask what should stop speaking.
+
+That is the discipline: decide what not to teach the market.


### PR DESCRIPTION
## Summary
- Publishes Day 48: “Decide What Not to Teach the Market” for 2026-06-07.
- Adds one blog post focused on negative publishing / retirement discipline for GEO.
- Preserves the buyer-risk framing and Google caveat while avoiding repo-cleanup or internal automation framing.

## Changed file
- docs/blog/posts/daily-blog-day-48.md

## Checks run
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-48.md` — passed
- Targeted content checks for answer-engine mentions, Google caveat, concrete disposition decisions, and forbidden internal framing — passed
- `python3 -m pytest tests/test_validate_frontmatter.py` — 3 passed
- `python3 -m mkdocs build --strict` — failed because the existing site emits 90 unrelated warnings (pre-existing nav/RoamLinks/AutoLinks warnings)
- `python3 -m mkdocs build` — passed

## Reviewer / freshness notes
- Selected candidate scored 29/30.
- Freshness centre is negative publishing/do-not-teach governance, not repo churn, implementation chronology, or CSS cleanup.
- I made a metadata-only YAML safety adjustment by quoting the `geo_tactics` item containing `: ` so the repo frontmatter validator and MkDocs parser treat it as a string.
