### PR TITLE
Day 51: Match the Asset to the Answer Surface

### DIFF
--- a/docs/blog/posts/daily-blog-day-51.md
+++ b/docs/blog/posts/daily-blog-day-51.md
@@ -1,0 +1,215 @@
+---
+title: "Day 51: Match the Asset to the Answer Surface"
+date: 2026-06-10
+slug: "day-51-match-the-asset-to-the-answer-surface"
+description: "A decision framework for CMOs, Marketing Directors, and founders: match each GEO asset to the answer surface and buyer moment it is meant to influence."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - content strategy
+  - buyer journeys
+geo_tactics:
+  - Map each public asset to the answer surface, buyer moment, and commercial decision it is meant to support across ChatGPT, Claude, Perplexity, Gemini, and AI-assisted search.
+  - Separate the roles of category explainers, comparison frames, proof pages, tool pages, checklists, source trails, and next-step pages instead of relying on one generic GEO page.
+  - Design assets around summaries, citations, links, competitor lists, source paths, and follow-up routes so answer engines can support the right buyer decision.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems, not llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as required switches."
+---
+
+# Day 51: Match the Asset to the Answer Surface
+
+Most wasted GEO spend does not fail because the brand published nothing.
+
+It fails because the brand published one generic page and expected it to do seven different jobs.
+
+A CMO, Marketing Director, or founder does not need "more content" as an abstract goal. They need the right public asset to help a qualified buyer make the next decision: understand the category, compare options, trust the claim, try the tool, follow the source trail, or take the next step.
+
+That distinction matters more in answer engines than it did on a traditional website journey. ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other AI-assisted search surfaces do not all expose the same path. Some compress a market into a short summary. Some show links prominently. Some lean on source trails. Some place competitors next to each other. Some push the buyer towards a follow-up question before they ever click.
+
+If every one of those surfaces is expected to use the same generic page, the brand is asking one asset to behave like an explainer, comparison, proof pack, tool, checklist, citation source, and conversion page at the same time.
+
+It usually becomes none of them.
+
+<!-- more -->
+
+The publishing question is not, "Do we have a page about this?"
+
+It is, "Which answer surface and buyer moment is this page meant to support?"
+
+## One page cannot carry the whole buyer route
+
+A generic GEO page often looks efficient from inside the business.
+
+It can describe the offer, mention the category, include a few claims, add a call to action, link to a tool, gesture at proof, and contain enough terminology to feel complete. It gives leadership something visible to point at. It gives the team a destination for campaigns, internal links, and answer-engine monitoring.
+
+But answer surfaces do not reward completeness in the same way a stakeholder review does.
+
+When an answer engine summarises a market, it is trying to assemble a useful response from sources that can play specific roles. It may need a neutral definition, a clear category boundary, a comparison frame, a credible proof point, a next-step path, or a source that confirms a claim. A single dense sales page may not be the best source for all of those jobs.
+
+The buyer has the same problem.
+
+A founder asking ChatGPT what GEO is does not need the same asset as a Marketing Director comparing GEO agencies. A CMO asking Perplexity for evidence of AI-search visibility work does not need the same page as an operator looking for an llms.txt generator or an internal team trying to decide what to fix first. A buyer who lands from an AI-assisted search result may need a confident next step, while a buyer still inside a conversational answer may need a cleaner category explanation before they click anything.
+
+The commercial mistake is treating those moments as one journey stage called "traffic".
+
+They are different decisions.
+
+Different decisions need different public assets.
+
+## Start with the answer surface
+
+The asset map should start with the surface, not the content format.
+
+A practical GEO asset plan asks:
+
+- where will the buyer encounter the answer: ChatGPT, Claude, Perplexity, Gemini, Google AI features, classic organic search, a comparison list, a citation trail, or a shared answer from someone else?
+- what is the surface likely to expose: summary language, citations, links, competitor adjacency, source trails, follow-up prompts, or a traditional result page?
+- what is the buyer trying to decide at that moment: define the category, shortlist providers, compare options, validate proof, try something, brief a team, or book a conversation?
+- what public asset would make the next decision easier?
+
+That last question is the work.
+
+A category explainer helps the system and the buyer understand what the market is. A comparison frame helps the buyer distinguish options without forcing them into a sales call too early. A proof page gives the answer something specific to cite when claims need backing. A tool page creates utility and demonstrates competence. A checklist or playbook helps an internal champion move the idea through the business. A source trail makes claims easier to verify. A next-step page turns interest into action.
+
+Those assets can support each other, but they should not collapse into each other.
+
+If the comparison page is forced to be the proof page, it becomes heavy. If the explainer is forced to be the sales page, it becomes biased. If the tool page is forced to explain the whole category, it becomes cluttered. If the next-step page is forced to carry every citation, it becomes difficult for a serious buyer to act.
+
+The answer surface tells you which job the asset needs to do first.
+
+## The asset roles are different
+
+A useful asset map separates roles before it separates formats.
+
+### 1. The category explainer
+
+This is the page that teaches the market clearly.
+
+It should answer the basic questions without sounding like a pitch deck: what the category is, why it exists, what problems it solves, what it does not solve, how it differs from adjacent disciplines, and which buyer situations make it relevant.
+
+In GEO, this matters because answer engines compress categories. If the public corpus teaches a vague or bloated definition, the answer may compress the brand into the wrong market. If the explainer is clean, the brand has a better chance of being associated with the right category boundary.
+
+The explainer is not there to close the deal. It is there to stop the market being taught badly.
+
+### 2. The comparison frame
+
+This asset helps a buyer distinguish choices.
+
+It might compare approaches, provider types, tooling categories, operating models, or build-versus-buy decisions. The best version does not pretend competitors do not exist. It gives the buyer a useful frame for deciding which type of option fits their context.
+
+This is especially important when answer surfaces place brands beside each other. Competitor adjacency is not only a measurement event. It is a publishing design problem. If the market has no clear comparison frame, the answer may invent one from directories, old lists, broad SEO pages, or whoever has explained the category most clearly.
+
+The comparison frame should make the right distinction easy to repeat.
+
+### 3. The proof or case page
+
+This asset supports belief.
+
+It should be specific enough to carry a claim: what changed, for whom, why it mattered, what constraints existed, what evidence supports the outcome, and what a buyer can reasonably infer from it.
+
+A proof page is different from a trust badge collection. It does not just say "we are credible". It gives answer engines and human buyers something concrete to use when the question becomes, "Can they actually do this?"
+
+The risk is making proof the whole strategy. Proof matters, but not every surface or buyer moment is asking for proof first. Sometimes the buyer is still trying to understand the category. Sometimes they need a comparison. Sometimes they need a next step.
+
+Proof should be close enough to support the claim, not so heavy that every asset turns into a case study.
+
+### 4. The tool page
+
+A tool page gives the buyer something to use.
+
+For GEO, that could be a generator, checker, template, calculator, validator, audit worksheet, or lightweight diagnostic. The commercial value is not only the utility. It is that the tool demonstrates how the company thinks.
+
+Answer engines may treat useful public tools differently from pure sales pages because they satisfy a different intent. A buyer looking for an llms.txt generator, an AI-visibility checklist, or a GEO audit template may not be ready to choose an agency. But they are revealing the work they are trying to do.
+
+A strong tool page should not be buried inside a generic service page. It should have a clear job, clear inputs, clear outputs, and a sensible route to the next asset.
+
+### 5. The checklist or playbook
+
+This asset helps an internal champion move.
+
+Many buyers do not need to be convinced in isolation. They need to explain the problem to a founder, marketing team, sales lead, technical lead, or board. A checklist or playbook gives them a portable structure: what to review, what to prioritise, what to ignore, what to escalate, and what good looks like.
+
+This is where GEO becomes commercially useful. The buyer is no longer passively reading an answer. They are turning the answer into an internal decision.
+
+A checklist should therefore be practical, not ornamental. It should help the buyer decide what to do on Monday morning.
+
+### 6. The source trail
+
+Some answer surfaces expose sources more visibly than others.
+
+Perplexity, Google AI features, and AI-assisted search experiences can make the source path part of the answer. ChatGPT, Claude, and Gemini may handle retrieval and citation behaviour differently depending on product mode and query, but the underlying principle still holds: if the public material is thin, stale, contradictory, or buried, the answer has less useful material to work with.
+
+A source trail is the public path that makes a claim verifiable. It can include canonical pages, docs, explainers, research notes, changelogs where appropriate, glossary entries, and linked supporting assets.
+
+The caveat matters. Google's AI features rely on Google's core Search ranking and quality systems. There is no responsible reason to tell a client that `llms.txt`, special AI markup, arbitrary chunking, or an over-engineered structured-data scheme is a magic switch for Google AI visibility. Machine-readable exports can be useful for cross-agent or non-Google discovery where validated, but they are not a substitute for strong, crawlable, useful public content.
+
+The source trail should make the truth easier to find. It should not become a ritual.
+
+### 7. The next-step page
+
+This is the page that helps a qualified buyer act.
+
+It should not try to teach the entire category from scratch. It should not carry every proof point. It should not behave like a dumping ground for every concern the business has.
+
+A good next-step page answers: who this is for, what problem they are likely facing, what happens next, what information is useful before a call, and why the action is worth taking now.
+
+This matters because AI-referred buyers often arrive with context already formed. They may have read a summary, compared options, followed a citation, or asked several follow-up questions before landing. Sending them to a generic page can flatten that intent.
+
+The next-step page should respect the buyer's momentum.
+
+## Build the map before producing the content
+
+The asset map does not need to be complicated.
+
+For each asset, define five fields:
+
+- buyer moment: category entry, comparison, proof, tool use, internal briefing, verification, or conversion;
+- answer surface: ChatGPT, Claude, Perplexity, Gemini, Google AI features, AI-assisted search, or classic organic search;
+- surface behaviour: summary, citation, link, competitor list, source trail, follow-up path, or result page;
+- asset role: explainer, comparison frame, proof page, tool page, checklist, source trail, or next-step page;
+- commercial decision: understand, shortlist, trust, try, brief, verify, or act.
+
+This is enough to expose weak assumptions.
+
+If every surface points to the same page, the strategy is probably too blunt. If every buyer moment points to a proof asset, the brand may be skipping education. If every asset tries to rank for every prompt, the team may be optimising for visibility instead of decision support. If the only next step is "book a call", the journey may be asking too much too early.
+
+The point is not to create a larger content backlog.
+
+The point is to stop producing assets without knowing which decision they are meant to change.
+
+## This is not another dashboard problem
+
+It is tempting to turn the asset map into another measurement exercise.
+
+That would miss the point.
+
+Surface-specific measurement is useful, but the publishing decision comes before the dashboard. The team needs to know what each asset is for before it can interpret whether answer-engine movement is good or bad.
+
+A mention gain on a weak generic page may not help the buyer. A citation to the wrong asset may create confusion. A comparison query that lands on a category explainer may leave the buyer without a useful frame. A proof question that lands on a tool page may demonstrate competence but fail to support the claim. A high-intent buyer who reaches a broad educational post may leave with more understanding but no next step.
+
+The operational question is simple:
+
+> If this answer surface sends the buyer here, does this asset help them make the next commercial decision?
+
+If the answer is no, the problem is not only visibility.
+
+It is asset-role mismatch.
+
+## The sharper discipline
+
+GEO is not a race to create the largest pile of AI-readable material.
+
+It is the discipline of making the right public facts, frames, tools, and next steps available at the moments when answer engines shape buyer decisions.
+
+That means a team should be able to say why each asset exists.
+
+This explainer teaches the category. This comparison frame protects the shortlist. This proof page supports the claim. This tool page creates useful interaction. This checklist helps the champion brief the team. This source trail makes the answer verifiable. This next-step page turns informed interest into action.
+
+When that map is clear, the content strategy becomes less noisy.
+
+The business stops asking whether it has enough pages.
+
+It starts asking whether each surface has the asset it needs to move the buyer one decision forward.


### PR DESCRIPTION
## Summary
- Adds the approved Day 51 build-in-public post: `docs/blog/posts/daily-blog-day-51.md`
- Preserves the approved asset-role/surface-matching thesis with a frontmatter validation fix for YAML parsing
- Keeps the PR payload isolated to the single intended blog post file

## Checks
- `python3` content assertions for title/date/slug, `<!-- more -->`, and forbidden-term absence: passed
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-51.md`: passed
- `mkdocs build --strict`: failed due to 90 pre-existing project warnings from roamlinks/autolinks/nav warnings, not this post
- `mkdocs build`: passed

## Payload
- `docs/blog/posts/daily-blog-day-51.md` only
