### PR TITLE
docs: add daily blog day 53

### DIFF
--- a/docs/blog/posts/daily-blog-day-53.md
+++ b/docs/blog/posts/daily-blog-day-53.md
@@ -1,0 +1,261 @@
+---
+title: "Day 53: Fix the Route Before You Judge the Demand"
+date: 2026-06-12
+slug: "day-53-fix-the-route-before-you-judge-the-demand"
+description: "A commercial diagnostic for CMOs, Marketing Directors, and founders: separate answer-engine visibility from the route that turns AI-referred interest into a sales conversation."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - conversion paths
+  - demand generation
+geo_tactics:
+  - Audit the full AI-referred demand route: answer-engine recommendation, cited or visited asset, visible next action, CTA clarity, and sales handoff.
+  - Diagnose weak AI-search outcomes by separating visibility, recommendation quality, landing-page intent match, next-step clarity, and sales follow-up before commissioning more content.
+  - Treat route failure as commercial leakage: a qualified buyer can discover the company and still fail to find the right action.
+  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems, not llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as required switches.
+---
+
+# Day 53: Fix the Route Before You Judge the Demand
+
+A buyer can discover the company and still have nowhere obvious to go.
+
+That is one of the easiest ways to misread AI visibility.
+
+A CMO, Marketing Director, or founder sees weak pipeline from ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another AI-assisted search surface and draws a clean conclusion: the channel is not sending qualified demand. The screenshots may look promising, the mentions may exist, the brand may even be described correctly, but the commercial result is thin. So the team asks for more content, more monitoring, more mentions, more prompt coverage, or a bigger GEO push.
+
+Sometimes that is the right response.
+
+But often the leak is simpler and more expensive: the buyer found the company, landed somewhere plausible, and could not see the next commercial step.
+
+The problem was not demand.
+
+The problem was the route.
+
+<!-- more -->
+
+## AI visibility is not a complete journey
+
+Answer-engine visibility can create a false sense of completion.
+
+If the company appears in an answer, leadership can feel that the discovery problem is partly solved. If the answer is accurate, the team can feel that the positioning problem is improving. If the answer cites a relevant page, the content team can feel that the source strategy is working.
+
+Those are useful signals, but they are not the whole buyer route.
+
+A commercial route has several handoffs:
+
+- the answer surface recommends, describes, cites, or links the company;
+- the buyer follows the visible path, or searches the brand after reading the answer;
+- the destination page matches the buyer's current intent;
+- the next action is obvious enough to survive distraction, scepticism, and internal review;
+- the sales handoff preserves the context that made the buyer act.
+
+Any one of those handoffs can fail.
+
+If the answer recommends the company but sends the buyer to a broad educational page with no relevant next step, the route fails. If the cited asset explains the category well but hides the commercial action below generic navigation, the route fails. If the CTA says something vague like "learn more" when the buyer is ready to diagnose a revenue problem, the route weakens. If the contact form receives the lead but sales has no context for the AI-referred question, the handoff loses value.
+
+The team may report that AI search is not converting.
+
+What actually happened is that a buyer signal reached a broken route.
+
+## Do not diagnose the channel before the path
+
+The first instinct is usually to judge the surface.
+
+"ChatGPT mentions us but does not send traffic."
+
+"Perplexity cites the wrong page."
+
+"Gemini knows the category but does not treat us like the obvious provider."
+
+"Google's AI features show the market, but buyers are not converting from it."
+
+Those observations may be true. They still need diagnosis before they become strategy.
+
+The practical question is not only, "Did the answer engine name us?"
+
+It is:
+
+> If a qualified buyer follows the route created by this answer, can they take the next commercial step without guessing?
+
+That question changes the work.
+
+It stops the team from treating every weak outcome as a content-volume problem. It also stops the team from treating every AI surface as a pure visibility channel. Different surfaces create different expectations. A buyer coming from a cited Perplexity answer may expect source continuity. A buyer who saw the company named in ChatGPT may search the brand and expect a direct route from the homepage. A buyer comparing providers in Claude may arrive with a sharper evaluation question. A buyer moving through Google AI features may still be influenced by the broader Search result set and page quality signals.
+
+The mechanics differ, and Google's AI features should not be treated as a separate switch that requires `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data. Strong, crawlable, useful content and ordinary Search quality still matter.
+
+But across surfaces, the commercial principle is the same.
+
+Visibility without a route is not a demand engine.
+
+It is an exposed handoff.
+
+## A route diagnostic for AI-referred demand
+
+Before deciding that AI search is weak, audit the route in five parts.
+
+### 1. Visibility: did the buyer have a chance to find you?
+
+Start with the basic discovery question.
+
+For the buyer question that matters, does the company appear at all? Is it named directly? Is it implied as a category participant? Is it cited? Is it linked? Is it absent while competitors are named? Does the surface describe the company accurately enough for a buyer to recognise relevance?
+
+This is the visibility layer, and it still matters. A buyer cannot follow a route that never appears.
+
+But visibility should not be treated as success by itself. A mention can be commercially weak if it is attached to the wrong buyer question, the wrong category, the wrong comparison set, or a destination that does not support action.
+
+The output of this layer is simple: for each high-fit buyer question, record whether the surface creates a plausible path towards the company.
+
+Not a vanity mention.
+
+A plausible path.
+
+### 2. Recommendation quality: did the answer create the right expectation?
+
+Next, inspect what the answer says before the buyer clicks, searches, or follows up.
+
+Does it recommend the company for the work the company actually wants? Does it frame the offer clearly? Does it explain who the company is for? Does it place the company beside the right alternatives? Does it set an expectation that the destination page can satisfy?
+
+A route can break before the website loads.
+
+If the answer positions the company as a general content agency but the commercial offer is an AI visibility diagnostic, the buyer arrives with the wrong mental model. If the answer says the company has a tool but the page promotes a service call, the buyer feels friction. If the answer names the company as one option among many but gives no reason to act, the next page has to do more work.
+
+Recommendation quality is not about flattering language. It is about expectation fit.
+
+The best AI-referred route is one where the answer prepares the buyer for the next page, and the next page confirms that the buyer is in the right place.
+
+### 3. Destination fit: did the page match the buyer moment?
+
+A high-intent buyer does not always need a homepage.
+
+Sometimes they need a diagnostic offer. Sometimes they need a comparison frame. Sometimes they need a clear explanation of the service. Sometimes they need proof. Sometimes they need a practical next step they can send to a founder, marketing lead, or sales colleague.
+
+This is where many teams misread performance.
+
+The answer surface may send buyers to a page that is technically relevant but commercially incomplete. A category explainer may earn the citation, but it may not help a ready buyer act. A blog post may answer the question, but it may not show the service route. A homepage may be clear to insiders, but not to someone arriving with a specific AI-search context. A tool page may demonstrate competence but fail to explain what happens after the output.
+
+Ask the uncomfortable question:
+
+> If this exact buyer landed on this exact page after this exact answer, would the next step be obvious?
+
+If not, the fix may not be another post. It may be a better route from the cited asset to the commercial destination, a clearer in-page action, a stronger internal link, or a landing page designed for the buyer moment the answer surface is creating.
+
+### 4. CTA clarity: did the action reduce friction or add it?
+
+A CTA is not just a button label.
+
+It is the commercial instruction at the moment of buyer uncertainty.
+
+For AI-referred demand, vague actions are expensive. A buyer who has already asked a detailed question may not respond to generic choices like "learn more", "explore", or "get started" if the page does not explain what those actions mean. They need to understand what happens next, who the action is for, and why it matches the problem they were researching.
+
+A strong route answers practical questions near the action:
+
+- is this for companies trying to understand AI visibility, fix a specific leak, compare competitors, or brief a leadership team?
+- what will happen after the buyer clicks: audit, call, diagnostic, proposal, tool output, or internal briefing?
+- what information should the buyer bring?
+- how quickly will they know whether the problem is worth fixing?
+- will the conversation connect to the answer or page that brought them here?
+
+This does not mean every page needs a hard sales CTA. Some buyer moments deserve a worksheet, a diagnostic, a comparison page, or a proof asset before the sales conversation.
+
+The issue is not whether the action is aggressive enough.
+
+The issue is whether the action is clear enough for the buyer's current intent.
+
+### 5. Sales handoff: did the commercial context survive?
+
+The route does not end at the form submission.
+
+If the buyer came from an AI-referred path, the context matters. What question were they asking? Which answer surface shaped their expectation? Which competitor or category frame were they evaluating? Which source or asset did they see? What did the CTA promise?
+
+If that context disappears, the sales conversation starts colder than it should.
+
+The team may know that a lead arrived from a page. It may not know that the buyer was comparing providers, checking whether GEO work was credible, looking for a route from answer visibility to pipeline, or trying to diagnose why a competitor was being recommended first.
+
+That lost context can make a qualified lead look weaker than it is.
+
+A useful handoff captures the commercial question, not just the referrer. At minimum, sales should know the source surface where available, the landing asset, the CTA used, the buyer's stated problem, and the follow-up promise the page made.
+
+Otherwise the business may create demand with one system and receive it with another system that has forgotten why the buyer moved.
+
+## The route map belongs beside the GEO dashboard
+
+A GEO dashboard can tell the team what is happening in the answer environment.
+
+It cannot, by itself, tell the team whether the business is ready to receive the demand that environment creates.
+
+That requires a route map.
+
+For each priority buyer question, write down:
+
+- the answer surfaces where the question appears: ChatGPT, Claude, Perplexity, Gemini, Google AI features, AI-assisted search, classic search, or another relevant path;
+- the current answer outcome: absent, named, recommended, cited, linked, compared, or misframed;
+- the likely destination: cited page, homepage, searched brand result, comparison page, tool page, blog post, or contact page;
+- the buyer's expected next step at that moment;
+- the actual next action visible on the page;
+- the handoff owner: marketing, website, sales, founder, RevOps, or a named team;
+- the evidence required to decide whether the route is working.
+
+This is not bureaucracy. It is leakage control.
+
+If the buyer question is commercially weak, the route can be watched. If the question is high-intent and the company is absent, the visibility problem matters. If the company is visible but the answer creates the wrong expectation, the positioning or source environment needs work. If the answer is strong but the destination is vague, the route needs fixing. If the page converts but sales loses context, the handoff needs repair.
+
+Those are different problems.
+
+Different problems should not all become "publish more content".
+
+## What to fix before declaring weak demand
+
+Before leadership concludes that answer-engine demand is not qualified, run a small route review.
+
+Pick three buyer questions that would matter if they came from a real prospect:
+
+- one category question;
+- one comparison or shortlist question;
+- one problem-aware question with clear commercial intent.
+
+Run them across the answer surfaces your buyers are likely to use. Capture the answers and visible sources where available. Follow the route as a buyer would: click the citation, search the brand, open the named page, read the CTA, submit or simulate the next step, and inspect what sales would receive.
+
+Then classify the failure:
+
+- no route: the company does not appear, or appears too weakly to create movement;
+- wrong expectation: the answer frames the company in a way the destination does not satisfy;
+- wrong destination: the page is relevant to the topic but not to the buyer moment;
+- weak action: the next step is vague, buried, generic, or mismatched;
+- broken handoff: the lead context does not reach the person who has to continue the conversation;
+- acceptable route: the path is clear enough, and the remaining issue may be demand volume, surface behaviour, or sales execution.
+
+That classification is more useful than a broad judgement about whether AI search "works".
+
+It tells the team where the leak sits.
+
+## The commercial mistake
+
+The commercial mistake is assuming that discovery and demand are the same thing.
+
+They are not.
+
+Discovery means the buyer can encounter the company in an answer environment. Demand means the buyer can move from that encounter into a meaningful commercial step. GEO work often focuses on the first half because it is easier to see: mentions, citations, rankings, source patterns, competitor adjacency, answer quality.
+
+The second half is less glamorous and more important.
+
+Can the buyer move?
+
+Can the page receive them?
+
+Can the action make sense?
+
+Can sales continue the conversation without losing the reason the buyer arrived?
+
+If not, the company may be closer to AI-referred demand than the dashboard suggests. It may not need to start by proving that the channel is real. It may need to fix the route that makes the signal visible as revenue.
+
+For CMOs, Marketing Directors, and founders, that distinction matters.
+
+Before judging the demand, inspect the path.
+
+A broken route can make a real buyer signal look weak.
+
+Fix the route first.

--- a/docs/blog/posts/daily-blog-day-53.md
+++ b/docs/blog/posts/daily-blog-day-53.md
@@ -13,10 +13,10 @@ tags:
   - conversion paths
   - demand generation
 geo_tactics:
-  - Audit the full AI-referred demand route: answer-engine recommendation, cited or visited asset, visible next action, CTA clarity, and sales handoff.
-  - Diagnose weak AI-search outcomes by separating visibility, recommendation quality, landing-page intent match, next-step clarity, and sales follow-up before commissioning more content.
-  - Treat route failure as commercial leakage: a qualified buyer can discover the company and still fail to find the right action.
-  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems, not llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as required switches.
+  - "Audit the full AI-referred demand route: answer-engine recommendation, cited or visited asset, visible next action, CTA clarity, and sales handoff."
+  - "Diagnose weak AI-search outcomes by separating visibility, recommendation quality, landing-page intent match, next-step clarity, and sales follow-up before commissioning more content."
+  - "Treat route failure as commercial leakage: a qualified buyer can discover the company and still fail to find the right action."
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems, not llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as required switches."
 ---
 
 # Day 53: Fix the Route Before You Judge the Demand


### PR DESCRIPTION
## Summary
- Adds Day 53 Build in Public post: "Fix the Route Before You Judge the Demand"
- Applies the approved final editorial artifact only, with YAML-safe quoting for `geo_tactics`
- Keeps the public post buyer-facing for CMOs, Marketing Directors, and founders

## Checks
- `python tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-53.md` passed
- Targeted content validation passed: required keys present, forbidden/repeated frames absent, unsafe GEO required-switch patterns absent
- `mkdocs build --strict` attempted; aborted on 90 pre-existing warnings (nav exclusions, absolute nav paths, RoamLinks/AutoLinks warnings)
- `mkdocs build` passed successfully
- GitHub PR checks are green: `validate` and Cloudflare Pages passed

## Payload
- `docs/blog/posts/daily-blog-day-53.md` only
