### PR TITLE
docs: add day 55 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-55.md
+++ b/docs/blog/posts/daily-blog-day-55.md
@@ -1,0 +1,237 @@
+---
+title: "Day 55: Do Not Let the Tool Become the Offer"
+date: 2026-06-14
+slug: "day-55-do-not-let-the-tool-become-the-offer"
+description: "A commercial note for CMOs, Marketing Directors, and founders: public GEO tools can earn attention, but they need clear offer boundaries so buyers and answer engines do not mistake the utility for the whole service."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - offer architecture
+  - commercial strategy
+geo_tactics:
+  - Use public tools, checkers, generators, trackers, and diagnostics to demonstrate competence without letting the utility define the entire commercial offer.
+  - "State tool-page boundaries clearly: what the tool helps with, what it does not decide, when judgement is required, and what a diagnostic conversation should cover."
+  - Audit whether ChatGPT, Claude, Perplexity, Gemini, Google AI features, and AI-assisted search describe the company as a widget, template, platform, agency, or strategic service.
+  - "Keep the Google caveat clear: Google's AI features do not require llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as visibility switches."
+---
+
+# Day 55: Do Not Let the Tool Become the Offer
+
+A useful public tool can create a commercial problem if it teaches the market the wrong thing about what the company sells.
+
+That is the trap for CMOs, Marketing Directors, and founders building around Generative Engine Optimization. A checker, generator, tracker, calculator, template, or diagnostic can earn attention because it is concrete. It gives buyers something to try. It gives answer engines something specific to describe. It proves that the team understands the mechanics well enough to make a practical artefact.
+
+But if the surrounding page is unclear, the tool can compress the whole business into the utility.
+
+The buyer leaves thinking, "They have a widget."
+
+The answer engine describes, "They offer a free tool."
+
+The sales conversation starts with the wrong expectation.
+
+<!-- more -->
+
+## Tools are easy for answer engines to explain
+
+Public tools travel well in answer environments because they are simple objects.
+
+ChatGPT, Claude, Perplexity, Gemini, Google AI features, and AI-assisted search experiences can often describe a tool more easily than they can describe a nuanced service offer. A tool has a name, a function, an input, an output, and a visible use case. It may have a page that is crawlable, shareable, and specific. It can be recommended in response to a practical question.
+
+That concreteness is useful.
+
+A buyer asking how to check AI visibility, generate an `llms.txt` file, compare answer surfaces, inspect citations, or understand whether a site is machine-readable may be closer to commercial interest than a generic awareness visitor. A practical utility can act as a proof point. It can show that the company has taste, technical fluency, and enough operational understanding to make something usable.
+
+The risk is not the tool.
+
+The risk is the category lesson the tool teaches.
+
+If the page only says what the utility does, answer engines may describe the company around that utility. If the CTA only points to more tool usage, buyers may assume the commercial offer is self-serve software. If the copy overclaims what the tool can prove, leadership may treat a quick output as a strategic answer. If the page hides the service boundary, serious buyers may qualify themselves out because they believe the company sells the small visible thing, not the larger judgement behind it.
+
+That is lead leakage through mispositioning.
+
+The company did not fail to attract attention.
+
+It attracted attention to the wrong commercial frame.
+
+## The tool needs an offer boundary
+
+A public GEO tool page should not behave like a product page unless the product is the offer.
+
+For a service business, a consultancy, or a strategic partner, the tool is usually a doorway. It helps a buyer see a problem, test a hypothesis, understand a surface, or collect an initial signal. It should not imply that the output is the diagnosis, the strategy, the implementation plan, or the guarantee.
+
+That boundary needs to be explicit.
+
+A strong tool page should answer five questions.
+
+### 1. What does this tool help with?
+
+Be concrete about the useful job.
+
+A tracker may help a team record whether the brand appears across priority answer surfaces. A generator may help create a machine-readable export for agents or non-Google discovery workflows. A checker may flag whether important pages are accessible, understandable, or aligned with a stated entity. A diagnostic worksheet may help leadership organise the first set of buyer questions.
+
+This is the practical promise.
+
+It should be specific enough that the buyer knows why the tool exists, and restrained enough that the tool is not asked to carry the entire service narrative.
+
+### 2. What does this tool not decide?
+
+This is where many pages become commercially dangerous.
+
+A tracker does not decide whether a visibility gap matters to pipeline. A generator does not prove Google AI visibility. A checker does not know whether the company's positioning is commercially sharp. A template does not know whether a board, founder, sales team, or marketing team will interpret the category correctly. A diagnostic form does not replace judgement about market timing, offer clarity, competitor pressure, or buyer intent.
+
+The page should say that plainly.
+
+Not defensively. Not as a legal disclaimer. As a sign of competence.
+
+Serious buyers do not lose confidence because a company admits the limit of a tool. They lose confidence when a small utility is presented as if it can answer a management question.
+
+### 3. When is human or commercial judgement required?
+
+The useful moment often comes after the output.
+
+The tool shows that the brand is absent from a question. Is that a commercial problem, or a low-intent query nobody should chase?
+
+The tool produces an `llms.txt` file. Does that help a non-Google agent or downstream system discover selected material, or is the team treating it as a magic switch for Google AI visibility without evidence?
+
+The tool shows that Perplexity cites one page, Claude describes another angle, ChatGPT summarises the category differently, Gemini leans on a broader market frame, and Google AI features surface conventional search results around the topic. Which difference matters? Which one is noise? Which one changes the next commercial move?
+
+That is judgement.
+
+It includes buyer-question selection, category boundaries, source quality, offer positioning, proof, sales context, and whether the finding deserves action at all.
+
+The page should make that handover visible.
+
+### 4. What commercial question does the tool open?
+
+A tool output is only valuable if it leads to a better question.
+
+Not, "Did we get a score?"
+
+A better question might be:
+
+- are answer engines describing us as the company we want buyers to understand?
+- is a free utility becoming the main thing the market associates with us?
+- are buyers being pointed towards a tool when they actually need a diagnostic conversation?
+- does the public page explain the difference between a quick check and a strategic visibility workflow?
+- are we attracting users who want a template, or buyers who have a board-level visibility problem?
+
+Those questions are commercial. They belong with leadership, product marketing, demand generation, and sales, not only with the person maintaining the tool.
+
+### 5. What is the appropriate next step?
+
+The next step should match the buyer's seriousness.
+
+A casual user may only need the output, a short explanation, or a follow-up resource. A practitioner may need implementation guidance. A Marketing Director may need to understand whether the issue affects a priority campaign. A CMO may need to know whether answer visibility is shaping consideration, competitor comparisons, or sales qualification. A founder may need to decide whether the company is being compressed into the wrong category.
+
+A single generic CTA will not fit all of those moments.
+
+For a serious buyer, the next step should not be "use the tool again" unless repeated use is the product. It may be a diagnostic conversation that reviews the buyer questions, the answer surfaces, the public sources, the offer boundary, and the commercial action the tool cannot decide.
+
+The page should explain that conversation before asking for it.
+
+## Avoid the two common overcorrections
+
+There are two ways to mishandle this.
+
+The first is to make the tool too grand.
+
+That happens when a page implies the utility can answer the strategic question by itself. The copy starts to promise AI visibility, answer-engine performance, Google AI inclusion, or commercial certainty from a narrow check. It may treat `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as if they are required switches for Google's AI features. It may make the output feel more decisive than it is.
+
+That is not GEO strategy. It is confidence theatre.
+
+Google's AI features should not be treated as something that can be unlocked by a single file, tag, chunking convention, or schema ritual. Useful, crawlable, credible pages and ordinary Search quality still matter. Machine-readable exports can be useful for some agents, workflows, and non-Google discovery contexts, but they should be presented as optional aids unless there is validated evidence for the specific surface and use case.
+
+The second overcorrection is to make the tool too small.
+
+That happens when the company hides the commercial context entirely. The page becomes a bare utility with no explanation of the strategic problem, no boundary between output and judgement, and no reason for a serious buyer to continue. It may attract usage, but it does not teach the market what the company is actually good at.
+
+The better approach is disciplined middle ground.
+
+Make the tool useful enough to stand on its own.
+
+Make the boundary clear enough that the offer is not reduced to the tool.
+
+## The commercial consequence is pricing and qualification
+
+This is not only a messaging issue.
+
+If the market understands the company as a tool provider, the company will be compared like a tool provider. Buyers will ask about features, free alternatives, usage limits, integrations, and whether they can do it themselves. Some of those questions may be valid. But if the real offer is strategic work around AI visibility, source quality, answer-surface interpretation, public evidence, and commercial decision-making, the company has allowed the wrong comparison frame to form.
+
+That weakens pricing.
+
+It also weakens qualification.
+
+A founder who needs a board-level view of AI visibility may bounce because the page looks like a small utility. A CMO who needs to understand why competitors are easier to recommend may assume the company only provides a tracker. A Marketing Director who needs to turn messy answer-engine findings into action may use the checker, get a partial output, and never realise that the valuable work starts with interpretation.
+
+The tool did its job.
+
+The offer architecture failed.
+
+A good public tool should therefore carry two messages at once:
+
+- "Here is a practical thing you can use now."
+- "Here is the larger commercial question this tool cannot answer for you."
+
+That is not a bait-and-switch. It is honest positioning.
+
+## What a better tool page says
+
+A stronger page does not need to be long. It needs to be precise.
+
+For example, a GEO tracker page might say:
+
+- this helps you record whether priority buyer questions produce mentions, citations, comparisons, or omissions across answer surfaces;
+- it does not decide which questions are commercially worth tracking, whether a change is material, or what action should follow;
+- judgement is needed when the finding affects a high-value category, competitor comparison, sales route, or leadership decision;
+- a diagnostic conversation should review the buyer questions, the source pattern, the answer differences by surface, the commercial risk, and the next action;
+- the appropriate next step is a short review if the tracker reveals repeated absence, misframing, competitor preference, or tool-only perception around a priority offer.
+
+An `llms.txt` generator page might say:
+
+- this helps produce a machine-readable index of selected public material for agents and compatible workflows;
+- it does not guarantee visibility in ChatGPT, Claude, Perplexity, Gemini, Google AI features, or any specific answer system;
+- it is not a replacement for useful pages, clear entity language, credible sources, or Search quality;
+- judgement is needed to decide which pages should represent the company, which pages should be excluded, and whether the export supports a real discovery use case;
+- the next step is a public-corpus review if the exercise reveals stale, conflicting, thin, or commercially misleading source material.
+
+A checker or diagnostic page might say:
+
+- this gives an initial read on one part of the AI-visibility problem;
+- it does not rank the company's total market position or prove revenue impact;
+- human judgement is needed to connect the finding to buyer intent, competitor context, and offer clarity;
+- a diagnostic conversation should cover the buyer's priority questions, current answer-surface behaviour, visible sources, commercial risk, and whether the company is being framed as the right kind of provider;
+- the next step is appropriate when the output exposes a gap the business would care about if a real buyer saw it.
+
+That kind of copy helps buyers and answer engines understand the object correctly.
+
+The tool is useful.
+
+The service is larger.
+
+The boundary is visible.
+
+## The leadership question
+
+Before launching a public GEO tool, leadership should ask one question:
+
+> If an answer engine, a buyer, or a competitor described us using only this page, would they understand the offer we actually want to sell?
+
+If the answer is no, the page is not ready.
+
+It may still work as a utility. It may still attract users. It may still be cited. It may still produce flattering usage numbers. But it can also train the market to put the company in the wrong box.
+
+That is the avoidable risk.
+
+A public tool should make the company easier to trust, not smaller than it is. It should give answer engines a concrete object without letting that object become the whole entity. It should give buyers a useful first step without pretending the first step is the strategy.
+
+Do not hide the tool.
+
+Do not inflate it either.
+
+Draw the boundary: what it does, what it does not decide, where judgement begins, and what commercial conversation should happen next.
+
+That is how a tool becomes a doorway into the offer instead of a substitute for it.


### PR DESCRIPTION
## Summary
- Add Day 55 Build in Public post: “Do Not Let the Tool Become the Offer”
- Preserve the approved commercial/GEO angle around tool-to-offer boundaries
- Quote two frontmatter list entries so YAML parses them as strings without changing public prose

## Checks
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-55.md`
- targeted content assertions for required GEO mechanisms and forbidden internal framing
- `mkdocs build` (passed; existing RoamLinks/AutoLinks/nav warnings remain baseline)

## Payload
- `docs/blog/posts/daily-blog-day-55.md` only
