### PR TITLE
docs: publish daily blog day 60

### DIFF
--- a/docs/blog/posts/daily-blog-day-60.md
+++ b/docs/blog/posts/daily-blog-day-60.md
@@ -1,0 +1,181 @@
+---
+title: "Day 60: Capture the Buyer Question Before You Count the AI Lead"
+date: 2026-06-19
+slug: "day-60-capture-the-buyer-question-before-you-count-the-ai-lead"
+description: "A practical sales-handoff note for CMOs, Marketing Directors, and founders: AI-referred demand should be qualified by the buyer question that created it, not only by the referrer or a generic AI lead label."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - sales handoff
+  - demand qualification
+geo_tactics:
+  - Capture the buyer question, answer surface, buyer interpretation, competitor context, and next objection when a prospect arrives from ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led surface.
+  - Treat AI-referred demand as a feedback loop for prompt-family tracking, offer positioning, CTA design, sales follow-up, competitor comparisons, and GEO prioritisation.
+  - Separate qualified demand, wrong-fit curiosity, competitor-comparison pressure, and route confusion before counting a lead as evidence that AI visibility is working.
+  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility.
+---
+
+# Day 60: Capture the Buyer Question Before You Count the AI Lead
+
+The least useful version of an AI lead is the label.
+
+A prospect arrives and someone writes, "Came from ChatGPT," "Saw us in Perplexity," "Google AI result," or simply "AI referral." For a CMO, Marketing Director, or founder, that sounds like progress. It suggests that answer-led discovery is becoming commercially real rather than a slide in a strategy deck.
+
+But the label is too thin to manage.
+
+It does not explain what the buyer asked. It does not show what the answer taught them before they arrived. It does not reveal whether they were comparing vendors, looking for a definition, checking a claim, validating a shortlist, trying to solve an urgent problem, or wandering through a broad curiosity query with no buying intent.
+
+The commercial evidence is not only that AI appeared somewhere in the journey.
+
+The useful evidence is the buyer question that created the journey.
+
+<!-- more -->
+
+## The question carries the intent
+
+AI-referred demand can look deceptively clean in a report.
+
+A source field says referral. A landing page shows a visit. A form note says the prospect found the company through ChatGPT, Claude, Perplexity, Gemini, a Google AI feature, or another answer-led surface. A screenshot circulates internally. The team sees a new path into pipeline and wants to count it.
+
+Counting matters, but it should not be the first diagnostic.
+
+The first diagnostic is the question.
+
+A buyer asking "best GEO agency for B2B SaaS" is in a different state from a buyer asking "what is generative engine optimization". A buyer asking "Zero Shot Agency alternatives" is different from one asking "how do I know if ChatGPT is sending qualified leads". A founder asking whether AI search is worth investment has a different objection from a Marketing Director asking how sales should follow up when a prospect quotes an answer engine.
+
+Those questions may all create an AI-influenced touchpoint.
+
+They do not create the same commercial situation.
+
+The question tells the team whether the buyer is researching the category, validating a vendor, comparing options, checking risk, looking for implementation help, or trying to route an internal decision. Without that context, the lead is easy to overvalue, undervalue, or misunderstand.
+
+That is why sales should not only ask, "Where did you hear about us?"
+
+They should ask, lightly and naturally:
+
+> What were you trying to find out when you asked?
+
+That one answer is often more useful than the source label.
+
+## The surface changes what the buyer brings into the call
+
+The same buyer question can create different expectations depending on the surface that answered it.
+
+Perplexity may expose citations and make the buyer conscious of sources. ChatGPT or Claude may give a fluent explanation that feels like a recommendation even when the source trail is not the main event. Gemini and Google AI features may appear alongside or inside a broader search journey shaped by Google's ranking and result systems. Other vertical tools, community summaries, or workflow assistants may wrap the answer in their own context.
+
+That means the sales handoff should preserve the surface, but not stop there.
+
+The surface helps explain the buyer's mental state. Did they arrive with links they had already reviewed? Did they see competitors named beside the brand? Did they receive a short category definition, a ranked list, a comparison paragraph, a source-backed answer, or a broad summary? Did the answer push them towards a call, a checklist, a pricing question, a competitor comparison, or a sceptical objection?
+
+A simple note can capture enough:
+
+- Buyer question: what they asked or were trying to answer.
+- Surface: where the answer came from, if they know.
+- Interpretation: what they took away from the answer.
+- Competitor context: who else was named or compared.
+- Next objection: what they still need to believe before moving forward.
+
+That is not a giant intake burden.
+
+It is a better sales handoff.
+
+It turns "AI lead" into a short commercial record: this buyer arrived with this question, from this answer context, with this assumption, and this remaining uncertainty.
+
+## Do not confuse curiosity with qualified demand
+
+The danger of counting AI leads too early is that every answer-led arrival starts to look like proof of market traction.
+
+Some of it will be qualified demand. A serious buyer has a problem, asks a high-intent question, sees the company framed as credible, and arrives ready to discuss fit.
+
+Some of it will be wrong-fit curiosity. A student, competitor, founder, investor, researcher, or early-stage operator asks a broad question and clicks through because the brand appeared in the answer. That is useful visibility, but it may not be pipeline.
+
+Some of it will be competitor-comparison pressure. The buyer is not asking whether the category exists. They are asking why this company instead of another one. That does not require a generic nurture path. It requires sharper differentiation, proof, and sales follow-up.
+
+Some of it will be route confusion. The buyer had real intent, but the answer sent them to an awkward page, an old offer, a tool that looked like the whole service, or a next step that did not match the question. The source label may say AI. The real issue may be positioning or route design.
+
+These distinctions matter because they produce different actions.
+
+Qualified demand should inform sales priority and follow-up. Wrong-fit curiosity may belong in education or exclusion. Competitor-comparison pressure should feed comparison pages, proof assets, objection handling, and offer positioning. Route confusion should feed CTA, landing-page, and handoff fixes.
+
+If all four are reported as "AI leads", the business learns almost nothing.
+
+## Question capture improves attribution without pretending to perfect it
+
+This is not a call for perfect AI attribution.
+
+Perfect attribution is the wrong promise. Buyers move across private chats, public search, internal Slack threads, forwarded links, sales conversations, review sites, podcasts, webinars, and competitor pages. Many will not remember the exact answer. Some will paraphrase. Some will say "ChatGPT" when the real path included Google, a colleague, and three vendor pages.
+
+That does not make question capture useless.
+
+It makes it practical.
+
+The goal is not to reconstruct every step of the journey with forensic certainty. The goal is to collect enough context to improve commercial decisions. If several prospects arrive after asking variations of the same question, the team has a prompt family worth tracking. If multiple buyers mention the same competitor in AI answers, the comparison gap deserves attention. If the same misconception keeps appearing, the public footprint may be teaching the market badly. If high-intent questions send buyers to low-intent pages, the route needs repair.
+
+The pattern is the value.
+
+A useful monthly review might ask:
+
+- Which buyer questions created serious conversations?
+- Which surfaces shaped the strongest or weakest expectations?
+- Which competitors appeared in the buyer's pre-call context?
+- Which objections seemed to be created or amplified by answer-led discovery?
+- Which pages, proof points, or offers did buyers expect to see next?
+- Which questions produced curiosity but not fit?
+
+Those answers improve attribution because they connect source signals to buyer intent.
+
+They also prevent attribution theatre. The team is not claiming, "AI caused this deal." It is saying, "This buyer question, on this surface, shaped the conversation in this commercially useful way."
+
+That is a stronger management signal.
+
+## The feedback loop belongs to marketing and sales together
+
+Question capture fails when it becomes another field nobody trusts.
+
+If marketing designs a complex form that sales never uses, the insight disappears. If sales hears the buyer question but records only the source label, marketing cannot improve the public footprint. If leadership asks for an AI pipeline number without asking what those buyers actually wanted, the programme drifts towards vanity reporting.
+
+The workflow should be lighter.
+
+Sales captures the language in the buyer's words. Marketing groups those notes into prompt families, surfaces, objections, and content gaps. Product marketing or founders inspect the repeated patterns for positioning and offer implications. GEO work then prioritises fixes based on commercial frequency and severity, not only on ranking anxiety.
+
+A buyer says they asked, "Who can help us understand why AI answers recommend our competitor?" That points to competitor audit content, proof of diagnostic method, and sales follow-up around comparison pressure.
+
+A buyer says they asked, "How do we know if AI search is sending us real demand?" That points to measurement framing, source capture, question families, and qualification language.
+
+A buyer says they asked, "What does Zero Shot Agency actually do?" That may be a positioning warning if the answer they received was generic.
+
+A buyer says they asked, "Do we need llms.txt to appear in Google AI answers?" That requires a careful answer. For Google AI features, teams should stay grounded in Google's core Search ranking and quality systems. Useful, crawlable, credible, coherent pages matter. There is no need to pretend that llms.txt, special AI markup, arbitrary chunking, or over-focused structured data is a required visibility switch.
+
+Each question becomes a work item only if it carries commercial weight.
+
+That is the discipline.
+
+## The better sales note
+
+The next time a prospect says AI helped them find the company, resist the urge to stop at the source.
+
+Do not only ask whether it was ChatGPT, Claude, Perplexity, Gemini, Google, or something else.
+
+Ask what they were trying to find out. Ask what the answer made them believe. Ask who else appeared. Ask what still felt unclear. Ask which page or next step they expected after the answer.
+
+Then record the short version.
+
+Not a transcript. Not a surveillance exercise. Not a perfect attribution model.
+
+A sales note:
+
+> Asked ChatGPT for agencies that can diagnose why competitors are appearing in AI answers. Saw us and two larger SEO agencies. Took away that we are more technical but wanted proof of commercial outcomes. Next objection: whether this is a one-off audit or an ongoing operating model.
+
+That note is commercially useful.
+
+It helps sales follow up with the right proof. It helps marketing see the comparison frame. It helps leadership understand whether AI visibility is creating demand, pressure, confusion, or education. It helps the GEO work focus on the buyer questions that actually shape consideration.
+
+The AI lead label can stay in the CRM.
+
+But it should not be the only thing the company learns.
+
+If answer-led discovery is becoming part of the buying journey, the question is the handoff. Capture it before counting the lead.

--- a/docs/blog/posts/daily-blog-day-60.md
+++ b/docs/blog/posts/daily-blog-day-60.md
@@ -16,7 +16,7 @@ geo_tactics:
   - Capture the buyer question, answer surface, buyer interpretation, competitor context, and next objection when a prospect arrives from ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led surface.
   - Treat AI-referred demand as a feedback loop for prompt-family tracking, offer positioning, CTA design, sales follow-up, competitor comparisons, and GEO prioritisation.
   - Separate qualified demand, wrong-fit curiosity, competitor-comparison pressure, and route confusion before counting a lead as evidence that AI visibility is working.
-  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
 ---
 
 # Day 60: Capture the Buyer Question Before You Count the AI Lead


### PR DESCRIPTION
## Summary
- Publishes Day 60 Build-in-Public post: "Capture the Buyer Question Before You Count the AI Lead".
- Adds the approved/revised final artifact to `docs/blog/posts/daily-blog-day-60.md`.
- Keeps the post focused on the buyer question behind AI-referred demand before counting it as an AI lead.

## Angle / freshness rationale
- Selected angle score: 27/30 across freshness, buyer relevance, GEO specificity, source-material fit, commercial usefulness, and low repetition risk.
- Chosen to avoid recent repetition of proof, evidence, trust, source-path, and public-corpus themes.
- Preserves the accurate Google caveat: Google AI visibility is grounded in core Search ranking and quality systems, not `llms.txt`, special AI markup, arbitrary chunking, or over-structured data as required switches.

## Verification
- Confirmed final artifact exists at `/home/claw/.hermes/zsa-editorial-artifacts/day-60/revision/daily-blog-day-60.md`.
- Content checks passed for title/date/slug, buyer audience, answer-engine references, Google caveat, and absence of forbidden internal process terms.
- `mkdocs build --strict` failed due to existing site warnings (RoamLinks/AutoLinks/nav warnings); it did not surface a fatal content error for this post.
- `mkdocs build` passed successfully.
- Confirmed PR payload contains only `docs/blog/posts/daily-blog-day-60.md`.
