### PR TITLE
docs: add day 58 build in public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-58.md
+++ b/docs/blog/posts/daily-blog-day-58.md
@@ -13,10 +13,10 @@ tags:
   - positioning
   - commercial diagnostics
 geo_tactics:
-  - Audit answer-engine descriptions for missing commercial facts: buyer fit, differentiators, proof points, use cases, comparison context, and next step.
-  - Compare actual answers against the buyer questions and decision criteria the company wants to own, then turn omissions into a prioritised content, positioning, and sales-enablement brief.
-  - Treat a brand mention without useful explanation as an incomplete visibility signal, especially when competitors are described more clearly or more credibly.
-  - Keep the Google caveat clear: Google's AI features do not require llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as visibility switches.
+  - "Audit answer-engine descriptions for missing commercial facts: buyer fit, differentiators, proof points, use cases, comparison context, and next step."
+  - "Compare actual answers against the buyer questions and decision criteria the company wants to own, then turn omissions into a prioritised content, positioning, and sales-enablement brief."
+  - "Treat a brand mention without useful explanation as an incomplete visibility signal, especially when competitors are described more clearly or more credibly."
+  - "Keep the Google caveat clear: Google's AI features do not require llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as visibility switches."
 ---
 
 # Day 58: Audit the Answer for What It Leaves Out

--- a/docs/blog/posts/daily-blog-day-58.md
+++ b/docs/blog/posts/daily-blog-day-58.md
@@ -1,0 +1,192 @@
+---
+title: "Day 58: Audit the Answer for What It Leaves Out"
+date: 2026-06-17
+slug: "day-58-audit-answer-for-what-it-leaves-out"
+description: "A diagnostic memo for CMOs, Marketing Directors, and founders: AI visibility work should inspect the useful commercial facts answer engines omit, not only whether the brand is mentioned."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - positioning
+  - commercial diagnostics
+geo_tactics:
+  - Audit answer-engine descriptions for missing commercial facts: buyer fit, differentiators, proof points, use cases, comparison context, and next step.
+  - Compare actual answers against the buyer questions and decision criteria the company wants to own, then turn omissions into a prioritised content, positioning, and sales-enablement brief.
+  - Treat a brand mention without useful explanation as an incomplete visibility signal, especially when competitors are described more clearly or more credibly.
+  - Keep the Google caveat clear: Google's AI features do not require llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as visibility switches.
+---
+
+# Day 58: Audit the Answer for What It Leaves Out
+
+A brand can appear in an AI answer and still lose the shortlist.
+
+That is the uncomfortable part of AI visibility measurement for CMOs, Marketing Directors, and founders. The first instinct is to ask whether ChatGPT, Claude, Perplexity, Gemini, or a Google AI feature names the company. That question matters, but it is not enough.
+
+A mention is not the same as a recommendation.
+
+If the answer says the brand exists but leaves out who it is best for, what makes it different, what evidence supports the claim, which use cases it fits, how it compares, or what a serious buyer should do next, the visibility is commercially thin. The company has been included in the answer, but not equipped to win the next conversation.
+
+That is why GEO work should audit omissions, not only mentions.
+
+<!-- more -->
+
+## The missing facts are the diagnostic
+
+Answer engines compress markets.
+
+They take public material, third-party context, competitor language, product pages, review content, documentation, articles, and the buyer's question, then produce a short explanation. In that compression, some facts survive and some disappear.
+
+The disappeared facts are useful.
+
+They show what the market cannot easily infer from the company's public footprint. They show where the brand's positioning is too vague, where proof is not prominent enough, where differentiators are not stated in buyer language, where comparison context is absent, and where the next step is not obvious.
+
+For leadership, this turns AI visibility from a vague anxiety into a practical diagnostic.
+
+Instead of asking only, "Did the answer mention us?" the better question is:
+
+> What would a qualified buyer still not understand after reading this answer?
+
+That question changes the work.
+
+A company may be visible by name but invisible by value. It may be listed beside competitors but not differentiated from them. It may be described accurately at a category level but not connected to the use case the buyer cares about. It may have strong proof somewhere on the site, but the answer does not carry that proof into the summary. It may be cited, linked, or named, yet still fail to create a reason to continue.
+
+Those are not vanity findings.
+
+They are briefs.
+
+## Six omissions worth tracking
+
+A useful omission audit does not need to become a giant dashboard. It needs a consistent checklist against the buyer questions the company wants to own.
+
+### 1. Buyer fit
+
+Does the answer explain who the company is best for?
+
+Not merely the broad category, but the commercial fit. Enterprise or mid-market. Technical or non-technical buyers. Regulated or fast-moving teams. Founder-led companies or large marketing departments. Complex buying committees or self-serve teams.
+
+If the answer names the brand but does not explain fit, the buyer is left to guess whether it belongs on the shortlist.
+
+That usually points to a positioning or page-structure problem. The public footprint may say what the company does without making the ideal buyer obvious. The fix may be clearer audience language, stronger segment pages, better use-case pages, or proof that maps to the buyers leadership actually wants.
+
+### 2. Differentiation
+
+Does the answer explain why the company is different from plausible alternatives?
+
+This is where many AI visibility readouts become too generous. A brand mention can look like progress until the same answer describes every provider with interchangeable language: helps teams improve visibility, supports AI search, offers audits, creates content, provides strategy.
+
+If the differentiator is missing, the answer may be technically accurate and commercially weak.
+
+The omission asks a hard question: is the difference absent from the answer because the answer engine missed it, or because the public material does not state it cleanly enough for a buyer to use?
+
+The response should not be to stuff pages with slogans. It should be to make the real commercial distinction explicit: method, operating model, technical depth, speed, governance, integration with sales, category focus, proof standard, or the specific risk the company is best at solving.
+
+### 3. Proof points
+
+Does the answer carry evidence, or only claims?
+
+A company can say it is experienced, technical, trusted, strategic, fast, data-driven, or specialist. Those words rarely survive as persuasion unless the answer can connect them to evidence.
+
+Useful proof may include case studies, measurable outcomes, customer examples, technical artefacts, named experience, independent references, certifications, public methodology, or credible demonstrations of the work. The right proof depends on the market.
+
+The omission matters because answer engines often summarise claims more easily than they preserve evidence. If competitors are described with concrete proof while the company is described with adjectives, the buyer receives an uneven comparison.
+
+That does not mean inventing proof or overstating results.
+
+It means making existing proof easier to find, interpret, and attach to the right buyer question.
+
+### 4. Use cases
+
+Does the answer explain when the company should be used?
+
+A generic category description may be enough for awareness. It is not enough for a serious buyer trying to decide whether to act.
+
+For GEO, the use-case layer is often where commercial relevance appears. A buyer may not simply ask, "Who does AI visibility?" They may ask who can help when competitors are being recommended first, when answer engines misunderstand the offer, when a new category needs explanation, when sales teams need better answer-led context, or when leadership needs a baseline before investing.
+
+If those use cases are missing, the brand may appear too abstract.
+
+The fix may be use-case pages, sharper service descriptions, examples tied to buying situations, or content that names the moments when the work becomes urgent.
+
+### 5. Comparison context
+
+Does the answer explain how the company relates to alternatives?
+
+Buyers rarely evaluate in isolation. They compare agencies, tools, consultants, in-house teams, incumbent SEO partners, AI workflow vendors, and sometimes doing nothing.
+
+If the answer names the company but gives richer context to competitors, the omission is commercial. The buyer may understand the competitor's place in the market before they understand yours.
+
+This does not require aggressive competitor pages or unsupported claims. It requires enough public context for an answer engine and a human buyer to understand the decision boundary. When is this company the better fit? When is another option more appropriate? What trade-off is the buyer actually making?
+
+Clear comparison context helps answer engines avoid flattening every provider into the same paragraph.
+
+It also helps sales teams, because the same omission usually appears in calls: buyers ask how the company differs, and the public answer has not prepared them.
+
+### 6. Next step
+
+Does the answer make the next commercial action obvious?
+
+Visibility without a next step can create curiosity without momentum. A buyer may see the brand, understand the category, and still not know what to do.
+
+The next step does not always have to be "book a call". It may be reading a diagnostic page, checking a methodology, comparing service options, reviewing examples, downloading a guide, or sending a specific internal question to the team.
+
+But if the answer creates interest and the public route does not support that interest, the opportunity leaks.
+
+This is why omission analysis belongs with route design and sales enablement, not only content production. The question is not just what the answer says. It is whether the answer leaves the buyer with enough context to take a useful next action.
+
+## A mention can hide a positioning problem
+
+The danger of mention-only reporting is that it can make weak visibility look like a win.
+
+A report that says "we appeared in three answer engines" may be factually true. It may also conceal that the answer called the company a generic marketing agency, omitted the priority offer, failed to mention the strongest proof, placed a competitor in a clearer category, and gave the buyer no reason to choose a next step.
+
+That is not a victory.
+
+It is a warning with a brand mention attached.
+
+The commercial question is whether the answer can help a buyer make progress. Can they understand the company's role? Can they see why it fits their situation? Can they compare it with alternatives? Can they trust the claim? Can they decide what to do next?
+
+If not, the brand has not become recommendable in the way leadership needs.
+
+This is also where surface-specific wording matters. Perplexity may expose citations more visibly. ChatGPT or Claude may produce a clean explanation without the same source trail. Gemini and Google AI features may present the company in contexts shaped by Google's broader search systems and result formats. Those differences should be preserved in the audit rather than collapsed into one generic "AI answer" score.
+
+The Google caveat stays intact. Teams should not treat `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google's AI visibility. Useful, crawlable, credible pages and ordinary search quality still matter. Machine-readable exports and structured content can be useful in some contexts, but they are not magic keys.
+
+## Turn omissions into a worklist
+
+The output of an omission audit should be a prioritised worklist, not a panic list.
+
+A simple structure works:
+
+- Buyer question tested: the commercial question or question family being inspected.
+- Answer surface: ChatGPT, Claude, Perplexity, Gemini, Google AI feature, or another relevant surface.
+- Brand treatment: absent, named, described, compared, cited, recommended, or misframed.
+- Missing facts: buyer fit, differentiator, proof, use case, comparison context, next step, or another commercially important attribute.
+- Commercial risk: why the omission matters to pipeline, sales confidence, category understanding, or competitive selection.
+- Likely fix: positioning update, service-page rewrite, proof asset, comparison explanation, use-case page, sales enablement note, or route improvement.
+- Owner: marketing, sales, product marketing, founder, SEO, content, or agency partner.
+
+That structure keeps the audit useful.
+
+It prevents the team from treating every weak answer as a demand for more content. Some omissions are messaging problems. Some are proof problems. Some are sales-enablement problems. Some are page hierarchy problems. Some are category-definition problems. Some are not urgent because the buyer question is not commercially important.
+
+The discipline is to connect the missing fact to the business consequence.
+
+If the answer omits buyer fit, the work may be audience clarity. If it omits proof, the work may be making evidence public or easier to cite. If it omits differentiators, the work may be sharper positioning. If it omits the next step, the work may be conversion-route design. If it omits comparison context, the work may be sales enablement and market education.
+
+That is a better planning input than "we need to rank in AI".
+
+## The leadership question
+
+Before celebrating a brand mention in an answer engine, ask what the answer left out.
+
+Would a serious buyer know who the company is for? Would they understand why it is different? Would they see credible proof? Would they know which use case it fits? Would they understand the comparison? Would they know what to do next?
+
+If the answer is no, the visibility work is not finished.
+
+The next sprint should not be driven by panic about AI search. It should be driven by the missing commercial facts that stop the company becoming easy to recommend.
+
+GEO is not only the work of getting named.
+
+It is the work of making the right explanation survive compression.


### PR DESCRIPTION
## Summary
- Adds the Day 58 Build in Public post: omission-analysis diagnostics for AI visibility/GEO.
- Applies the approved final artifact to `docs/blog/posts/daily-blog-day-58.md` only.

## Checks
- Targeted frontmatter/content checks passed: title/date/slug, required metadata, forbidden terminology, internal-story framing, and Google AI caveat.
- Source artifact copy verified byte-for-byte with `cmp`.
- `mkdocs build --strict` failed on existing site-wide warning classes (RoamLinks/AutoLinks/nav warnings, plus the generated absolute blog nav warning).
- `mkdocs build` passed.

## Payload
- `docs/blog/posts/daily-blog-day-58.md` only.
