### PR TITLE
docs: add daily blog day 62

### DIFF
--- a/docs/blog/posts/daily-blog-day-62.md
+++ b/docs/blog/posts/daily-blog-day-62.md
@@ -1,0 +1,144 @@
+---
+title: "Day 62: Give Every AI Visibility Gap a Next Decision"
+date: 2026-06-21
+slug: "day-62-give-every-ai-visibility-gap-a-next-decision"
+description: "A practical GEO operating note for CMOs, Marketing Directors, and founders: an AI visibility baseline is only useful when each gap is routed to a commercial decision, owner, risk, and next evidence."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - action register
+  - commercial prioritisation
+geo_tactics:
+  - "Turn answer-engine gaps into a decision register that names the gap type, commercial risk, next decision, owner, and next evidence instead of treating every finding as a generic content task."
+  - "Route omissions, weak comparisons, unsupported claims, stale material, proxy-only signals, and buyer-route problems to different actions: rewrite, prove, compare, retire, route, monitor, or defer."
+  - "Prioritise gaps by commercial consequence and decision urgency before assigning budget, content work, sales enablement, source correction, or monitoring cadence."
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 62: Give Every AI Visibility Gap a Next Decision
+
+An AI visibility baseline should not leave a CMO, Marketing Director, or founder with a long diagnostic dump and a vague instruction to publish more content.
+
+The valuable output is a register of decisions.
+
+Each gap should say what commercial risk it creates, what choice the business now has to make, who should own that choice, and what evidence would change the answer. Without that translation layer, the baseline becomes another report: interesting, defensible, and difficult to act on.
+
+GEO becomes useful when visibility findings are converted into prioritised decisions.
+
+<!-- more -->
+
+## A finding is not yet an action
+
+Answer-led discovery creates many kinds of gaps.
+
+ChatGPT may omit the company from a category answer. Claude may describe the offer accurately but miss the strongest proof point. Perplexity may cite a useful source while framing the comparison around the wrong competitors. Gemini may surface an old public claim. A Google AI feature may reflect the same strengths and weaknesses already present in core Search because Google's AI features rely on core Search ranking and quality systems.
+
+Those are not the same problem.
+
+They should not receive the same response.
+
+One gap may require a clearer public claim. Another may need third-party proof. Another may need a comparison asset. Another may require retiring stale material. Another may simply need monitoring because one answer snapshot is not enough to justify a campaign.
+
+If the baseline turns every gap into "write another page", it has skipped the commercial work.
+
+## The action register is the useful artefact
+
+A practical post-baseline register should be simple enough for a leadership team to review and specific enough for specialists to execute.
+
+It does not need to be a complicated scoring model. It needs to prevent findings from floating around as loose observations.
+
+A useful row might include:
+
+| Gap type | Commercial risk | Next decision | Owner | Next evidence |
+|---|---|---|---|---|
+| Brand omitted from a high-intent category answer | Buyers may build shortlists without seeing the company | Decide whether this category deserves a visibility push now | Marketing lead | Repeat prompts across surfaces, compare named competitors, review ranking/citation sources |
+| Competitor described with clearer proof | Sales starts the conversation behind the strongest alternative | Decide whether to add stronger proof to the public claim or build a comparison asset | Founder or proposition owner | Current proof inventory, win/loss notes, competitor answer captures |
+| Answer cites an old or weak source | The market may learn a dated version of the offer | Decide whether to update, replace, outreach, or retire the source | Content owner | Source review, traffic and citation context, updated claim set |
+| Buyer lands on a poor next step after an AI-assisted journey | Qualified attention leaks after discovery | Decide whether to change the route, CTA, or follow-up question | Demand or sales lead | Landing-page behaviour, form notes, sales call context |
+| Only proxy signals exist | Team may overclaim visibility before seeing the answer | Decide whether to inspect now or monitor until direct answer evidence exists | GEO lead | Saved answer transcripts, citation checks, search context |
+| One volatile answer shows a risky claim | Team may overreact to a single run | Decide whether to monitor, correct public material, or escalate | Marketing lead | Repeated captures by prompt family, surface, and date |
+
+The register does two things at once.
+
+It keeps commercial risk visible, and it keeps the response disciplined.
+
+## Different gaps need different decisions
+
+The most common mistake after a baseline is flattening the work.
+
+An omission is treated like a stale claim. A weak comparison is treated like a missing blog post. A citation issue is treated like a technical switch. A buyer-route problem is treated like an awareness problem. A single volatile answer is treated like proof of market movement.
+
+That flattening creates expensive busywork.
+
+A brand omission may be a positioning issue, a source issue, a competitive strength issue, or a prompt-family issue. The next decision is not automatically "publish more". It may be to decide which category the company wants to be eligible for, whether the public site actually supports that category, and whether the category is commercially worth pursuing.
+
+A weak comparison may call for sharper proof, but it may also reveal that the business has not made its trade-offs legible. If an answer engine lists the company beside poor-fit competitors, the decision may be to publish a comparison asset, clarify the offer boundary, or stop chasing that comparison because it attracts the wrong buyer.
+
+A stale claim may not need a new campaign. It may need governance. If old pages, old decks, old directory entries, or old partner descriptions are teaching the market the wrong version of the company, the decision is whether to update, redirect, retire, or correct those sources.
+
+A buyer-route gap is different again. If the answer creates demand but the next page asks the wrong question, the issue is not only visibility. It is conversion path design. The decision belongs with the team responsible for turning attention into a qualified conversation.
+
+## Owners prevent the register becoming another report
+
+The register should not only say what was found. It should say who can make the next decision.
+
+That does not mean every row needs a committee.
+
+Some rows belong with marketing because the public claim is unclear. Some belong with sales because the buyer question changes qualification. Some belong with product because the answer exposes a feature misunderstanding. Some belong with the founder because the category choice or comparison set is strategic. Some belong with content because stale material is shaping the market. Some belong with a GEO or analytics lead because the current evidence is too thin and needs monitoring rather than action.
+
+The owner is not there for bureaucracy.
+
+The owner is there to stop a baseline from becoming everybody's problem and nobody's decision.
+
+## The next evidence matters as much as the next action
+
+A good action register also names what would change the decision.
+
+That is especially important in GEO because answer surfaces vary. ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led products do not expose the same mechanics, citations, freshness signals, or buyer routes. A finding that appears once in one surface should not automatically trigger the same investment as a repeated high-intent gap across several surfaces.
+
+The next evidence might be another prompt sample. It might be a source review. It might be a competitor comparison capture. It might be a sales note from a buyer who arrived with an answer already in their head. It might be a Search result, because Google AI features are connected to core Search quality systems rather than a separate switch that can be toggled with special markup.
+
+Naming the next evidence keeps the team honest.
+
+It says, "We are not ignoring this." It also says, "We are not pretending this is proven yet."
+
+## The leadership question is prioritisation
+
+For buyers of GEO work, the strategic question is rarely, "How many gaps did the audit find?"
+
+A large enough baseline will always find gaps.
+
+The better question is:
+
+> Which gaps deserve a decision this month?
+
+That question changes the shape of the work. It pulls the conversation away from raw findings and towards commercial consequence.
+
+- Which gap could exclude the company from an active shortlist?
+- Which gap teaches the market the wrong category?
+- Which gap makes a competitor easier to trust?
+- Which gap sends qualified attention to the wrong page?
+- Which gap is too thin to act on but important enough to monitor?
+- Which gap should be deliberately ignored because the buyer, category, or prompt family is not worth the effort?
+
+That last option matters.
+
+A mature action register must allow "do nothing yet" as a real decision. Otherwise every signal becomes a task, every task becomes content, and the team loses the ability to prioritise.
+
+## The baseline should end with choices
+
+An AI visibility baseline is only commercially useful if it helps the business choose.
+
+Choose the category to defend. Choose the comparison to clarify. Choose the claim to substantiate. Choose the stale material to retire. Choose the buyer route to improve. Choose the volatile signal to monitor. Choose the gap that does not deserve budget yet.
+
+That is why the action register matters.
+
+It turns answer-engine findings into decisions a business can budget, delegate, review, and revisit. It gives every gap a next step without pretending every gap needs the same response.
+
+The point is not to make the diagnostic longer.
+
+The point is to make the next decision visible.


### PR DESCRIPTION
## Summary
- Adds Day 62 daily blog post: “Give Every AI Visibility Gap a Next Decision”
- Preserves the post-baseline action-register angle: rewrite, prove, compare, retire, route, monitor, or defer
- Keeps the Google AI caveat and cross-surface GEO framing across ChatGPT, Claude, Perplexity, Gemini, and Google AI features / AI-assisted search

## Verification
- [x] Payload scoped to one file: `docs/blog/posts/daily-blog-day-62.md`
- [x] Forbidden-frame/content scan passed: no repo update, PR recap, bug report, implementation note, internal automation chronology, SearchGPT, ChatGPT with browsing, or Google-special-markup framing
- [x] `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-62.md`
- [x] `git diff --cached --check`
- [x] `mkdocs build`

## Notes
- Quoted the `geo_tactics` frontmatter list items in the copied post so the existing frontmatter validator parses entries containing `: ` as strings.
- `mkdocs build` passed with existing site warnings: MkDocs 2.0 advisory, mkdocs-roamlinks-plugin deprecation notice, excluded-from-nav informational entries, absolute nav path informational entries, and existing RoamLinks/AutoLinks missing-target warnings.
