### PR TITLE
docs: add daily blog day 57

### DIFF
--- a/docs/blog/posts/daily-blog-day-57.md
+++ b/docs/blog/posts/daily-blog-day-57.md
@@ -1,0 +1,195 @@
+---
+title: "Day 57: Measure Volatility Before You Call It Visibility"
+date: 2026-06-16
+slug: "day-57-measure-volatility-before-visibility"
+description: "A measurement note for CMOs, Marketing Directors, and founders: one answer-engine result is not market visibility. GEO needs sampling, volatility tracking, source drift, and competitor movement before leadership calls a brand visible or absent."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - measurement
+  - competitive visibility
+geo_tactics:
+  - Measure visibility as a pattern across repeated buyer-question families, answer engines, dates, and competitor sets rather than as one screenshot or one prompt run.
+  - Track answer volatility, share-of-answer, competitor movement, and citation or source drift before treating a brand as visible, absent, winning, or losing.
+  - Separate noisy prompt variation from actionable evidence by sampling high-intent questions on a cadence and recording which sources, competitors, and claims recur.
+  - Keep the Google caveat clear: Google's AI features do not require llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as visibility switches.
+---
+
+# Day 57: Measure Volatility Before You Call It Visibility
+
+One answer-engine result is not market visibility.
+
+It is a sample.
+
+That distinction matters for CMOs, Marketing Directors, and founders because Generative Engine Optimization can easily become a screenshot argument. Someone runs a prompt in ChatGPT, Claude, Perplexity, Gemini, or a Google AI feature. The brand appears, disappears, gets mentioned after a competitor, or is left out entirely. The team reacts as if the market has spoken.
+
+But answer engines are not static rankings pages. They summarise, select, cite, compress, and compare in ways that can change across engines, phrasing, timing, source availability, and the buyer question being asked.
+
+If leadership treats one run as proof, it will overreact to noise.
+
+If leadership measures volatility, it can see the pattern.
+
+<!-- more -->
+
+## A screenshot is not a signal
+
+A single answer can be useful as evidence that something is possible.
+
+It can show that an answer engine can name the company, can misunderstand the offer, can prefer a competitor, can cite an old page, or can build a category explanation without the brand in it. That is worth noticing.
+
+It is not enough to decide whether the company is visible.
+
+A screenshot does not answer the questions leadership actually needs:
+
+- Does the brand appear repeatedly for commercially important buyer questions?
+- Does it appear across the answer surfaces buyers are likely to use?
+- Does it appear with the right competitors, or only in isolated prompts?
+- Does the answer describe the offer accurately enough to create a sales route?
+- Are the cited or implied sources stable, current, and defensible?
+- Is the competitor movement persistent or just one noisy run?
+
+Those are measurement questions, not screenshot questions.
+
+The difference is the difference between saying, "We saw the brand once," and saying, "Across the buyer-question family that matters to pipeline, the brand appears in eight of twelve runs, competitors A and B are named more consistently, and the sources behind the answers are drifting between our current service page, an old blog post, and third-party category roundups."
+
+The second statement gives leadership evidence to interpret.
+
+The first gives leadership something to argue about.
+
+## Visibility is a pattern across buyer-question families
+
+GEO measurement should start with the questions a serious buyer would actually ask.
+
+Not one vanity prompt. Not one broad category query. Not a prompt designed to make the brand appear. A buyer-question family is a small cluster of related questions around the same commercial situation:
+
+- category discovery: "Who helps B2B companies improve AI search visibility?"
+- comparison: "Which agencies work on GEO for enterprise SaaS brands?"
+- problem diagnosis: "Why does ChatGPT recommend competitors but not our company?"
+- implementation risk: "How should a CMO measure whether answer engines understand our offer?"
+- purchase justification: "What should a founder ask before investing in GEO?"
+
+The exact questions will change by market, but the principle holds. A leadership team should measure the prompts tied to demand, sales risk, competitor comparison, and investment confidence.
+
+Then it should repeat them.
+
+Repeated sampling shows whether the brand is consistently absent, occasionally present, wrongly framed, source-dependent, or increasingly associated with the right commercial category. It also shows whether a competitor is genuinely easier for answer engines to recommend, or whether one result looked dramatic because the prompt wording accidentally favoured them.
+
+This is where share-of-answer becomes useful. Not as a vanity percentage, but as a way to ask, "When the market asks this family of buyer questions, how often are we part of the answer, how often are competitors part of it, and how often is the answer built from sources we can improve?"
+
+That is closer to usable visibility evidence.
+
+This is the step before threshold-setting. Before a team decides what score is good enough, what trend deserves escalation, or which investment should move first, it has to know whether the underlying evidence is stable enough to classify visibility at all.
+
+## Volatility changes the interpretation
+
+Volatility is not a measurement nuisance. It is part of the finding.
+
+If the answer changes dramatically every time the same buyer question is tested, the leadership conclusion should not be, "We are winning," or, "We are invisible." It should be, "This answer surface is unstable for this question, so we need more samples before calling the pattern visible, absent, improving, or declining."
+
+High volatility can mean several things.
+
+The market category may be poorly defined. The public sources may be thin or inconsistent. Competitors may have similar claims without strong differentiators. The answer engine may be switching between source types: vendor pages, review sites, listicles, documentation, news coverage, analyst content, or community discussions. The prompt may be too broad to expose a buyer-relevant route.
+
+Low volatility can also mean several things.
+
+It may show that one competitor owns the answer pattern. It may show that the answer engine repeatedly trusts the same source set. It may show that the company's current positioning is consistently misunderstood. Or it may show that the brand is reliably present for the right buyer question, which is a different commercial situation from appearing once in a cherry-picked prompt.
+
+The mistake is treating volatility as background noise.
+
+In GEO, volatility tells you how confident you should be in the classification.
+
+A CMO does not need perfect certainty before acting. But they do need to know whether a finding is stable enough to describe the market. If a brand is absent in one run and present in the next five, the readout should be different from a brand that is absent in twenty repeated high-intent runs across multiple surfaces.
+
+The same is true for competitors. One competitor mention may not matter. A competitor that appears repeatedly, gets named earlier, is described more clearly, and is supported by more current sources is a different problem.
+
+## Source drift matters as much as mentions
+
+The question is not only whether the brand appears.
+
+It is also what the answer engine appears to be using to understand the market.
+
+Source drift happens when repeated answers lean on different materials over time or across engines. One run may cite a current service page. Another may lean on an old blog post. Another may use a third-party category article. Another may summarise from pages without visible citations. Another may ignore the company entirely and build the answer from competitor pages.
+
+For leadership, that matters because sources shape the story.
+
+If a current page supports the priority offer but an old page carries the stronger crawlable explanation, the answer may preserve stale positioning. If third-party roundups explain competitors better than the company's own site explains its offer, the market may inherit someone else's framing. If Perplexity cites one source set while ChatGPT summarises another and Google AI features surface a different route, the team should not collapse those events into the same metric.
+
+Different answer surfaces behave differently.
+
+A citation in Perplexity is not the same event as a mention in ChatGPT. A Gemini or Google AI feature result sits closer to Google's broader search and quality ecosystem than a standalone conversational answer. Claude may give a careful explanation without producing the same visible source trail. ChatGPT may produce a confident category summary where the brand's inclusion, order, and framing vary by prompt and context.
+
+That does not mean each surface needs a completely separate strategy.
+
+It means measurement should preserve the differences long enough for leadership to interpret them. If the same competitor wins across surfaces, that is useful. If each surface reaches a different conclusion, that is useful too. If the brand only appears when the prompt names it, that is a weaker visibility claim than appearing unprompted in buyer-led category questions.
+
+The Google caveat belongs in this conversation. Teams should not treat `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google's AI visibility. Useful, crawlable, credible pages and ordinary search quality still matter. Machine-readable exports and structured content can help in some contexts, especially for non-Google discovery and agent-friendly interpretation, but they are not magic proof of visibility.
+
+## What leadership should ask before reacting
+
+Before turning one answer into a commercial response, leadership should ask a measurement set of questions.
+
+### 1. What buyer-question family are we measuring?
+
+If the prompt is not tied to a commercial situation, the result may be interesting without being useful. A CMO should know whether the question represents category discovery, competitor comparison, implementation risk, purchase justification, or post-referral validation.
+
+### 2. How many times have we sampled it?
+
+A single run can start the investigation. It should not finish it. Repeated samples across days, phrasings, and engines give the team a better view of answer volatility.
+
+### 3. Which competitors move with us?
+
+The issue is rarely just whether the brand appears. It is whether competitors appear more often, appear earlier, get clearer descriptions, receive stronger source support, or are associated with the buyer problem more consistently.
+
+### 4. Which sources keep showing up?
+
+A leadership team should know whether answers are leaning on current company pages, old content, third-party articles, competitor pages, review platforms, documentation, press, analyst material, or uncited summaries. Source drift can explain why the answer changes.
+
+### 5. Are we seeing noise or stable visibility evidence?
+
+Not every fluctuation deserves work. Not every absence is a crisis. The goal is to separate noisy prompt variation from evidence stable enough to classify the brand's presence, absence, competitor exposure, and source dependency.
+
+These are not end-buyer questions.
+
+They are management questions for deciding whether GEO evidence is stable enough to name.
+
+## The useful output is a volatility note, not a victory slide
+
+A strong GEO readout should not only say, "We are visible," or, "We are missing."
+
+It should say where the finding is stable, where it is volatile, and what would make the next sample smarter.
+
+For example:
+
+- "The brand is consistently absent for implementation-risk questions, but appears in category-discovery prompts when named alongside competitors."
+- "Competitor A appears more often across ChatGPT and Perplexity, but Gemini and Google AI features favour broader publisher sources."
+- "The answers that include us rely on an old service page, while the current offer page is not shaping the summary."
+- "The market category itself is unstable; answer engines rotate between consultants, SEO tools, content agencies, and internal AI workflow vendors."
+- "The competitor issue is real for comparison questions, but not for problem-diagnosis questions."
+
+This is more useful than a binary visibility score because it preserves interpretation context.
+
+A founder can see whether the issue is positioning. A Marketing Director can see which source assets are shaping the answer. A CMO can see whether the competitor risk is persistent enough to investigate. Sales can understand whether the handoff problem starts in the answer, the source, or the first conversation after the click.
+
+The point is not to create a giant dashboard before anyone acts.
+
+The point is to stop pretending one answer is the market.
+
+## The leadership question
+
+Before calling a brand visible, absent, winning, or losing in answer engines, ask whether the evidence has survived repetition.
+
+Has the same buyer-question family been sampled more than once? Have the relevant answer surfaces been separated rather than averaged away? Have competitor mentions been tracked as movement, not anecdotes? Have source changes been recorded? Is the finding stable enough to support the visibility classification?
+
+If not, the right conclusion is not confidence.
+
+It is curiosity with a measurement plan.
+
+GEO is not only about being named by an answer engine. It is about understanding whether the market can repeatedly find, describe, compare, and trust the company when buyer questions move through answer-led discovery.
+
+Visibility is a pattern.
+
+Measure the volatility before you declare the win.

--- a/docs/blog/posts/daily-blog-day-57.md
+++ b/docs/blog/posts/daily-blog-day-57.md
@@ -16,7 +16,7 @@ geo_tactics:
   - Measure visibility as a pattern across repeated buyer-question families, answer engines, dates, and competitor sets rather than as one screenshot or one prompt run.
   - Track answer volatility, share-of-answer, competitor movement, and citation or source drift before treating a brand as visible, absent, winning, or losing.
   - Separate noisy prompt variation from actionable evidence by sampling high-intent questions on a cadence and recording which sources, competitors, and claims recur.
-  - Keep the Google caveat clear: Google's AI features do not require llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as visibility switches.
+  - "Keep the Google caveat clear: Google's AI features do not require llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as visibility switches."
 ---
 
 # Day 57: Measure Volatility Before You Call It Visibility


### PR DESCRIPTION
## Summary
- Adds Day 57 Build-in-Public post: "Measure Volatility Before You Call It Visibility"
- Applies the approved final revision artifact to `docs/blog/posts/daily-blog-day-57.md`
- Keeps the PR payload isolated to the intended blog post file

## Checks
- Targeted frontmatter/content validation: PASS
- Forbidden terminology/internal-story check: PASS
- `mkdocs build --strict`: fails on 90 pre-existing site warnings (RoamLinks/AutoLinks/nav warnings), not introduced by this post
- `mkdocs build`: PASS

## Payload
- `docs/blog/posts/daily-blog-day-57.md` only
