### PR TITLE
docs: add daily blog day 64

### DIFF
--- a/docs/blog/posts/daily-blog-day-64.md
+++ b/docs/blog/posts/daily-blog-day-64.md
@@ -1,0 +1,122 @@
+---
+title: "Day 64: Stop Treating Every Answer Engine Like the Same Channel"
+date: 2026-06-23
+slug: "day-64-stop-treating-every-answer-engine-same-channel"
+description: "A practical GEO field note for CMOs, Marketing Directors, and founders: ChatGPT, Claude, Perplexity, Gemini, and Google AI features create different buyer expectations, so AI visibility work needs surface-specific assets, evidence, KPIs, and follow-up routes."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - buyer intent
+  - content strategy
+geo_tactics:
+  - Segment answer-led discovery by surface, buyer mode, evidence needed, best asset, useful KPI, and wrong reaction before deciding what to build or measure.
+  - Treat ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led surfaces as different commercial contexts rather than one blended AI visibility channel.
+  - "Match each surface to the buyer's likely next step: shortlist formation, due diligence, source inspection, comparison, internal explanation, or conversion follow-up."
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 64: Stop Treating Every Answer Engine Like the Same Channel
+
+A CMO should be suspicious of any AI visibility dashboard that treats every answer engine as the same channel.
+
+A ChatGPT answer, a Claude synthesis, a Perplexity result, a Gemini response, and a Google AI feature do not create the same buyer moment. They may all sit under the broad label of "AI search" or "answer-led discovery", but a buyer does not experience them as interchangeable.
+
+One surface may help the buyer form a shortlist. Another may help them understand a category. Another may expose citations for quick source inspection. Another may sit beside conventional Search results and reflect the same public-quality signals that already matter in Google. Another may be used internally by a team trying to explain options to a board, founder, or procurement lead.
+
+If those moments are collapsed into one generic score, the team starts making the wrong moves. They overreact to isolated screenshots. They build the same content asset for every gap. They send sales the wrong context. They celebrate mentions that do not change a buying conversation, and they panic about absences that were never commercially urgent.
+
+GEO is not only the work of being named. It is the work of matching the right public evidence, offer framing, content asset, measurement, and follow-up path to the way each answer surface shapes buyer expectations.
+
+<!-- more -->
+
+## One AI visibility channel is too blunt
+
+The lazy version of AI visibility asks one question: "Do we appear?"
+
+That question is useful for orientation, but it is too blunt for commercial action. The stronger question is: "What kind of buyer expectation does this surface create, and what would we need to be credible there?"
+
+A buyer using an answer engine to understand a market may need clear category language. A buyer using it to compare vendors may need trade-offs, proof, pricing context, integrations, service boundaries, and a reason to talk. A buyer following citations may need source material that can support the claim without collapsing into generic marketing copy. A buyer seeing a Google AI feature is still in a Search-shaped environment, where the underlying public pages, reputation, relevance, and quality systems matter more than any imagined AI-only switch.
+
+That distinction matters because each surface can produce a different failure mode.
+
+A brand can be present but misframed. It can be absent from a high-intent category but visible in a low-value informational answer. It can be cited by a source-led surface without being explained as a serious option. It can be described accurately in one engine and flattened into a generic vendor in another. It can be over-measured in places where the buyer is only browsing and under-invested in places where the buyer is actually building a shortlist.
+
+The mistake is not measuring too much. The mistake is measuring everything as if it means the same thing.
+
+## Segment surfaces by the buyer job
+
+A practical GEO review should separate answer surfaces before it assigns work.
+
+This does not require pretending to know every model's internal mechanism. It requires observing the surface, saving the answer, noting the context, and asking what buyer job the surface appears to serve in that moment. The framework can stay simple:
+
+| Surface or surface type | Buyer mode | Evidence needed | Best asset to strengthen | Useful KPI | Wrong reaction |
+|---|---|---|---|---|---|
+| ChatGPT-style synthesis | "Help me understand the category and options" | Clear positioning, use cases, trade-offs, credible public claims | Category explainer, comparison page, use-case page, offer boundary | Quality of explanation and fit, not just mention count | Treating every mention as qualified demand |
+| Claude-style reasoning or internal memo support | "Help me make sense of a complex decision" | Structured arguments, constraints, risks, decision criteria, plain-English proof | Decision guide, evaluation framework, technical explainer | Whether the company is framed as a serious answer to the buyer's decision | Publishing shallow listicles because the brand was absent |
+| Perplexity-style cited answer | "Show me the sources behind this claim" | Source strength, recency, third-party context, quotable claims | Evidence-led pages, research notes, customer proof, authoritative references | Citation usefulness and claim support | Counting citations without checking what they support |
+| Gemini and broader Google-adjacent discovery | "Answer this in a Search-shaped context" | Strong public pages, topical relevance, reputation, crawlable quality content | Core landing pages, explainers, comparison assets, source hygiene | Whether the answer reflects accurate, useful public material | Chasing llms.txt, magic markup, arbitrary chunking, or over-focused structured data as a Google AI switch |
+| Google AI features | "Give me a quick answer within the wider Search journey" | The same public quality signals that help Google understand and rank useful pages | Search-quality fundamentals: helpful pages, clear claims, credible sources, accessible structure | Accuracy and commercial usefulness of the surfaced explanation | Treating Google's AI features as separate from core Search ranking and quality systems |
+| Vertical, review, or community answer surfaces | "What do users, peers, and specialists say?" | Reviews, community language, category context, real objections, implementation details | Review strategy, customer stories, forum-aware FAQs, objection handling | Whether peer language supports the desired market position | Trying to solve peer-context gaps with only owned blog content |
+
+The table is not meant to become another reporting ritual. It is meant to stop the team from assigning the same remedy to different commercial situations.
+
+If a surface is mainly helping a buyer form a shortlist, the work may be positioning, comparison, and category eligibility. If it is mainly exposing source trails, the work may be evidence quality and claim support. If it is mainly sitting inside the Google ecosystem, the work should respect Google's stated reality: Google's AI features rely on core Search ranking and quality systems. There is no requirement to add llms.txt, special AI markup, arbitrary content chunking, or excessive structured data to unlock visibility in those features.
+
+## Build different assets for different answer moments
+
+A surface-specific approach changes the content plan.
+
+The usual generic response to an AI visibility gap is "publish more content". That is rarely precise enough.
+
+If ChatGPT or Claude gives a vague explanation of the company, the missing asset may be a sharper category narrative or decision framework. The buyer needs to understand what the company is for, what it is not for, and why it belongs in the conversation.
+
+If Perplexity cites weak or outdated material, the missing asset may be evidence. The answer may need a stronger public claim, an updated source, a research note, a customer proof point, or a third-party reference that can carry weight when cited.
+
+If a Google AI feature surfaces a thin or misleading explanation, the response should start with the underlying Search-shaped reality. Are the core pages helpful, clear, current, accessible, and aligned with the query? Is the strongest claim buried on a page that does not deserve to rank? Is the public site asking Google to infer the business from vague language? The answer is not to bolt on AI-only decoration. The answer is to improve the public material that quality systems can understand and trust.
+
+If a vertical or community surface frames the company poorly, the missing asset may not live on the website at all. It may be customer language, review context, implementation examples, partner material, or clearer handling of objections that appear in peer discussions.
+
+This is where GEO becomes commercial rather than cosmetic. The work is not "optimise for AI" in the abstract. The work is deciding which answer moment matters, what buyer expectation is being set, and what asset would make the company easier to explain correctly.
+
+## Route the follow-up by surface, not by screenshot
+
+Different answer surfaces also need different follow-up routes.
+
+A high-intent shortlist answer that omits the company may be urgent for proposition and content. A cited answer that includes the company but supports the wrong claim may be urgent for evidence and source hygiene. A reasoning-heavy answer that misunderstands the offer may be urgent for positioning. A low-value informational answer that mentions the company weakly may simply be noise.
+
+This prevents three common executive mistakes:
+
+- sending every AI-sourced lead to sales with no context about the buyer question;
+- asking content to fix problems that are actually proof, positioning, product, or reputation problems;
+- turning every visible answer into a KPI before anyone has checked whether that surface influences a real buying step.
+
+A better handoff is surface-specific:
+
+| If the surface shows... | Route to... | With this question |
+|---|---|---|
+| Strong mention, weak explanation | Positioning or proposition | What claim would make us easier to understand? |
+| Good citation, poor commercial framing | Content and sales enablement | What next step should the buyer see after the source? |
+| Competitor explained with clearer trade-offs | Proposition, content, founder/leadership | Which trade-off are we failing to make public? |
+| Google AI feature reflects stale public material | Search/content owner | Which core page or source is teaching the wrong story? |
+| Peer or review surface repeats an objection | Customer marketing or product marketing | Is the objection true, outdated, or unanswered? |
+| Low-intent answer mentions the brand | Measurement owner | Is this commercially useful, or just visibility noise? |
+
+The point is not to create a heavier process. The point is to stop routing every surface through the same operational reflex.
+
+## The CMO move: separate the surfaces before funding the fix
+
+Before a leadership team funds a GEO roadmap, it should ask for segmentation.
+
+Which answer surfaces matter for the buying journey? Which ones shape awareness, shortlists, due diligence, source inspection, internal explanation, or final confidence? Which gaps create commercial risk, and which ones are only measurement noise? Which content assets, proof assets, comparison pages, source improvements, or sales handoffs belong to each surface?
+
+That is a more useful conversation than arguing over a single blended AI visibility score.
+
+For CMOs, Marketing Directors, and founders, the practical move is simple: stop asking whether the brand is visible "in AI" as if AI were one place. Ask where the buyer is asking, what kind of answer they receive, what expectation that answer creates, and what the business needs to make that expectation accurate.
+
+A serious GEO baseline should not flatten ChatGPT, Claude, Perplexity, Gemini, Google AI features, and specialist answer surfaces into one channel. It should separate the buyer moments, inspect the evidence each moment requires, and route the fix to the team that can actually change the commercial outcome.
+
+That is how AI visibility turns from a screenshot collection into a decision about revenue relevance.


### PR DESCRIPTION
## Summary
- Adds the Day 64 build-in-public post about treating answer engines as separate buyer surfaces.
- Keeps the PR payload scoped to one intended blog post: `docs/blog/posts/daily-blog-day-64.md`.
- Preserves the Google caveat that Google AI features rely on core Search ranking and quality systems, not `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data.

## Checks
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-64.md` ✅
- Targeted Day 64 frontmatter/content assertions ✅
- `mkdocs build` ✅ (site builds; existing repo warnings remain)
- `mkdocs build --strict` ⚠️ fails on existing repo warnings (nav/roamlinks/autolinks baseline), not this post
- `PYTHONPATH=. pytest tests/test_validate_frontmatter.py test_markdown.py` ✅ (3 passed)

## Notes
- The final artifact had two YAML list items containing `: ` in `geo_tactics`; I quoted those strings in the repo copy so the existing frontmatter validator and MkDocs YAML parsing pass without changing the visible article text.
