### PR TITLE
Day 49: Choose the Buyer Question Before You Chase the Mention

### DIFF
--- a/docs/blog/posts/daily-blog-day-49.md
+++ b/docs/blog/posts/daily-blog-day-49.md
@@ -1,0 +1,285 @@
+---
+title: "Day 49: Choose the Buyer Question Before You Chase the Mention"
+date: 2026-06-08
+slug: "day-49-choose-the-buyer-question-before-you-chase-the-mention"
+description: "A commercial GEO note for CMOs, Marketing Directors, and founders: define the buyer questions that represent real demand before interpreting AI-answer mentions, absences, competitors, or share-of-answer movement."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - buyer intent
+  - prompt strategy
+  - commercial positioning
+geo_tactics:
+  - "Design the prompt and query portfolio around commercially material buyer decisions before treating mentions or absences as useful signals."
+  - "Map questions by buyer intent, category fit, shortlist influence, competitor set, proof need, and sales-conversation impact."
+  - "Interpret broad-prompt zeroes across ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search as diagnostic inputs, not definitive proof of market invisibility."
+  - "Keep the Google caveat clear: llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 49: Choose the Buyer Question Before You Chase the Mention
+
+A zero mention can look like a failure.
+
+A team runs a few broad prompts across ChatGPT, Claude, Gemini, Perplexity, or an AI-assisted search surface. The brand does not appear. Competitors do. The dashboard turns red. The instinct is immediate: publish more content, add comparison pages, create proof assets, tune the site, and start asking why the answer engines have missed the company.
+
+Sometimes that instinct is right.
+
+But not always.
+
+A zero mention on a broad query such as "best AI agencies" may not mean the market cannot see the company. It may mean the prompt is too vague, the category is wrong, the buyer moment is unclear, the competitor set is too broad, or the business has not decided which question it actually wants to own.
+
+For CMOs, Marketing Directors, and founders, that distinction matters. The commercial problem is not "how do we get mentioned everywhere?" It is "which buyer questions would change pipeline quality, shortlist inclusion, or sales conversations if we appeared with the right frame?"
+
+<!-- more -->
+
+GEO work becomes expensive when the team chases mentions before choosing the buyer question.
+
+## Broad prompts can hide the real market
+
+Broad prompts are tempting because they feel obvious.
+
+A leadership team wants to know whether the company appears for the biggest category phrases. An agency wants to know whether it is named among the "best" providers. A founder wants to know whether ChatGPT or Gemini recognises the brand when someone asks for help. A CMO wants a clean baseline they can revisit every month.
+
+Those prompts can be useful, but they are rarely enough.
+
+"Best AI agencies" is not one buying question. It is a pile of possible intents:
+
+- a founder looking for a strategic partner;
+- a marketing leader looking for GEO support;
+- a product team looking for agent implementation;
+- a procurement team building a longlist;
+- a student or journalist looking for examples;
+- a curious operator with no budget and no defined problem.
+
+If the brand does not appear in that answer, the absence is not automatically a commercial emergency. The query may be too generic for the desired buying motion. It may reward size, fame, listicle presence, directories, or broad agency categories rather than the specific commercial moment the business cares about.
+
+A specialist company can lose a broad prompt and still be well positioned for a better question.
+
+The opposite is also true. A company can win a broad mention and still fail the buyer moment that matters. If it appears in a generic shortlist but is described as the wrong kind of provider, compared against weak-fit alternatives, or routed towards a vague next step, the mention may create false comfort.
+
+The first job is not to collect mentions. The first job is to choose the questions that represent demand.
+
+## A buyer question is a positioning decision
+
+Prompt selection looks like measurement work, but it is really positioning work.
+
+The questions a team chooses tell answer engines, analysts, agencies, executives, and internal stakeholders what market the company believes it is in. They define the category being tested, the competitors being treated as relevant, the buyer problem being prioritised, and the outcome the business wants to influence.
+
+That means the prompt portfolio should not be built only from keyword volume, executive curiosity, or whatever appears in a competitor report.
+
+It should start with commercial judgement.
+
+For each candidate question, ask:
+
+- Would a qualified buyer ask this before choosing a provider?
+- If we appeared in the answer, would it improve shortlist inclusion, not just brand awareness?
+- Would the right mention make sales easier by setting the correct category, problem, proof, or next step?
+- Does the question describe the market we want to compete in, or a broad category where we will always look less obvious?
+- Would absence here signal a commercial gap, or merely a noisy prompt?
+
+Those are leadership questions, not dashboard questions.
+
+A prompt can be technically measurable and commercially useless. It can produce a neat score while failing to represent any real buying decision. It can make the team optimise for a phrase that attracts the wrong audience, the wrong competitors, or the wrong expectations.
+
+The prompt set becomes a strategy document whether the team admits it or not.
+
+## Separate category-entry questions from shortlist questions
+
+One reason teams overreact to broad absence is that they mix different kinds of questions into one bucket.
+
+A useful GEO baseline should separate at least four question types.
+
+### 1. Category-entry questions
+
+These are the questions buyers ask when they are still naming the problem.
+
+Examples might include:
+
+- "How do B2B companies improve visibility in AI answers?"
+- "What is generative engine optimisation for professional services?"
+- "How should a marketing team prepare for AI-assisted search?"
+
+The goal here may not be a direct shortlist mention. It may be category framing: does the answer describe the problem in a way that makes the company's approach more legible? Does it name the right risks? Does it avoid compressing the work into old SEO language or generic content production?
+
+A brand absence here is not always fatal. A bad category frame may be more commercially important than a missing brand.
+
+### 2. Problem-aware questions
+
+These are questions from buyers who know the pain but have not yet chosen the solution shape.
+
+They may ask:
+
+- "Why is our company not appearing in ChatGPT answers?"
+- "How do we know which AI search questions matter for pipeline?"
+- "What should a CMO measure in an AI visibility audit?"
+
+These questions are often more valuable than generic category prompts because they reveal a real internal discussion. The buyer is not asking for a directory. They are trying to decide what the problem means and what kind of work deserves budget.
+
+For these prompts, the answer should help the buyer understand the commercial issue and make the company easier to consider.
+
+### 3. Shortlist questions
+
+These are closer to vendor selection.
+
+They might include:
+
+- "Which agencies help B2B companies with generative engine optimisation?"
+- "Who can help a founder improve AI visibility before a fundraise?"
+- "Best GEO consultants for a specialist professional services firm"
+
+Here, mentions matter more directly because the buyer is constructing a market. But the query still needs discipline. A shortlist question should include enough context to represent the desired buyer, not just the broadest possible category.
+
+If the team only tracks "top AI consulting firms", it may be testing against global consultancies, software vendors, research labs, and generalist agencies. That might be interesting. It may not be the buying moment the business can actually win.
+
+### 4. Comparison and proof questions
+
+These questions appear when the buyer is trying to reduce risk.
+
+They may ask:
+
+- "How do GEO agencies differ from SEO agencies?"
+- "What proof should I ask for before hiring an AI visibility partner?"
+- "How should I compare specialist AI visibility agencies?"
+
+For these, the issue is not only whether the brand appears. The issue is whether the answer teaches the right evaluation frame. If the answer says buyers should look for volume of content, generic technical fixes, or a magic file for Google AI visibility, the market has been taught the wrong test.
+
+The company may need to influence the criteria before it worries about the mention.
+
+## Treat absence as a question, not a verdict
+
+A small prompt run can be useful source material. It can show that a brand is missing from broad AI-answer outputs. It can show that competitors appear more often. It can reveal whether the answer engines understand the category, which sources they prefer, and how they describe the buyer problem.
+
+But a small run should not be treated as definitive market evidence.
+
+If four broad prompts return zero mentions, the right response is not panic. It is diagnosis.
+
+Ask what the absence might mean:
+
+- Is the query too broad for the company's actual category?
+- Is the prompt written in buyer language or internal language?
+- Does the answer reveal a competitor set the business actually wants to join?
+- Are the visible sources dominated by directories, listicles, old SEO pages, or broad consulting brands?
+- Does the question represent a real sales conversation, or just executive curiosity?
+- Would winning this prompt attract the right buyer, or simply make the dashboard look better?
+
+This protects the team from false conclusions.
+
+A zero on "What are the best AI agencies?" may be a useful warning. It may show that the company lacks enough public category signal, third-party reference, comparison language, or proof to be considered in broad answers. But it may also show that the phrase is too undefined to guide action.
+
+The absence becomes valuable only when the team can connect it to a commercial decision.
+
+## Build a prompt portfolio from the sales motion backwards
+
+The strongest prompt sets are built backwards from the revenue conversation.
+
+Start with the moments that would change the business if answer engines mediated them badly:
+
+- a high-fit buyer trying to name the problem;
+- a CMO deciding whether GEO is strategic or experimental;
+- a founder comparing specialist partners against generalist agencies;
+- a Marketing Director deciding what evidence to trust;
+- a board asking whether the company is visible in the new discovery layer;
+- a sales team hearing that a competitor appeared first in an AI-generated shortlist.
+
+Then turn those moments into question families.
+
+A practical portfolio might include:
+
+1. Category-definition questions: how should the market understand the problem?
+2. Buyer-problem questions: what pain or risk is the buyer trying to solve?
+3. Solution-shape questions: what kind of help does the buyer think they need?
+4. Shortlist questions: which providers does the answer layer recommend?
+5. Comparison questions: what criteria, competitors, and tradeoffs appear?
+6. Proof questions: what evidence does the answer suggest buyers should trust?
+7. Next-step questions: where does the answer send a high-intent buyer?
+
+Each family should have a commercial owner. Not because every prompt needs a meeting, but because the team needs to know why the question exists.
+
+If nobody can explain the buyer moment behind a prompt, it should not drive the strategy.
+
+## The competitor set is part of the test
+
+Prompt choice also decides which competitors count.
+
+A broad query may compare a specialist agency with global consultancies, SEO shops, content platforms, automation tools, software vendors, and familiar enterprise brands. That can make the specialist look absent even when the real buyer would never compare all of those options in one decision.
+
+A more precise buyer question can produce a more useful competitor set.
+
+For example, "top AI consulting firms" may surface companies that sell transformation programmes, engineering capacity, or enterprise advisory work. That does not necessarily answer who can help a CMO improve answer-engine visibility around commercially important buyer questions.
+
+The second question is narrower, but commercially sharper.
+
+This is not about hiding from competition. It is about measuring against the market the company is actually trying to win.
+
+If a team wants to enter a broader category, it should say so explicitly. Then broad-prompt absence becomes a positioning challenge: what public evidence, language, proof, and third-party validation would make the company plausible in that larger set?
+
+If the team wants to dominate a specialist question, it should not let generic category prompts distract the roadmap.
+
+## Share-of-answer only matters after question quality
+
+Share-of-answer metrics can be useful. They show whether a brand appears, how often it appears, which competitors appear alongside it, and whether visibility changes over time.
+
+But share-of-answer is only as good as the questions underneath it.
+
+A rising score on low-fit prompts may mean the team is becoming more visible to the wrong market. A falling score on broad prompts may matter less than a stable or improving presence on high-intent questions. A competitor may dominate generic lists while failing to appear in the precise buyer moments that lead to qualified conversations.
+
+This is why the prompt portfolio needs a quality review before the dashboard becomes a management tool.
+
+For each tracked question, label:
+
+- buyer stage;
+- commercial value;
+- category fit;
+- expected competitor set;
+- desired answer behaviour;
+- acceptable absence threshold;
+- owner and next action if the signal changes.
+
+Without that layer, the team risks treating every mention as equal and every absence as equally bad.
+
+They are not equal.
+
+A missing mention on a high-fit shortlist question may deserve immediate action. A missing mention on a vague category query may deserve investigation. A missing mention on a low-fit curiosity prompt may deserve no action at all.
+
+The discipline is knowing the difference before the report arrives.
+
+## Do not turn prompt design into technical superstition
+
+Once a team sees weak visibility, it is easy to look for a switch.
+
+A file. A markup pattern. A chunking method. A schema trick. A way to make the site easier for AI systems to ingest.
+
+Some machine-readable exports and structured approaches can be useful in the right context, especially for non-Google agents, internal knowledge flows, documentation consumers, or partner systems. Clean technical implementation matters. Accessible pages matter. Clear titles, canonical URLs, ordinary structured data where appropriate, and coherent public content all matter.
+
+But do not confuse those with a guaranteed Google AI visibility lever.
+
+For Google-related AI visibility, do not claim that `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data are required switches. They are not a substitute for deciding which buyer questions matter, publishing useful public information, and making the company easier to understand in ordinary web contexts.
+
+Technical neatness cannot rescue a vague market question.
+
+If the business has not chosen the buyer moment, the cleanest feed in the world may only make the wrong question easier to measure.
+
+## The useful baseline starts with a decision
+
+Before the next GEO baseline, leadership should make one decision that sounds simple but is often avoided:
+
+> Which buyer questions do we want answer engines to mediate in our favour?
+
+Not every question. Not every mention. Not every broad category phrase that might flatter the dashboard.
+
+The questions that matter are the ones that shape pipeline quality, shortlist inclusion, competitor comparison, proof expectations, or the first sales conversation.
+
+Once those questions are chosen, absence data becomes useful. A zero mention can be classified. A competitor appearance can be interpreted. A weak category frame can be fixed. A noisy prompt can be retired. A content asset can be prioritised because it supports a real buyer decision, not because a dashboard cell turned red.
+
+That is the commercial discipline.
+
+Chasing mentions is easy because it gives the team something visible to improve.
+
+Choosing the buyer question is harder because it forces the business to say what demand it actually wants.
+
+But that is where GEO becomes strategic.
+
+Do not chase the mention before you choose the market moment.


### PR DESCRIPTION
## Summary
- Add Build-in-Public Day 49 post on choosing buyer questions before measuring AI-answer mentions.
- Keep the GEO frame focused on prompt/query portfolio design, buyer intent mapping, category fit, competitor sets, and interpreting noisy answer-surface results.

## Checks
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-49.md` — passed
- `python3 tools/validate_frontmatter.py` — existing baseline failures remain on older Day 1-17/23/24 posts missing descriptions; Day 49 passes
- `mkdocs build` — passed, with existing RoamLinks/AutoLinks/nav warnings

## Payload
- `docs/blog/posts/daily-blog-day-49.md` only
