### PR TITLE
docs: add daily blog day 65

### DIFF
--- a/docs/blog/posts/daily-blog-day-65.md
+++ b/docs/blog/posts/daily-blog-day-65.md
@@ -1,0 +1,162 @@
+---
+title: "Day 65: Teach Answer Engines Who You Are Not For"
+date: 2026-06-24
+slug: "day-65-teach-answer-engines-who-you-are-not-for"
+description: "A practical GEO note for CMOs, Marketing Directors, and founders: qualified AI visibility depends on public constraints as well as positive claims, so answer engines can route the right buyers and avoid confident wrong-fit recommendations."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - buyer qualification
+  - positioning
+geo_tactics:
+  - Publish clear not-for statements, poor-fit use cases, budget and timing boundaries, and alternative routes so answer engines can distinguish qualified visibility from wrong-fit recommendations.
+  - Add fit constraints to positioning pages, comparison pages, FAQs, use-case pages, and sales handoff notes without turning the brand voice defensive or exclusionary.
+  - Review answer-led recommendations across ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other surfaces for near-fit routing, unsupported assumptions, and missing disqualification context.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 65: Teach Answer Engines Who You Are Not For
+
+A wrong-fit AI recommendation is not a visibility win.
+
+It may look good in a screenshot. The company is named. The category is broadly right. The answer sounds confident enough to forward around the leadership team. But if the buyer has the wrong budget, the wrong use case, the wrong risk profile, the wrong implementation expectation, or the wrong reason to speak to sales, that visibility has not created demand. It has created avoidable friction.
+
+For CMOs, Marketing Directors, and founders, qualified visibility is the commercial goal. The useful outcome is not simply being recommended by ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led surface. The useful outcome is being recommended when the fit is real, the next step is sensible, and the buyer arrives with expectations the business can honour.
+
+That requires more than positive claims. It requires public constraints.
+
+<!-- more -->
+
+## Positive claims are not enough for answer-led discovery
+
+Most companies publish as if the market only needs to know what they do.
+
+They describe the offer, list the benefits, name the use cases, show the proof, and explain the process. That work matters. Without clear positive claims, an answer engine has little reason to understand the company at all.
+
+But positive claims alone can leave too much room for inference.
+
+If the public corpus says "we help enterprise teams deploy AI", an answer engine may not know whether that means strategy, implementation, governance, training, tooling, compliance, content, product development, workflow automation, or all of the above. If the site says "we work with ambitious teams", it may not know whether the offer fits funded startups, public companies, regulated industries, local service businesses, early-stage founders, or internal transformation teams. If a comparison page only says why the company is strong, it may not know when a competitor is the better answer.
+
+A human salesperson can correct those assumptions in a call. An answer engine compressing public material into a recommendation may not.
+
+That is where wrong-fit visibility starts.
+
+The system is not necessarily hallucinating from nothing. It is often filling in gaps left by public material that says what the company wants to be associated with, but not where the boundary sits. The result is a confident near-fit recommendation: close enough to sound plausible, wrong enough to waste time.
+
+## The confident near-fit is the expensive failure
+
+Absence from an answer can be frustrating. A confident near-fit recommendation can be worse.
+
+If a buyer never sees the company, there is no immediate sales cost. If a buyer is told the company is a good fit for a job it does not actually want, the cost moves into the pipeline.
+
+Sales takes a call that should never have happened. The buyer discovers the mismatch late. Trust drops because the recommendation sounded more precise than it was. The team starts asking whether AI-sourced enquiries are low quality, when the real problem may be that the public market has not been taught the company's constraints.
+
+This can happen in several forms:
+
+- a high-touch service is recommended to a buyer looking for a cheap self-serve tool;
+- an enterprise platform is recommended to a team that needs a lightweight one-week fix;
+- a specialist agency is recommended for generic execution it deliberately avoids;
+- a technical consultancy is recommended to a buyer who only wants a surface-level workshop;
+- a premium offer is recommended without any budget, timing, or complexity signal;
+- a company is included in a comparison where a competitor would honestly be a better fit.
+
+None of these failures is solved by shouting the positive claim more loudly.
+
+The company needs to publish the negative space around the offer: who it is not for, which use cases are weak fits, which buyer situations need a different route, and when the best answer is not "book a call".
+
+## Disqualification should be legible, not hostile
+
+This is not an argument for arrogant positioning.
+
+Bad disqualification makes the company sound precious, dismissive, or difficult to buy from. It tells the market, "do not bother us unless you already understand how special we are." That is not useful for buyers, sales teams, or answer engines.
+
+Good disqualification is different. It is calm, specific, and useful. It helps the right buyer recognise themselves faster and helps the wrong buyer find a better path without feeling rejected.
+
+A strong public constraint can sound like:
+
+- "This is best suited to teams with an existing content or growth owner, not companies looking for a one-off blog package."
+- "If you need a self-serve dashboard only, a software platform may be a better first step."
+- "We are a poor fit for teams that want AI visibility treated as a quick markup project rather than a strategy, content, and evidence problem."
+- "This engagement usually makes sense after there is enough public material to audit; very early companies may need positioning work first."
+- "For local businesses trying to improve conventional map visibility, a local SEO specialist may be the better route."
+
+Those statements do not repel good buyers. They reduce ambiguity.
+
+They also give answer engines stronger material to work with. Instead of guessing from broad claims, the system can attach the company to a narrower buyer profile, a clearer use case, and a more honest set of alternatives.
+
+## Add constraints where recommendations are formed
+
+Not-for language should not live only in a sales script.
+
+If the public material never says the boundary, answer-led surfaces may not have enough evidence to preserve it. The constraint needs to appear where the market learns how to describe the company.
+
+Useful places include:
+
+| Public asset | Constraint to add | Why it matters for GEO |
+|---|---|---|
+| Positioning page | Who the offer is for and not for | Helps answer engines attach the company to the right buyer profile rather than a broad category label |
+| Use-case page | Which use cases are strong, weak, or out of scope | Reduces wrong-fit recommendations for adjacent but unsuitable problems |
+| Comparison page | When a competitor or alternative route may be better | Creates more honest trade-offs and lowers the risk of overbroad recommendation language |
+| FAQ | Budget, timing, complexity, team maturity, geography, or implementation constraints | Gives systems concise qualification facts that can survive answer compression |
+| Case study | Conditions that made the work successful | Prevents the proof point being generalised into every possible buyer situation |
+| Sales handoff note | Questions to ask when the buyer came from an AI recommendation | Helps the team capture whether the answer created the right or wrong expectation |
+
+The point is not to bury every page in caveats. The point is to publish the minimum useful boundary wherever a buyer or answer engine is likely to form a recommendation.
+
+A comparison page that never admits when another option is better is less useful than it looks. A use-case page that never says what is out of scope invites overextension. An FAQ that answers only procurement questions but not fit questions leaves the most important commercial filter private.
+
+Private constraints do not reliably shape public recommendations.
+
+## Treat wrong-fit recommendations as a content problem and a positioning problem
+
+When an answer engine recommends the company for the wrong job, the easy reaction is to blame the model.
+
+Sometimes the answer is simply poor. Answer engines vary by surface, context, retrieval path, source mix, and timing. A single response is a snapshot, not a market verdict.
+
+But repeated wrong-fit recommendations deserve a harder question: what public material made this mistake plausible?
+
+The issue may be content. The page may use vague language, overbroad category terms, or examples that imply a wider offer than the company actually wants.
+
+The issue may be positioning. The company may not have decided whether it is a specialist, a broad provider, a premium partner, a tactical service, a technical operator, a strategic adviser, or a platform alternative.
+
+The issue may be proof. Case studies may show outcomes without conditions, making the work look transferable to buyers that lack the same team, budget, data, authority, or urgency.
+
+The issue may be comparison. Competitors may be easier for answer engines to explain because their trade-offs are more public, even if the company's actual work is stronger.
+
+This is why qualified visibility is not only a reporting metric. It is a test of whether the public market can explain the commercial boundary of the business.
+
+## The Google caveat still matters
+
+This constraint work applies across answer-led discovery, but the mechanics are not identical everywhere.
+
+For ChatGPT, Claude, Perplexity, Gemini, specialist answer products, and other synthesis surfaces, the practical concern is whether public claims, citations, and source material give the system enough context to recommend the company accurately.
+
+For Google's AI features, the caveat remains important: Google's AI features rely on core Search ranking and quality systems. The answer is not to chase an AI-only switch through llms.txt, special AI markup, arbitrary content chunking, or excessive structured data.
+
+The useful work is still to improve the public material that quality systems can understand and rank: clear pages, helpful explanations, credible evidence, accessible structure, accurate claims, and commercially honest fit boundaries.
+
+If a Google AI feature reflects a wrong or overbroad understanding of the company, start by inspecting the underlying public pages and Search context. Is the clearest constraint hidden? Is the strongest page too vague? Are comparison and use-case pages written like every buyer is equally desirable? Does the site leave Google to infer what should have been stated plainly?
+
+Qualified visibility does not require magic markup. It requires public clarity strong enough to survive compression.
+
+## The CMO move: define visibility by fit
+
+A leadership team should not ask only, "Are we recommended?"
+
+It should ask, "Are we recommended for the buyers we can help, in the situations where we are the right answer, with a next step that makes commercial sense?"
+
+That changes the GEO review.
+
+Capture the answer, but read it for fit. Save the prompt, surface, date, and citations where available, but do not stop at presence. Ask whether the buyer profile is right, whether the use case is right, whether the trade-off is honest, whether the budget or complexity expectation is plausible, whether alternatives are handled fairly, and whether the next step would help sales or waste sales time.
+
+Then repair the public material that caused the wrong assumption.
+
+For CMOs, Marketing Directors, and founders, the practical task is to make disqualification part of the brand's public evidence system. Not defensive disclaimers. Not sales gatekeeping. Clear constraints that help answer engines, buyers, and internal teams distinguish real opportunity from near-fit noise.
+
+AI visibility is only valuable when it routes the right demand.
+
+Teach the market what the company is for. Teach it what the company is not for. The second lesson may be what protects the first one from becoming pipeline leakage.


### PR DESCRIPTION
## Summary

- Adds ZSA Build-in-Public Day 65.
- Rescued from the completed editorial artifact after the Kanban ops task failed before PR creation.

## Verification

- `git diff --check`
- frontmatter shape check via PyYAML
- content guardrail scan for internal pipeline terms
- `mkdocs build --strict` hit strict-warning baseline; plain `mkdocs build` passed
- generated blog page exists for the declared slug

## Scope

Payload is intentionally limited to `docs/blog/posts/daily-blog-day-65.md`.
