### PR TITLE
fix: point homepage audit CTA to contact page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ hero:
   note: "No automated SEO reports or sales calls. Just an empirical diagnostic of your AI visibility."
   actions:
     - text: "Request an Audit"
-      link: "mailto:drew@zeroshotagency.com"
+      link: "contact/"
       primary: true
     - text: "View Our Playbook"
       link: "strategy/"


### PR DESCRIPTION
## Summary
- change the homepage "Request an Audit" CTA from a direct mailto link to the contact page
- avoid the primary CTA linking to Cloudflare email-protection URLs

## Verification
- `/dev/shm/zsa-mkdocs-venv/bin/python -m mkdocs build`
- confirmed built homepage renders `Request an Audit` with `href="contact/"`
