### PR TITLE
docs: add day 59 build-in-public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-59.md
+++ b/docs/blog/posts/daily-blog-day-59.md
@@ -1,0 +1,166 @@
+---
+title: "Day 59: Retire the Page Before It Teaches the Market"
+date: 2026-06-18
+slug: "day-59-retire-the-page-before-it-teaches-the-market"
+description: "A practical GEO note for CMOs, Marketing Directors, and founders: stale public pages, old claims, and orphaned offers keep instructing buyers and answer engines until they are retired, redirected, replaced, or clearly contextualised."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - content governance
+  - positioning
+geo_tactics:
+  - "Treat every public page, PDF, help article, archive, and comparison page as market instruction until it has a clear lifecycle state: current, replaced, archived, redirected, or intentionally unavailable."
+  - "Map stale claims to commercial risk: outdated offers, deprecated product language, prototype positioning, old pricing, unsupported category claims, and pages that answer buyer questions the company no longer wants to own."
+  - "Use canonical replacements, redirects where appropriate, navigation and sitemap control, clear archive or noindex decisions where technically justified, and recurring checks across search and answer surfaces."
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-structured data are not required switches for Google AI visibility."
+---
+
+# Day 59: Retire the Page Before It Teaches the Market
+
+A page does not stop working because the team stopped believing it.
+
+That is the uncomfortable part of public content governance for CMOs, Marketing Directors, and founders. An old landing page, a forgotten comparison article, a prototype offer, a deprecated product claim, or a buried help document can still be found, quoted, summarised, forwarded, and used to explain the company.
+
+The market does not know that a page is stale unless the company makes that state legible.
+
+Answer engines and search systems do not see the private meeting where strategy changed. Buyers do not see the internal note that a claim was withdrawn. Sales teams still inherit the objection when someone arrives with yesterday's promise, yesterday's category language, or yesterday's offer in their head.
+
+That is why page retirement belongs inside GEO governance.
+
+<!-- more -->
+
+## Old pages become accidental positioning
+
+Most companies treat publishing as the visible act and retirement as housekeeping.
+
+That is backwards.
+
+Publishing tells the market what the company wants to be known for today. Retirement tells the market what the company no longer wants to be held to tomorrow. If the second motion is weak, the first one is compromised.
+
+A stale page can create several commercial problems at once.
+
+It can describe an offer the company no longer sells. It can promise a feature that has been deprecated or renamed. It can use positioning from an earlier stage of the business. It can frame the company around a category it has outgrown. It can preserve early, experimental copy that was useful for speed but not strong enough to become durable market language.
+
+None of those pages need to be prominent to cause trouble.
+
+They only need to be retrievable.
+
+A buyer may find one through search. A competitor may link to it in a comparison. A sales prospect may ask an AI system to explain the company and receive a summary influenced by old material. A journalist, analyst, partner, or internal team member may reuse a claim because it still looks public and official.
+
+When that happens, the company is not merely suffering from content clutter. It is teaching the market two stories at once.
+
+One story says what the company believes now. The other says what the internet can still prove it once said.
+
+## GEO is also withdrawal discipline
+
+GEO is often discussed as an additive discipline: create clearer pages, publish better explanations, structure useful answers, strengthen comparison content, improve category language, and make proof easier to find.
+
+That work matters.
+
+But visibility is not only shaped by what a company adds. It is shaped by what it leaves in circulation.
+
+Answer engines and search systems work from public traces: pages, snippets, citations, third-party mentions, documentation, reviews, articles, cached references, links, and repeated language across the web. Different systems retrieve, rank, and summarise in different ways, and no team controls the whole process. But a team can control a large part of its own public footprint.
+
+That control includes withdrawal.
+
+If a claim is no longer true, leaving it live is not neutral. If a product line has changed, leaving the old offer discoverable without context is not neutral. If a comparison page reflects a market that has moved on, leaving it unreviewed is not neutral. If a prototype page was never meant to become a durable description of the company, letting it remain indexable and linked is not neutral.
+
+Those pages are still inputs.
+
+They can be selected, summarised, compared, contradicted, or used as supporting context. They can also create uncertainty when newer pages say something different. In a human buying process, inconsistency becomes a question. In an answer environment, inconsistency becomes a compression problem: which version of the company should the system carry forward?
+
+The practical goal is not to erase history. It is to make the status of history clear.
+
+A company can say: this is current. This replaces the old version. This page is preserved for archive context. This offer is retired. This claim no longer applies. This page should redirect. This document should not appear in discovery surfaces. This comparison has been updated.
+
+That is governance, not tidying.
+
+## The stale-page audit starts with buyer risk
+
+A useful retirement audit should not begin with the largest sitemap export and a vague instruction to "clean up content".
+
+It should begin with commercial risk.
+
+Ask which public materials could create the wrong expectation in a serious buyer's mind.
+
+Start with offer pages. Are there services, packages, products, workshops, tools, integrations, or pricing references that no longer match what the business sells? If a buyer found the page today, would sales honour it, explain it away, or have to apologise for it?
+
+Then review positioning pages. Are there old category labels, old audience definitions, old claims about being "for everyone", or early-stage descriptions that conflict with current strategy? If an answer engine summarised the company from that page, would leadership recognise the result?
+
+Next, review proof and comparison pages. Are there case-style claims that lack current context? Are competitor comparisons outdated? Are benchmark statements still defensible? Are old badges, partner references, or integrations presented as if they are current?
+
+Then check orphaned assets. PDFs, old campaign pages, changelog posts, help documents, launch announcements, webinar pages, media kits, glossary pages, and experimental concept pages often survive outside the main navigation. They may not be part of the current site journey, but they can still be part of the public record.
+
+The audit question is simple:
+
+> If this page appeared in an AI-generated summary or a buyer's pre-call research, would it help the deal, confuse the deal, or create an objection from an old strategy?
+
+That question keeps the work grounded.
+
+It avoids treating retirement as an aesthetic cleanup. It connects lifecycle decisions to the conversations that revenue teams actually have.
+
+## Not every old page should disappear
+
+Retirement does not always mean deletion.
+
+Sometimes the right move is a redirect to the current page. If an old offer has a direct replacement, a permanent redirect can preserve the route while making the current version clear. The buyer gets the right destination, and search systems receive a stronger signal about which page should represent the topic.
+
+Sometimes the right move is a canonical replacement. If two pages overlap, the company may need one clear current source rather than several near-duplicates that compete to explain the same thing.
+
+Sometimes the right move is an archive label. Historical material can be valuable when it is clearly marked as historical. A launch note, research post, or deprecated documentation page may deserve to stay available, but not masquerade as current guidance.
+
+Sometimes the right move is removal from navigation and sitemap surfaces. A page can remain accessible for specific users while no longer being promoted as a current market asset.
+
+Sometimes noindex is appropriate. That should be a technical and strategic decision, not a panic reflex. There are good reasons to keep some pages discoverable and good reasons to remove others from search discovery. The point is to decide deliberately.
+
+And sometimes the right move is deletion.
+
+If a page is inaccurate, commercially harmful, unsupported, or created for a moment that should not persist, preserving it out of inertia is not governance. It is risk acceptance without a decision.
+
+The exact mechanism matters less than the discipline: every material public page should have an owner, a currentness state, and a replacement or retirement path.
+
+## Watch the answers after the change
+
+Retiring stale material is not complete the moment a redirect ships or a page is archived.
+
+The team still needs to watch what buyers and answer surfaces do with the change.
+
+Search results may take time to update. Third-party pages may still quote old language. AI answers may continue to surface stale phrasing if it exists elsewhere or if the newer replacement is less clear. Sales calls may reveal that prospects are still arriving with old assumptions.
+
+That does not mean the retirement failed. It means the footprint has layers.
+
+A practical GEO workflow should include recurring stale-source checks. Ask common buyer questions in the systems your market actually uses. Search for old offer names, retired claims, outdated category phrases, and deprecated product language. Look for snippets that still carry withdrawn language. Review the pages answer engines cite or appear to rely on. Ask sales which objections sound like they came from public material rather than the current pitch.
+
+The finding is not always "publish more".
+
+Sometimes the finding is "make the replacement page stronger". Sometimes it is "redirect the old route". Sometimes it is "mark the archive more clearly". Sometimes it is "update partner copy". Sometimes it is "stop repeating the old phrase in new material".
+
+For Google AI features specifically, the work should stay grounded in normal search quality and accessibility, not folklore. There is no need to pretend that llms.txt, special AI markup, arbitrary content chunking, or over-engineered structured data acts as a required switch for Google AI visibility. The better discipline is the boring, durable one: make current pages useful, crawlable, internally coherent, and clearly preferred over stale alternatives.
+
+## The commercial test
+
+The leadership question is not, "Have we cleaned up the site?"
+
+The better question is:
+
+> Are we still publicly teaching anything we would not want a qualified buyer, analyst, journalist, partner, salesperson, or answer engine to repeat?
+
+That question changes the standard.
+
+It makes retirement part of positioning. It makes redirects part of sales enablement. It makes archive labels part of trust. It makes sitemap and navigation choices part of market instruction. It makes claim withdrawal visible as a real operating discipline, not a private preference trapped in a planning document.
+
+Companies that ignore this will keep fighting ghosts. A buyer will ask about an offer nobody sells. An AI answer will describe an old category fit. A sales call will begin with a correction. A competitor will look clearer because its public story has fewer unresolved versions.
+
+Companies that manage it well give the market fewer wrong paths to follow.
+
+They do not rely on the newest page to overpower every old trace by magic. They decide which pages should speak, which should point elsewhere, which should be labelled as history, and which should stop teaching altogether.
+
+That is the GEO lesson.
+
+Every public page is an instruction until the company changes, replaces, contextualises, or retires it.
+
+If the page no longer represents the business, do not let it keep representing the business to the market.


### PR DESCRIPTION
## Summary
- Adds the approved Day 59 Build in Public post about page retirement, redirects, archive decisions, and claim withdrawal as GEO governance.
- Applied only `docs/blog/posts/daily-blog-day-59.md` on a clean branch from `origin/main`.
- Preserved the approved artifact content, with only YAML quoting added in `geo_tactics` so frontmatter validates as strings.

## Checks
- Content assertions passed: frontmatter/date/title/slug/description and `<!-- more -->` present; Google AI caveat present.
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-59.md` passed.
- `mkdocs build --strict` failed on 90 pre-existing site warnings (RoamLinks/autolinks/nav warnings), not on this post.
- `mkdocs build` passed.

## Payload
- `git diff --name-only origin/main...HEAD` contains only `docs/blog/posts/daily-blog-day-59.md`.
