### PR TITLE
docs: add day 52 build in public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-52.md
+++ b/docs/blog/posts/daily-blog-day-52.md
@@ -1,0 +1,200 @@
+---
+title: "Day 52: Audit the Competitor the Answer Engine Names First"
+date: 2026-06-11
+slug: "day-52-audit-the-competitor-the-answer-engine-names-first"
+description: "A practical diagnostic for CMOs, Marketing Directors, and founders: use competitor mentions in answer engines to find the signals that make another brand easier to recommend."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - competitor analysis
+  - positioning
+geo_tactics:
+  - Audit competitor visibility by buyer question, answer confidence, category/entity clarity, comparison framing, third-party citations, source freshness, and offer specificity.
+  - Treat share-of-answer as a diagnostic input, not a vanity scoreboard; ask what signals made a competitor easier to recommend for the specific buyer moment.
+  - Convert competitor answer visibility into positioning, content, proof, offer, and comparison-page decisions.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems, not llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as required switches."
+---
+
+# Day 52: Audit the Competitor the Answer Engine Names First
+
+The uncomfortable answer-engine audit is not the one where your brand is missing.
+
+It is the one where a competitor is named quickly, confidently, and with a clearer reason to believe.
+
+For a CMO, Marketing Director, or founder, that result can look like a visibility problem. The instinct is to ask, "How do we get mentioned there?" That is understandable, but too shallow. A mention is only the visible symptom. The useful question is why the answer engine found the competitor easier to recommend for that buyer question.
+
+Was the competitor's category clearer? Was their offer easier to describe? Did third-party sources repeat their positioning more consistently? Did they have fresher comparison material? Were they attached to a more specific use case? Did they publish proof in a form that made the recommendation less risky? Did the market simply have more public language for them than for you?
+
+That is the commercial diagnostic.
+
+Not, "Why are they winning the scoreboard?"
+
+"What signals made them the safer answer?"
+
+<!-- more -->
+
+## Competitive visibility is a market signal
+
+Answer engines do not surface competitors in a vacuum.
+
+When ChatGPT, Claude, Perplexity, Gemini, Google AI features, or AI-assisted search experiences name a provider, they are usually compressing a mix of public material: the brand's own pages, third-party mentions, comparison lists, reviews, articles, directories, documentation, news, and whatever current retrieval path is available for the query and product mode.
+
+The mechanics vary by surface. Some answers cite sources. Some do not. Some lean into web retrieval. Some produce a synthesis from model knowledge and available context. Google's AI features sit inside Google's broader Search ecosystem and quality systems, not a separate magic channel that can be switched on with special AI markup.
+
+But the strategic point is consistent enough to be useful.
+
+If a competitor is named more confidently than you, the answer is telling you something about the public market memory around that buyer question.
+
+That memory may be accurate, outdated, incomplete, or unfair. It may be shaped by old SEO pages, analyst language, category directories, review sites, partner pages, comparison posts, or the competitor's own cleaner messaging. It may overstate them. It may miss you. It may put you in the wrong comparison set.
+
+Either way, the answer is a diagnostic object.
+
+The risk is not that a dashboard shows one fewer mention this week. The risk is that a qualified buyer asks a serious question and receives a market frame that makes another company easier to understand, trust, and shortlist.
+
+That is lost consideration before your sales team ever knows the buyer exists.
+
+## Do not start by chasing the name-drop
+
+A competitor mention can create panic because it is concrete. Someone can screenshot it. A board member can forward it. A founder can ask why the company is not there. A marketing team can turn it into a tracking programme by the afternoon.
+
+The danger is responding with mention-chasing content.
+
+That usually creates generic pages with broad phrases, thin comparison copy, and forced references to every category term the team wants associated with the brand. It may increase the amount of public material, but it does not necessarily make the brand easier to recommend.
+
+A stronger audit starts with the competitor's advantage in the answer.
+
+Look at the answer and ask:
+
+- what role did the competitor play: category leader, specialist, cheaper option, enterprise option, technical option, local option, integration partner, or default example?
+- what language did the answer use to justify them?
+- did the answer cite or imply a source type: comparison article, review site, documentation, case study, marketplace, analyst note, news item, or the competitor's own page?
+- was the recommendation based on a specific use case, buyer type, geography, platform, integration, feature, proof point, or reputation signal?
+- what did the answer not say about us that a qualified buyer would need to know?
+
+Those questions move the team away from vanity visibility and towards commercial interpretation.
+
+The issue may not be that the brand needs a louder page. It may need a sharper category boundary, a more explicit comparison frame, a clearer offer, fresher third-party validation, a better explanation of who it is for, or a proof asset attached to the actual buyer question.
+
+## A compact competitor-answer audit
+
+A practical diagnostic does not need to become a research theatre.
+
+For one high-value buyer question, run the same question across the answer surfaces that matter to your market. Use realistic wording, not a keyword stuffed prompt. Capture the answers, citations where available, named providers, order, confidence language, and follow-up suggestions.
+
+Then audit the first-named competitor across six lenses.
+
+### 1. Market role
+
+What is the competitor being used as an example of?
+
+Are they presented as the category default, the enterprise-safe choice, the specialist, the technical leader, the accessible tool, the agency, the platform, the budget option, or the best-known brand?
+
+This matters because the answer engine may not be saying, "They are better." It may be saying, "They are easier to place in this market role."
+
+If your company wants that role, the audit should expose why the public corpus does not support it yet. If you do not want that role, the answer may reveal a category framing problem: buyers may be asking a question that places you in a comparison set you should either contest or avoid.
+
+### 2. Entity clarity
+
+Can the answer describe who the competitor is, what they do, who they serve, and what they are known for without hedging?
+
+Entity clarity is not only a technical SEO concern. It is a buyer comprehension issue. If public sources describe one competitor with stable language and describe your company with five drifting phrases, the answer has an easier job with them.
+
+Look for the repeated nouns and verbs around the competitor. Then compare your own public language. Are you consistently attached to the same category, buyer, problem, and offer? Or does the market have to reconcile a consultancy page, a product page, an old founder interview, a directory listing, and a few vague social posts?
+
+The answer engine is not the only reader struggling with that inconsistency. Buyers struggle with it too.
+
+### 3. Offer specificity
+
+What exactly is the competitor being recommended for?
+
+A competitor with a clear offer often beats a broader brand in answer environments because the recommendation can be made with less explanation. "Use this provider for X" is easier to answer than "consider this company that broadly helps with several adjacent things."
+
+This is where the audit becomes useful for positioning.
+
+If the competitor is recommended for a narrow use case, decide whether that use case is commercially important enough to contest. If it is, the response may be an offer page, a comparison frame, a use-case explainer, a diagnostic tool, or a stronger service package. If it is not, the team can stop treating that answer as a crisis.
+
+Not every competitor mention is worth fighting.
+
+### 4. Source pattern
+
+Where does the answer seem to get its confidence?
+
+For surfaces that show citations, inspect the cited sources. For surfaces that do not, inspect the likely public source pattern: competitor pages, third-party lists, reviews, comparison articles, partner pages, documentation, marketplace pages, podcasts, interviews, or news.
+
+The goal is not to reverse-engineer a secret ranking formula. It is to understand the evidence environment the buyer is being shown.
+
+A competitor might be ahead because five third-party pages repeat the same market role. They might have a comparison page that names the alternatives plainly. They might have fresher documentation. They might be included in directories that your buyer actually trusts. They might have old but still prominent content that defines the category in their favour.
+
+Once you know the source pattern, the fix becomes less mystical.
+
+You may need better owned content. You may need independent mentions. You may need a cleaner comparison page. You may need to update stale material. You may need partners, customers, or industry sources to describe the category with language that reflects the market as it is now.
+
+### 5. Proof shape
+
+What proof is attached to the competitor's recommendation?
+
+Proof does not have to be the main hook of every GEO discussion, but it matters when an answer is making a recommendation. A buyer asking "which agency should we speak to?" or "which platform is best for this use case?" is implicitly asking for risk reduction.
+
+The competitor's proof might be explicit: case studies, named customers, reviews, benchmarks, accreditations, integrations, public examples, or media coverage. It might also be structural: a long-running product, visible documentation, frequent updates, or multiple third-party sources saying the same thing.
+
+The audit should ask whether your proof supports the same buyer question.
+
+A strong proof point buried on a general page may not help. A claim with no specific example may not travel. A case study that proves the wrong outcome may not support the comparison. A testimonial that only says "great team" may not reduce risk for a CMO deciding whether this company belongs on the shortlist.
+
+The question is not, "Do we have proof?"
+
+It is, "Does the public proof make this recommendation easier to make?"
+
+### 6. Freshness and coverage
+
+Is the competitor's public material fresher or more complete around the buyer question?
+
+Answer visibility can lag reality. A company may have changed its offer, launched a stronger service, won better customers, or narrowed its positioning without that change becoming visible in the public corpus. Internally, the team knows the new story. Externally, the answer environment may still be reading last year's version.
+
+Check source dates, page updates, recent articles, comparison freshness, product language, and whether the buyer question is covered directly or only implied.
+
+Freshness is not about publishing for the sake of publishing. It is about making sure the market has current material for the questions that shape qualified consideration.
+
+If the competitor owns the fresh answer and you own the stale one, the buyer may never see the version of the company you believe you are selling.
+
+## Turn the audit into decisions
+
+The output of this diagnostic should not be a longer prompt tracker.
+
+It should be a decision memo.
+
+For each priority buyer question, write down:
+
+- the first-named competitor and the role they are given;
+- the signal that appears to make them easy to recommend;
+- whether that role is commercially important to contest;
+- the gap in your own public material;
+- the action: positioning change, offer clarification, comparison page, use-case page, proof asset, third-party outreach, source refresh, or no action.
+
+That last option matters. "No action" is a valid decision when the competitor is winning a question that does not represent your target buyer, desired category, or profitable offer. GEO work becomes expensive when every mention loss is treated as equally important.
+
+The discipline is to separate ego pain from market risk.
+
+If the competitor is named first for a question your best buyer asks before creating a shortlist, act. If they are named first for a generic query with weak commercial intent, record it, but do not let it hijack the roadmap.
+
+## The sharper question
+
+Competitive answer visibility is useful because it shows how the market is being compressed in front of buyers.
+
+It is not a trophy table. It is not a demand-generation dashboard by itself. It is not proof that the named competitor is objectively better. It is a prompt to inspect the signals that made one company easier to recommend than another.
+
+For a CMO or founder, that is where the commercial value is.
+
+When an answer engine names a competitor first, do not stop at the screenshot.
+
+Ask what made them the safer answer: the category, the entity, the offer, the sources, the comparison frame, the proof, the freshness, or the buyer-question coverage.
+
+Then decide whether that advantage is worth contesting.
+
+If it is, the work is not to beg the answer engine for a mention.
+
+The work is to make the market evidence clearer, fresher, more specific, and more useful for the buyer question that matters.


### PR DESCRIPTION
## Summary
- Publishes Day 52 Build in Public post: “Audit the Competitor the Answer Engine Names First”.
- Applies the approved final artifact to `docs/blog/posts/daily-blog-day-52.md` only.
- Includes a minimal YAML-only frontmatter quoting fix so `geo_tactics` remains `list[str]` and the existing validator passes.

## Checks
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-52.md` → passed (`Frontmatter validation passed.`)
- Targeted content assertions → passed: title, date, slug, buyer audience, GEO mechanisms, Google caveat, and forbidden internal frames absent.
- `mkdocs build --strict` → failed because the repository currently emits 90 pre-existing warnings in strict mode, mainly RoamLinks/AutoLinks missing targets, pages outside nav, and existing absolute blog nav URLs.
- `mkdocs build` → passed (`Documentation built in 7.94 seconds`).

## Payload verification
- `git diff --name-only origin/main...HEAD` → `docs/blog/posts/daily-blog-day-52.md` only.

## Candidate rationale
Selected candidate scores: freshness 4, buyer relevance 5, GEO specificity 5, source-material fit 4, commercial usefulness 5, low repetition risk 4. Total: 27/30.
