### PR TITLE
docs: add daily blog day 56

### DIFF
--- a/docs/blog/posts/daily-blog-day-56.md
+++ b/docs/blog/posts/daily-blog-day-56.md
@@ -1,0 +1,198 @@
+---
+title: "Day 56: Make the First GEO Call Easy to Start"
+date: 2026-06-15
+slug: "day-56-make-first-geo-call-easy-to-start"
+description: "A practical intake note for CMOs, Marketing Directors, and founders: the first GEO baseline call should need only enough context to start the commercial conversation, not a giant homework pack."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - sales intake
+  - commercial strategy
+geo_tactics:
+  - "Start a GEO baseline with a small commercial intake: domain, priority offer, target buyers, and a few competitors or buyer questions."
+  - "Treat Search Console data, analytics, sales notes, proof assets, call transcripts, and internal documents as useful enrichment, not mandatory prerequisites for the first conversation."
+  - "Separate buyer questions, competitor context, answer surfaces, source evidence, and commercial risk before turning baseline findings into recommendations."
+  - "Keep the Google caveat clear: Google's AI features do not require llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as visibility switches."
+---
+
+# Day 56: Make the First GEO Call Easy to Start
+
+A first GEO baseline call should not feel like a procurement exercise.
+
+That sounds obvious until a CMO, Marketing Director, or founder asks what they need to provide before anyone can tell them whether answer-engine visibility is a real commercial issue. The answer can quickly become a homework pack: Search Console access, analytics exports, sales notes, CRM fields, call transcripts, proof assets, internal positioning documents, product decks, competitor lists, keyword research, historical SEO reports, and every public page the company has ever published.
+
+Some of that material can improve the work.
+
+Almost none of it should be required to start the first conversation.
+
+If the first step towards a Generative Engine Optimization baseline feels heavy before the buyer understands its value, the intake design is creating friction at exactly the wrong moment. The baseline is supposed to help leadership see whether ChatGPT, Claude, Perplexity, Gemini, Google AI features, and AI-assisted search are shaping buyer understanding, competitor comparisons, and commercial routes. It should not begin by asking the buyer to assemble a forensic archive.
+
+<!-- more -->
+
+## The first call only needs enough context to find the risk
+
+A useful first GEO call can start with four inputs.
+
+- the company's domain;
+- the priority offer or market category the business wants buyers to understand;
+- the target buyers who matter commercially;
+- a few competitors, buyer questions, or comparison situations the leadership team already cares about.
+
+That is enough to begin.
+
+The domain shows the public footprint that answer engines and buyers can already inspect. The priority offer defines the commercial lens. The target buyer tells the team whose questions matter. The competitor or question set gives the baseline a direction, so it does not collapse into generic visibility checking.
+
+This is not a complete dataset. It is a starting frame.
+
+A founder may say, "We sell AI workflow automation to operations teams, and buyers compare us with consultancies and internal build options." A Marketing Director may say, "The priority is our enterprise compliance offer, and the risky questions are around implementation speed, governance, and proof." A CMO may say, "If an answer engine recommends competitors for category searches, I need to know whether that is a source problem, positioning problem, or sales-route problem."
+
+That is enough to make the first call useful.
+
+The baseline can then test whether answer surfaces understand the company in relation to those commercial priorities. It can inspect whether the public site supports the offer, whether competitors are easier to recommend, whether answer engines reach for the right sources, and whether a qualified buyer would see a credible next step.
+
+The first call is not trying to finish the diagnosis.
+
+It is trying to decide whether the diagnosis is worth doing.
+
+## Optional data improves delivery, not permission
+
+The mistake is treating every useful input as a required input.
+
+Search Console data can help show how existing search demand, page performance, query patterns, and crawlable assets relate to AI-assisted discovery. Analytics can help reveal which pages already receive commercially meaningful attention. Sales notes can expose the language buyers actually use. CRM data can show which segments convert. Call transcripts can reveal recurring objections. Proof assets can show what evidence the company can safely make public. Internal documents can clarify positioning, priority markets, and product boundaries.
+
+All of that can make the baseline sharper.
+
+But if those inputs become mandatory before the first conversation, the buyer is asked to prove commitment before they know what problem is being assessed. That is backwards.
+
+The first call should establish the commercial question:
+
+- Are answer engines describing the company as the right kind of provider?
+- Are priority buyer questions producing the company, a competitor, a category article, or nobody useful?
+- Are ChatGPT, Claude, Perplexity, Gemini, Google AI features, and broader AI-assisted search creating different expectations?
+- Do the visible sources support the offer the business wants to sell?
+- If a buyer follows the route from answer to site, does the next step make sense?
+- Is the issue likely to be visibility, positioning, public evidence, competitor confidence, route design, or sales context?
+
+Only after those questions are framed does deeper data have a job.
+
+Search Console may help explain why a page is or is not a strong public source. Analytics may help decide whether an AI-referred route is commercially meaningful. Sales notes may help distinguish a vanity prompt from a real buyer question. Proof assets may help determine whether the company has enough visible evidence to support the claim answer engines are being asked to make.
+
+The order matters.
+
+Optional inputs should enrich the baseline. They should not become the tollgate before leadership can understand whether GEO deserves attention.
+
+## Heavy intake kills momentum
+
+Over-demanding intake creates three commercial problems.
+
+The first is delay.
+
+A buyer who is already uncertain about AI visibility will not always gather five internal datasets for a speculative baseline. They may need legal approval for analytics access, sales leadership approval for CRM notes, product approval for proof assets, and founder approval for positioning documents. By the time the information is assembled, the original commercial urgency has cooled.
+
+The second problem is category confusion.
+
+If the first interaction feels like a technical audit, the buyer may assume the work is mostly data extraction, SEO tooling, or dashboard setup. That weakens the strategic frame. A GEO baseline is not only asking, "What can we measure?" It is asking, "When buyers ask commercially important questions in answer-led environments, does the market see us clearly enough to choose us?"
+
+That is a leadership question, not only an access request.
+
+The third problem is false precision.
+
+A large intake pack can make the work feel more rigorous before the baseline has identified the right question. Teams can spend hours normalising analytics, reviewing internal notes, and cataloguing assets, then discover that the main issue is simpler: answer engines do not understand the offer, a competitor has clearer public evidence, the CTA is too vague, or the first sales conversation asks the wrong follow-up question.
+
+More data did not create more clarity.
+
+It created a heavier way to reach the obvious issue.
+
+A lighter first call protects momentum because it keeps the buyer in the commercial problem. It asks for enough context to identify the risk, then earns the right to request deeper material when the additional information has a clear use.
+
+## The first call should separate five things
+
+A strong first call does not need a giant intake form. It needs a disciplined conversation.
+
+### 1. Buyer questions
+
+Start with the questions that would matter if a real prospect asked them.
+
+Not every prompt is worth measuring. A broad research question may produce visibility but no revenue implication. A narrow comparison question may be commercially urgent even if the search volume is tiny. A problem-aware question may reveal whether the company is included in the buyer's shortlist, ignored, or framed as the wrong kind of provider.
+
+The first call should identify a small set of questions tied to the priority offer.
+
+### 2. Competitor context
+
+Competitors give the baseline a commercial edge.
+
+The point is not to copy their content or chase every mention. The point is to understand whether answer engines have an easier time trusting, describing, or recommending someone else. If a competitor appears more often, is it because they have clearer positioning, stronger public proof, more useful comparison language, broader third-party corroboration, better routes from source to offer, or simply more crawlable material around the buyer question?
+
+A first call can start with two or three names.
+
+That is enough to avoid measuring the company in isolation.
+
+### 3. Answer surfaces
+
+Different answer surfaces create different buyer expectations.
+
+ChatGPT may summarise the category and name plausible providers. Claude may lean into explanation and fit. Perplexity may make citations and source selection more visible. Gemini and Google AI features may sit closer to conventional search quality, result sets, and broader web signals. Other AI-assisted search experiences may blend answer, link, and comparison behaviour in their own ways.
+
+The first call should not pretend every surface is the same dashboard row.
+
+It should ask which surfaces matter to the buyer journey and what kind of expectation each one is likely to create.
+
+The Google caveat belongs here. Teams should not treat `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google's AI visibility. Useful, crawlable, credible pages and ordinary Search quality still matter. Machine-readable exports and structured content can be useful in some contexts, but they are not magic keys.
+
+### 4. Public sources and proof
+
+Answer engines can only work with what they can interpret.
+
+The first call should identify whether the public footprint gives them a clean story: what the company does, who it serves, what offer matters, what evidence supports the claim, and what action a buyer should take next. If the company has proof assets, case studies, technical notes, comparison pages, customer language, or sales evidence, those may improve the later baseline.
+
+But the first question is simpler:
+
+> If a buyer or answer engine looked at the public footprint today, would the priority offer be easy to understand?
+
+If the answer is no, deeper internal evidence may explain why, but it does not remove the public visibility problem.
+
+### 5. Commercial risk
+
+The baseline should end in risk language leadership can use.
+
+Not every weak answer is urgent. Not every absence matters. Not every citation problem deserves a sprint. The first call should separate low-risk noise from commercially relevant patterns: repeated absence for high-intent questions, competitor preference where pipeline is active, misframing of the offer, reliance on outdated sources, tool-only perception, weak conversion routes, or sales handoffs that lose the original buyer question.
+
+That is the reason for the first call.
+
+It translates answer-engine behaviour into business risk before the team commits to heavier analysis.
+
+## A better intake promise
+
+The intake promise for a first GEO baseline should be simple:
+
+Bring your domain, the offer you most need buyers to understand, the buyers who matter, and a few competitors or questions that would make leadership pay attention.
+
+That is enough to start.
+
+If the baseline shows a real commercial pattern, then ask for the material that improves the next stage. Search Console can help inspect the search-side source pattern. Analytics can help judge route performance. Sales notes can sharpen buyer language. Proof assets can support public evidence gaps. Internal documents can clarify positioning choices. None of those inputs should be dismissed.
+
+They should arrive when they have a job.
+
+This changes the tone of the sales conversation. Instead of saying, "Send us everything and we will audit it," the provider can say, "Let us find the visible commercial risk first. If there is something worth fixing, we will tell you exactly which extra inputs will make the diagnosis stronger."
+
+That is a lower-friction ask.
+
+It is also a more confident one.
+
+## The leadership question
+
+Before offering a GEO baseline, ask whether the first call is easy for a serious buyer to start.
+
+If the answer is no, the offer may be creating its own demand leak.
+
+A CMO should not need to organise a data-room project before learning whether answer engines are misrepresenting a priority offer. A Marketing Director should not need to extract every dashboard before understanding which buyer questions matter. A founder should not need to provide a complete archive before discovering whether competitors are becoming easier for AI systems to recommend.
+
+The first call should reduce uncertainty, not add administration.
+
+Start with the smallest useful commercial frame: domain, offer, buyer, competitor or question.
+
+Then let the baseline earn the deeper homework.


### PR DESCRIPTION
## Summary
- Adds Day 56 daily blog post: "Make the First GEO Call Easy to Start".
- Preserves the approved first-call-friction / lightweight intake angle for GEO baselines.
- Keeps the Google caveat intact and references ChatGPT, Claude, Perplexity, Gemini, Google AI features, and AI-assisted search.

## Verification
- [x] Isolated worktree/branch based on `origin/main`.
- [x] Payload scope verified: only `docs/blog/posts/daily-blog-day-56.md`.
- [x] `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-56.md` passed using the Hermes Python venv because system `python3` lacks `yaml`.
- [x] Content checks passed for required GEO terms, Google caveat terms, and forbidden/internal framing.
- [x] `mkdocs build` passed.

## Baseline warnings
`mkdocs build` warnings match the clean `origin/main` baseline for this worktree: Material/MkDocs 2.0 notice, `mkdocs_roamlinks_plugin` deprecation warning, existing unnaved pages, existing absolute blog nav paths, existing RoamLinks missing-target warnings, and existing AutoLinks missing `link-to-*` warnings.

## Notes
The source artifact's `geo_tactics` frontmatter contained unquoted `: ` values, which parsed as YAML dicts and failed the repo validator. This PR quotes those frontmatter list items without changing their text, and changes one body phrase from "AI visibility" to "answer-engine visibility" to satisfy the approved GEO wording requirement.
