### PR TITLE
docs: add daily blog day 54

### DIFF
--- a/docs/blog/posts/daily-blog-day-54.md
+++ b/docs/blog/posts/daily-blog-day-54.md
@@ -1,0 +1,173 @@
+---
+title: "Day 54: Assign the Owner Before You Chase the Signal"
+date: 2026-06-13
+slug: "day-54-assign-owner-before-signal"
+description: "A practical operating model for CMOs, Marketing Directors, and founders: assign ownership, cadence, and decision thresholds before treating AI-visibility signals as strategy."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - marketing operations
+  - commercial accountability
+geo_tactics:
+  - Map every answer-engine signal to a named business owner before expanding monitoring or content production.
+  - Separate share-of-answer, answer volatility, source drift, citation quality, competitor inclusion, entity ambiguity, and conversion-route gaps into different operating decisions.
+  - Define a review cadence and decision threshold for each signal so teams know when to investigate, repair, escalate, or ignore noise.
+  - "Keep the Google caveat clear: Google's AI features do not require llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as visibility switches."
+---
+
+# Day 54: Assign the Owner Before You Chase the Signal
+
+The dangerous AI visibility metric is not the one that looks bad.
+
+It is the one nobody owns.
+
+A CMO, Marketing Director, or founder can now collect a growing list of signals from ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led discovery surfaces. The brand is mentioned in one answer and missing from another. A competitor appears first for a buyer question. A cited source changes. A category description drifts. A product page is referenced where a comparison page would make more sense. A high-intent answer gives the buyer no obvious route into a sales conversation.
+
+Each signal feels useful.
+
+But usefulness does not come from the dashboard. It comes from the decision the signal triggers.
+
+If no one knows who investigates the change, who fixes the source gap, who supplies proof, who owns the conversion route, or who decides whether the signal is commercially meaningful, the measurement programme becomes theatre. The business sees movement. The team produces reports. Leadership hears that AI visibility is being monitored.
+
+Nothing changes quickly enough to protect pipeline.
+
+<!-- more -->
+
+## Signals are not strategy until they have owners
+
+AI visibility work often starts with a reasonable question:
+
+"Where do we show up?"
+
+That question matters. Share-of-answer, citation quality, competitor inclusion, answer volatility, source drift, entity ambiguity, and conversion gaps can all reveal something commercially important. They show whether answer engines understand the company, whether the market category is being framed accurately, whether competitors are easier to recommend, and whether buyers who discover the brand have a credible next step.
+
+But the next question is more important:
+
+"Who is accountable for acting on this?"
+
+Without that second question, every metric becomes a marketing metric by default. The content team is asked to create more pages. The SEO team is asked to improve visibility. The website owner is asked to tidy conversion paths. Sales is asked whether leads are improving. Brand is asked whether the positioning is clear.
+
+Everyone touches the problem.
+
+No one owns the decision.
+
+That is where response time slows down. Teams duplicate analysis. A founder asks why the company is absent from a key answer, and the answer is still being passed around a week later. Marketing sees a competitor gain prominence, but no one knows whether the right response is a content update, a proof asset, a positioning correction, a partner citation, a product-page rewrite, or a sales enablement note.
+
+The signal was real.
+
+The operating model was missing.
+
+## Build an ownership map before the tracker
+
+The practical move is to map signals to owners before expanding the measurement stack.
+
+A useful ownership map does not need to be complicated. It needs four fields for each signal:
+
+- the owner who investigates it;
+- the cadence for reviewing it;
+- the threshold that turns it from noise into action;
+- the decision the owner is allowed to make.
+
+That last field is the one most teams skip.
+
+If the content lead owns citation quality but cannot decide which source pages need revision, ownership is cosmetic. If product marketing owns entity and category ambiguity but cannot change core positioning language, the signal will keep resurfacing. If demand generation owns conversion-route gaps but cannot alter the next action on high-intent pages, the route stays broken. If leadership owns competitor inclusion only when the dashboard is embarrassing, the business will respond late.
+
+The map should make accountability visible before the next report is generated.
+
+For example:
+
+- Share-of-answer should have a commercial owner, not only a reporting owner. If the company is absent from high-intent buyer questions, someone needs to decide whether the gap is priority market education, proof, positioning, or offer clarity.
+- Answer volatility should have an investigation owner. If the brand appears one week and disappears the next, someone needs to determine whether the change is surface noise, source instability, a competitor improvement, or a genuine weakness in the public footprint.
+- Source drift should have a corpus owner. If answer engines start leaning on outdated pages, third-party summaries, or low-context sources, someone needs to decide which public assets deserve repair, consolidation, or replacement.
+- Citation quality should have an evidence owner. If the cited source mentions the brand but does not support the claim buyers care about, someone needs to supply clearer proof.
+- Competitor inclusion should have a positioning owner. If the answer names a rival first, the question is not just visibility. It is whether the market has easier evidence for the competitor's claim.
+- Entity or category ambiguity should have a product-marketing owner. If answer engines confuse the company with adjacent tools, services, or categories, the business has a language problem before it has a ranking problem.
+- Conversion-route gaps should have a demand owner. If the answer creates interest but the next step is hidden, vague, or mismatched, the buyer path needs repair.
+
+This is where GEO becomes operational rather than ornamental.
+
+The signal says what changed.
+
+The ownership map says who moves.
+
+## Different signals need different decisions
+
+A common mistake is treating every answer-engine finding as a content task.
+
+Content is often part of the response. It is rarely the whole response.
+
+If Perplexity cites a page that explains the category but never connects the problem to the company's offer, the fix may be a page-level commercial route. If Claude describes the company accurately but omits a key use case, the fix may be clearer product language. If Gemini includes two competitors and excludes the company for a procurement-style question, the fix may be comparison evidence, third-party validation, or a sharper category claim. If Google AI features surface a broad informational result where the company wants commercial consideration, the fix may be stronger conventional search quality and clearer usefulness, not a special AI markup project.
+
+That Google caveat matters.
+
+Teams should not assume that llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are required switches for visibility in Google's AI features. The safer operating principle is to improve the same fundamentals that make a page useful, crawlable, credible, and eligible to perform in Google Search, while avoiding technical rituals that create confidence without evidence.
+
+The ownership map protects the business from that ritual behaviour.
+
+When each signal has a decision owner, the team can ask better questions:
+
+- Is this a source problem or a route problem?
+- Is the answer wrong, incomplete, unstable, or commercially weak?
+- Is the competitor named because they have better proof, clearer positioning, stronger distribution, or simply more available language around the question?
+- Does the cited page help a buyer choose, or only help an answer engine explain?
+- Is the threshold for action one bad answer, a repeated pattern, a high-value question, or a revenue-impacting surface?
+
+Those questions stop GEO from becoming a generic content backlog.
+
+They turn it into a management system.
+
+## The cadence should match the commercial risk
+
+Not every signal deserves the same level of urgency.
+
+That is another reason ownership matters.
+
+A category-definition answer that drifts slightly across low-intent research prompts may need monthly review. A high-intent buyer question where a competitor is repeatedly named first may need weekly review. A source drift issue that points buyers to outdated pricing, unsupported claims, or an old positioning page may need immediate repair. A conversion-route gap on a page commonly cited or visited after answer-led discovery may need the same urgency as any other demand leak.
+
+Cadence is a leadership choice, not a dashboard default.
+
+A founder does not need every AI answer escalated. A CMO does not need every citation change treated as an incident. A marketing director does not need a daily panic cycle around surface-level volatility.
+
+They need a rule for when movement matters.
+
+That rule might look like this:
+
+- investigate when a high-value buyer question changes materially across two consecutive reviews;
+- repair when an answer relies on a source that no longer reflects the offer;
+- escalate when a competitor becomes the default recommendation for a question tied to active pipeline;
+- ignore when low-intent volatility has no clear buyer or revenue implication;
+- test the route when the answer is favourable but commercial follow-through remains weak.
+
+The point is not to eliminate judgement.
+
+The point is to make judgement faster and less political.
+
+## The leadership question is accountability
+
+The buyer problem behind AI visibility is not, "How do we make one more blog post for AI?"
+
+It is, "When answer engines surface inconsistent, incomplete, or commercially awkward answers about our category, competitors, or offer, who in the business is accountable for turning that into action?"
+
+That question belongs in leadership conversations because the cost is not only inaccurate reporting.
+
+The cost is lost pipeline when buyers see a competitor first and no one responds. It is slow response when a source gap keeps reappearing but no one owns the repair. It is duplicated effort when content, SEO, product marketing, sales, and demand generation all analyse the same symptom from different angles. It is weak confidence when leadership sees the signal but cannot see the operating response.
+
+A stronger AI visibility programme starts with an ownership map:
+
+- Product marketing owns category and entity clarity.
+- Content owns source usefulness and freshness.
+- Demand generation owns commercial routes and next actions.
+- Sales owns feedback on whether AI-referred questions match real buying conversations.
+- Leadership owns the threshold for what becomes commercially material.
+
+The exact map will vary by business. The principle should not.
+
+Do not chase every answer-engine signal as if visibility itself is the strategy.
+
+Assign the owner first.
+
+Then the signal can do its real job: not proving that the brand is being watched, but showing the business where to act.


### PR DESCRIPTION
## Summary
- Adds Build-in-Public Day 54: "Assign the Owner Before You Chase the Signal"
- Preserves the approved buyer-relevant GEO operating-model angle
- Keeps the Google AI visibility caveat clear: no llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as required switches

## Verification
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-54.md`
- targeted content assertion for GEO mechanisms, caveats, and internal-workflow forbidden terms
- `mkdocs build` (passes; existing RoamLinks/AutoLinks/nav warnings remain)
- `git diff --cached --name-only` before commit showed only `docs/blog/posts/daily-blog-day-54.md`
