### PR TITLE
docs: add Day 50 GEO threshold discipline post

### DIFF
--- a/docs/blog/posts/daily-blog-day-50.md
+++ b/docs/blog/posts/daily-blog-day-50.md
@@ -1,0 +1,273 @@
+---
+title: "Day 50: Define the Threshold Before You Trust the Tracker"
+date: 2026-06-09
+slug: "day-50-define-the-threshold-before-you-trust-the-tracker"
+description: "A measurement discipline for CMOs, Marketing Directors, and founders: define commercial decision thresholds before treating AI-visibility telemetry as a management signal."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - measurement
+  - telemetry
+  - commercial decision-making
+geo_tactics:
+  - Define fix, investigate, watch, and ignore thresholds before reviewing AI-visibility movement across ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search.
+  - Separate material movement from answer volatility by tying share-of-answer, competitor adjacency, citation drift, and surface-specific changes to commercial consequences.
+  - Use thresholds to prevent leadership teams from overreacting to noisy prompt runs or underreacting to changes that could affect pipeline, shortlist inclusion, competitor framing, or sales conversations.
+  - "Keep the Google caveat clear: llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 50: Define the Threshold Before You Trust the Tracker
+
+A tracker can make a weak decision look scientific.
+
+It can show a line moving up, a mention disappearing, a competitor appearing beside the brand, a source changing, or a surface behaving differently from last week. It can make leadership feel closer to the answer-engine market because there is finally a repeatable signal instead of a few screenshots from ChatGPT, Claude, Perplexity, Gemini, or an AI-assisted search result.
+
+That is useful.
+
+It is also dangerous if the business has not decided what counts as a material change.
+
+For CMOs, Marketing Directors, and founders, the commercial value of AI-visibility telemetry is not that it produces more evidence. It is that it helps the team decide what to fix, what to investigate, what to watch, and what to ignore.
+
+Without thresholds, the tracker becomes another noisy dashboard.
+
+<!-- more -->
+
+The team does not need more movement. It needs a prior agreement about which movement matters.
+
+## A signal is not a decision
+
+Answer-engine visibility is volatile by nature.
+
+Different systems retrieve different sources, express different degrees of confidence, include different competitors, and compress the market in different ways. The same brand can appear strongly in one surface, weakly in another, and not at all in a third. A prompt can return a slightly different answer because the phrasing changed, the model changed, the source mix changed, the search layer changed, or the system simply generated a different summary.
+
+That does not make the data useless.
+
+It means the data needs rules before it becomes management input.
+
+A leadership team should not treat every mention gained as progress or every mention lost as a crisis. A one-position change on a low-fit question may be noise. A competitor appearing beside the brand on a high-fit shortlist question may be commercially significant. A source swap may be harmless if the answer still frames the company correctly. It may be urgent if the new source teaches the wrong category, wrong proof, wrong competitor set, or wrong next step.
+
+The difference is not visible from the metric alone.
+
+It comes from the threshold attached to the metric.
+
+## Thresholds turn telemetry into operating discipline
+
+A useful threshold answers a practical question:
+
+> If this signal changes, what should the business do?
+
+That question is more important than the chart.
+
+For each tracked buyer question, leadership should decide in advance what level of movement belongs in four lanes.
+
+### 1. Fix
+
+This is the lane for movement that could damage commercial outcomes now.
+
+Examples:
+
+- the brand disappears from a high-intent shortlist question it previously owned;
+- a competitor starts being recommended in the answer position where the brand used to appear;
+- the answer describes the company as the wrong kind of provider;
+- the visible sources route buyers towards an outdated offer or weak proof point;
+- the answer shifts from a qualified next step to a vague educational path;
+- sales starts hearing a competitor frame that matches the changed answer output.
+
+The fix lane should be small. If every movement becomes a fix, the team will burn attention on noise. But if no movement ever qualifies, the tracker is theatre.
+
+A fix threshold should name the commercial consequence. Not "share-of-answer fell by five points." Instead: "we lost presence on a buyer question that shapes shortlist inclusion for our best-fit market."
+
+That is a different conversation.
+
+### 2. Investigate
+
+This is the lane for movement that may matter, but needs diagnosis before action.
+
+A citation may change. A competitor may appear near the brand. A surface may stop using a familiar source. A prompt family may drift down for two runs in a row. The answer may still be commercially acceptable, but the direction deserves attention.
+
+The investigation should ask:
+
+- did the change appear on one surface or several?
+- did it affect one prompt, a question family, or a whole buyer stage?
+- did the competitor set become more or less relevant?
+- did the source mix move towards stronger evidence, weaker evidence, directories, listicles, forums, old pages, or third-party summaries?
+- did the answer preserve the right category, proof standard, and next step?
+- would a qualified buyer think differently after reading this output?
+
+Investigation protects the team from premature publishing, premature panic, and premature confidence.
+
+It also protects the content roadmap. A weak signal may not require a new page. It may require rewriting an existing page, strengthening a comparison frame, clarifying a service description, improving ordinary structured data where appropriate, updating a public proof asset, correcting stale material, or doing nothing until the movement repeats.
+
+### 3. Watch
+
+This is the lane for movement that is interesting but not yet actionable.
+
+The brand may fluctuate within an expected band. A competitor may appear in a broad category answer that does not represent the desired buyer. A source may change without altering the commercial meaning of the answer. A low-volume prompt may produce an odd result once.
+
+A watch threshold should define what would make the signal graduate.
+
+For example:
+
+- watch unless the movement persists for three consecutive runs;
+- watch unless the same competitor appears across two high-fit question families;
+- watch unless the answer starts changing the category frame;
+- watch unless the source drift moves from neutral sources to visibly weaker or stale sources;
+- watch unless sales hears the same market framing from prospects.
+
+This is how a team respects volatility without ignoring it.
+
+The watch lane is not a dumping ground. It is a holding pattern with a trigger.
+
+### 4. Ignore
+
+This is the most underrated lane.
+
+A good tracker should help the business ignore the right things.
+
+Some prompt movement is not commercially material. Some competitor appearances are irrelevant because the competitor set is wrong. Some mentions are vanity mentions. Some absences occur on questions no buyer would ask before choosing a provider. Some one-off runs are too unstable to shape budget, positioning, or content production.
+
+If the team cannot ignore low-value signals, the dashboard will govern the strategy by distraction.
+
+The ignore lane should be explicit. It should say: this movement is below the decision threshold, outside the target buyer moment, or not repeated enough to justify action.
+
+That is not complacency. It is management hygiene.
+
+## The threshold belongs to the buyer moment
+
+A single global threshold will usually fail.
+
+A 10% share-of-answer change is not equally important everywhere. It depends on the question, the buyer stage, the surface, the competitor set, the answer quality, and the commercial role of the prompt.
+
+A small movement on a high-intent shortlist question can matter more than a large movement on a generic category prompt. A citation change on a comparison question can matter more than a mention gain on an awareness prompt. A competitor moving closer to the brand in Claude may matter less than the same competitor appearing as the recommended option in Perplexity or an AI-assisted search surface that exposes links and next steps.
+
+The threshold should be attached to the buyer moment, not just the metric.
+
+For each tracked question, define:
+
+- buyer stage: category entry, problem-aware, shortlist, comparison, proof, or next step;
+- commercial consequence: pipeline quality, shortlist inclusion, competitor framing, objection handling, or sales enablement;
+- expected volatility: how much answer variation is normal before action;
+- surface sensitivity: whether ChatGPT, Claude, Perplexity, Gemini, or AI-assisted search has a specific role in the buyer journey;
+- competitor relevance: which neighbouring brands matter and which are noise;
+- source sensitivity: which citation or source changes would alter trust;
+- action threshold: fix, investigate, watch, or ignore.
+
+This makes telemetry legible to leadership.
+
+The dashboard no longer asks, "Did the number move?"
+
+It asks, "Did the market move in a way that affects a buyer decision we care about?"
+
+## Competitor adjacency needs a threshold too
+
+Competitor movement is especially easy to misread.
+
+A brand may not lose a mention, but the answer may start placing a competitor beside it. Or the competitor may appear in a stronger role: first recommendation, safer option, more established provider, better-fit specialist, lower-risk choice, or clearer next step.
+
+That can matter even if the brand is still visible.
+
+But not every adjacency is a threat.
+
+A broad prompt may surface global consultancies, SEO agencies, software vendors, analysts, agencies, and tools in one mixed answer. A specialist company may appear near businesses it does not actually compete with. The adjacency may reveal category confusion, but it may not represent a real sales contest.
+
+A good threshold separates three cases.
+
+First: irrelevant adjacency. The competitor appears because the prompt is too broad or the answer is mixing categories. This may be ignored or used to improve the prompt portfolio, but it should not trigger a positioning panic.
+
+Second: diagnostic adjacency. The competitor is relevant, but the answer is not yet favouring them in a commercially meaningful way. Watch or investigate the source mix, language, and repeated pattern.
+
+Third: material adjacency. The competitor is repeatedly framed as the stronger answer for a buyer question that affects shortlist inclusion, budget justification, or sales conversations. That belongs in the fix lane.
+
+The question is not, "Did a competitor appear?"
+
+The question is, "Did the answer change the buyer's comparison in a way that could cost us the conversation?"
+
+## Source drift is only useful when tied to consequence
+
+Citation and source movement can also become noisy if it is tracked without thresholds.
+
+A source change may be harmless. The answer may still describe the company accurately, present the right offer, cite a strong public page, and guide the buyer towards a useful next step.
+
+Or the source change may be the first sign of a real problem.
+
+The answer may stop grounding itself in the company's current public explanation and start relying on an older page, a third-party directory, a thin comparison list, a stale description, or a general article that compresses the category. The output may still mention the brand, but the source context may teach a weaker story.
+
+That distinction matters.
+
+A source-drift threshold should define what kind of citation movement deserves action:
+
+- current core page to current supporting page: usually watch;
+- current page to stale page: investigate or fix depending on buyer risk;
+- owned source to third-party listicle: investigate, especially for shortlist questions;
+- strong proof source to weak proof source: investigate or fix;
+- category-defining source to generic SEO or AI article: fix if it changes the market frame;
+- no visible source change and no commercial meaning change: ignore.
+
+This prevents the team from treating every citation swap as an emergency while still catching the changes that could reshape trust.
+
+For Google-related AI visibility, the same caveat applies: do not reduce the response to a magic switch. `llms.txt`, special AI markup, arbitrary chunking, and over-focused structured data are not required levers for Google AI visibility. Clean technical implementation, accessible pages, coherent public content, canonical URLs, useful ordinary structured data where appropriate, and strong public evidence all matter. But thresholds should be commercial before they become technical.
+
+The business problem is not "which file made the answer change?"
+
+It is "did the answer change enough to alter what a buyer believes?"
+
+## One-off prompt runs are not strategy
+
+One-off prompt runs are useful for exploration.
+
+They can reveal a blind spot, show unexpected competitors, expose category confusion, or give leadership a visceral sense of how answer engines describe the market.
+
+But a one-off run should not become the strategy by itself.
+
+If a single prompt result can redirect the content roadmap, the roadmap is too fragile. If a single screenshot can trigger a rewrite, a new comparison page, a technical sprint, or a leadership alarm, the team has not built a measurement system. It has built a reaction system.
+
+Thresholds create distance between observation and action.
+
+They say: this signal is interesting, but it must repeat. This movement is notable, but only on one surface. This competitor is visible, but not in a buyer moment we prioritise. This answer is imperfect, but still commercially acceptable. This change is small, but it hits a high-value shortlist question and needs work now.
+
+That distance is where judgement enters the system.
+
+## The leadership work happens before the report
+
+The best time to define thresholds is before the first dashboard review.
+
+Once the numbers arrive, every stakeholder has an incentive to interpret them through their own anxiety, curiosity, or agenda. Sales notices the competitor. Marketing notices the missing citation. The founder notices the broad absence. The content team notices the implied workload. The agency notices the opportunity to recommend action.
+
+That is normal.
+
+It is also why the decision rules should exist first.
+
+Before reviewing a GEO telemetry report, agree:
+
+1. Which buyer questions are commercially material?
+2. Which surfaces matter for each question family?
+3. Which competitor appearances are relevant enough to track?
+4. Which source changes would alter trust or next-step behaviour?
+5. Which answer-quality failures require immediate action?
+6. Which movements need repetition before action?
+7. Which signals should be ignored even if they look dramatic?
+
+These are management decisions, not analytics details.
+
+The tracker can measure movement. It cannot decide commercial importance on its own.
+
+## A useful tracker reduces noise
+
+The promise of AI-visibility telemetry is not perfect certainty.
+
+Answer engines will keep changing. Surfaces will differ. Prompt runs will vary. Competitors will move. Sources will drift. Buyers will ask messy questions that do not fit neat dashboards.
+
+The point is not to remove all volatility.
+
+The point is to stop volatility from becoming strategy.
+
+A useful tracker helps leadership see the market without being governed by every flicker. It turns answer movement into classified signals. It protects the team from vanity gains, noisy losses, and broad prompts that do not represent demand. It also catches real drift early enough to protect pipeline, shortlist inclusion, competitor framing, and sales conversations.
+
+That only works if the threshold exists before the signal.
+
+Define what you will fix, investigate, watch, and ignore.
+
+Then trust the tracker.


### PR DESCRIPTION
## Summary
- Adds Day 50 Build in Public post on defining decision thresholds before trusting AI-visibility tracker movement.
- Keeps the post buyer-readable for CMOs, Marketing Directors, and founders.
- Preserves Google AI caveats around `llms.txt`, special AI markup, arbitrary chunking, and structured data without overclaiming.

## Verification
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-50.md`
- `python3 -m pytest tests/test_validate_frontmatter.py -q`
- `mkdocs build`

## Payload
- `docs/blog/posts/daily-blog-day-50.md` only
