### PR TITLE
docs: add daily blog day 63

### DIFF
--- a/docs/blog/posts/daily-blog-day-63.md
+++ b/docs/blog/posts/daily-blog-day-63.md
@@ -1,0 +1,185 @@
+---
+title: "Day 63: Compare the Explanation, Not Just the Ranking"
+date: 2026-06-22
+slug: "day-63-compare-explanation-not-ranking"
+description: "A competitive GEO diagnostic memo for CMOs, Marketing Directors, and founders: the useful question is not only who appears in answer engines, but which company is explained most convincingly for buyers."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - competitive analysis
+  - positioning
+geo_tactics:
+  - Capture competitor answers across ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led discovery surfaces, then compare the explanation quality rather than reducing the result to brand presence or rank.
+  - Score each company on buyer fit, trade-offs, proof, use cases, category role, objections, next step, and reason to talk so competitive visibility becomes a commercial diagnostic.
+  - "Route weak explanations to specific decisions: clarify positioning, add proof, build comparison assets, tighten offer boundaries, improve buyer routes, or stop chasing categories that attract the wrong demand."
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 63: Compare the Explanation, Not Just the Ranking
+
+Competitive GEO work can become too shallow if it stops at a visibility table.
+
+Brand mentioned: yes or no. Competitor mentioned: yes or no. Position in the answer: first, second, third, absent. Those facts matter, but they do not explain why a buyer might leave the answer with a stronger reason to trust one company over another.
+
+For CMOs, Marketing Directors, and founders, the sharper question is this: which company did the answer engine explain best?
+
+If ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led surface gives your competitor a clearer buyer fit, stronger trade-off, better proof trail, more specific use case, and a more obvious next reason to talk, then the competitor may be winning even when the ranking table looks close.
+
+Competitive AI visibility is not only a ranking problem. It is an explanation-quality problem.
+
+<!-- more -->
+
+## A mention is not the same as a reason to believe
+
+A brand can appear in an answer and still be commercially weak.
+
+It may be named in a list with no meaningful distinction. It may be described with generic category language. It may be attached to an old claim, a vague feature, a poor-fit use case, or a comparison that does not reflect how the company actually wins. It may appear below a competitor, but the larger problem may not be position. The larger problem may be that the competitor is explained with more confidence.
+
+That difference matters because answer-led discovery compresses a messy public evidence trail into a short explanation.
+
+The buyer does not inspect every page, review, customer story, comparison, analyst note, forum thread, and product page before forming a first impression. The answer engine does part of that compression for them. It decides which claims survive, which competitors belong in the frame, which attributes are worth mentioning, and which differences sound important.
+
+A competitor can win that compression without owning every search result.
+
+They win when the answer gives the buyer a sentence that makes sense:
+
+- "This vendor is better for mid-market teams that need fast implementation."
+- "This company is stronger when compliance evidence matters."
+- "This product is cheaper, but it is weaker for complex workflows."
+- "This agency is more technical than a traditional SEO partner."
+- "This platform is a better fit if the team already uses this ecosystem."
+
+Those are not rankings. They are market explanations.
+
+A leadership team that only tracks position may miss the real loss: the market has a clearer story about the competitor than it has about them.
+
+## Compare the answer a buyer receives
+
+A useful competitive review should preserve the answer itself before turning it into a dashboard.
+
+Ask a set of buyer-relevant prompts across the surfaces that matter for the market. Save the response, prompt wording, date, surface, citations where available, location or account context where relevant, and the competitors named. Then inspect the content of the answer before scoring it.
+
+The point is not to pretend one transcript represents the whole market. Answer engines vary by time, context, retrieval path, source mix, and product surface. One answer is a snapshot, not a verdict.
+
+But snapshots become useful when they are compared carefully.
+
+For each answer, ask:
+
+- Which companies are included, omitted, or treated as category defaults?
+- What reason is given for each company to exist in the shortlist?
+- Is the company explained by buyer fit, feature list, proof, price, geography, technical depth, service model, or a vague label?
+- Are trade-offs clear, or does every company sound interchangeable?
+- Which claims are supported by cited or recognisable public evidence?
+- Which use cases are attached to each company?
+- Which objections are answered without the buyer needing to ask a follow-up?
+- What next step would a serious buyer take after reading the answer?
+
+This changes the diagnostic from "Are we visible?" to "Are we intelligible, credible, and commercially distinct when the market is compressed into an answer?"
+
+That is a more useful question.
+
+## Build an explanation-quality table
+
+A competitive GEO table should include ranking data, but it should not end there.
+
+A practical version might look like this:
+
+| Dimension | What to inspect | Commercial meaning |
+|---|---|---|
+| Buyer fit | Which customer profile is attached to each company? | Shows whether the answer understands who the company is for |
+| Category role | Is the company framed as a leader, specialist, budget option, technical choice, legacy player, or niche alternative? | Shows the market position being handed to the buyer |
+| Trade-offs | Are strengths and limitations stated clearly? | Shows whether the buyer can compare without flattening the options |
+| Proof | Are claims supported by credible pages, customer evidence, third-party sources, reviews, or recognisable market signals? | Shows whether the recommendation has a reason to be believed |
+| Use cases | Are specific buying situations named? | Shows whether the company is tied to real demand or generic awareness |
+| Offer boundary | Does the answer explain what the company should not be used for? | Shows whether poor-fit leads are being filtered or attracted |
+| Next reason to talk | Does the answer create a sensible next step? | Shows whether visibility can move into sales conversation |
+
+This table prevents the team from treating every competitor mention as equal.
+
+Two companies may both appear in a ChatGPT answer. One may be described as a category-relevant option with a clear use case, proof trail, and limitation. The other may be a bare name in a list. Those are not the same commercial outcome.
+
+Two companies may both be cited by Perplexity. One citation may support a strong claim. Another may simply be a source trail that happens to include the company. Those are not the same evidence.
+
+Two companies may both appear near a Google AI feature. But Google's AI features rely on core Search ranking and quality systems, so the useful work is still to inspect the underlying public material, the search context, and the explanation shown to the user. There is no special AI switch to flip through llms.txt, arbitrary chunking, over-focused structured data, or magic markup. The competitive question remains: what public evidence is strong enough to help the system explain the company accurately?
+
+## The best competitor may not be the highest-ranked one
+
+A ranked list can hide the more important competitive pattern.
+
+A company in position three may receive the strongest explanation. A company in position one may be treated as a generic incumbent. A company that appears less often may be described with sharper fit when it does appear. A newer competitor may be absent from one surface but explained unusually well on another because the public evidence around a specific use case is stronger.
+
+This is why averaging everything into a single visibility score can be dangerous.
+
+ChatGPT, Claude, Perplexity, Gemini, Google AI features, vertical search products, review surfaces, and answer-led research tools do not all behave the same way. They expose different source trails, different explanation styles, and different buyer moments. The goal is not to force them into one neat number before anyone reads the answers.
+
+The goal is to find the commercial pattern:
+
+- Are competitors being described with clearer buyer fit?
+- Are we being grouped with the wrong alternatives?
+- Are our strongest proof points missing from the explanation?
+- Are our trade-offs invisible, making us sound interchangeable?
+- Are weak competitors winning because their public story is easier to summarise?
+- Are answer engines attaching us to a category we should not chase?
+- Are buyers being given a next step for the competitor but not for us?
+
+That pattern is where the budget decision lives.
+
+## Route the finding to the right commercial decision
+
+Once explanation quality is visible, the response should be specific.
+
+If a competitor has clearer buyer fit, the decision may be to sharpen positioning on the public site, sales materials, comparison pages, and founder narrative. The issue is not merely content volume. It is that the market can explain the competitor's ideal customer faster than it can explain yours.
+
+If a competitor has stronger proof, the decision may be to add customer evidence, outcome detail, implementation examples, third-party validation, or concrete technical claims. A vague promise will often lose to a narrower claim that is easier to substantiate.
+
+If a competitor owns the trade-off, the decision may be to publish comparison assets that say what you are better for, what you are worse for, and when a buyer should choose someone else. Hiding limitations can make the answer weaker, not safer, because answer engines need contrast to explain choice.
+
+If the answer places you in the wrong category, the decision may be to clarify offer boundaries or stop chasing that category entirely. Some visibility is not worth buying. Being shortlisted for the wrong job creates bad-fit demand, longer sales cycles, and disappointed prospects.
+
+If the answer gives competitors a stronger next step, the decision may be to improve the buyer route: a clearer page, a better CTA, a comparison guide, a diagnostic offer, a pricing explanation, a founder note, or a sales handoff that matches the question the buyer just asked.
+
+If the answer is noisy or inconsistent, the decision may be to monitor rather than react. One capture should not trigger a full campaign. Repeated patterns across prompt families, surfaces, and dates deserve more weight than a single surprising response.
+
+The discipline is to resist the default reaction: "We need more content."
+
+Sometimes the business needs less content and a clearer claim. Sometimes it needs proof. Sometimes it needs a comparison asset. Sometimes it needs to stop competing for a weak category. Sometimes it needs to fix the route after the answer, not the answer itself.
+
+## What leaders should ask after the capture
+
+A CMO, Marketing Director, or founder does not need a 40-column spreadsheet to make this useful.
+
+They need a short competitive memo that answers five questions:
+
+1. Which competitors are explained more clearly than us?
+2. What exactly makes their explanation stronger: fit, proof, trade-off, use case, category role, objection handling, or next step?
+3. Is the weakness caused by missing public evidence, unclear positioning, stale sources, poor comparison assets, wrong category pursuit, or answer volatility?
+4. What commercial decision should we make now?
+5. What evidence would change that decision next month?
+
+That last question matters. GEO work should not pretend the market is static. Answer-led discovery changes as public evidence changes, products change, search systems change, and competitors publish better material. A competitive explanation review should therefore create a decision and a future evidence test.
+
+Not every weak explanation deserves immediate spend.
+
+But every repeated weak explanation deserves a named interpretation.
+
+## The real unit of competition is clarity
+
+In answer-led discovery, the buyer may never see the full messy trail that produced the summary.
+
+They see a compressed explanation of the category, the options, the differences, and the next places to look. That explanation may be imperfect. It may be incomplete. It may vary across surfaces. But it still shapes the first shortlist.
+
+So competitive GEO analysis should not stop at whether a brand appears or whether a competitor ranks one line above it.
+
+Those measures show visibility.
+
+Explanation quality shows whether visibility is doing commercial work.
+
+If the answer can explain your competitor's buyer fit, proof, use case, trade-off, and next step more clearly than it can explain yours, the response is not to chase the table. The response is to improve the public evidence, positioning, comparison assets, and buyer route that make a better explanation possible.
+
+The market does not only reward the company that gets named.
+
+It rewards the company that can be understood.


### PR DESCRIPTION
## Summary
- Adds Day 63 Build-in-Public blog post: "Compare the Explanation, Not Just the Ranking"
- Keeps the competitive GEO angle focused on explanation quality across answer engines
- Preserves the Google AI caveat: core Search ranking and quality systems matter; no llms.txt/special-markup/chunking-as-Google-requirement claim

## Verification
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-63.md` passed
- Targeted content assertions passed for title, date, slug, frontmatter, no ANGLE_STALE, buyer relevance, and Google caveat
- `mkdocs build --strict` ran and failed on existing site warnings / nav warnings (90 warnings)
- `mkdocs build` passed

## Payload
- Only `docs/blog/posts/daily-blog-day-63.md`
