### PR TITLE
docs: add daily blog day 66

### DIFF
--- a/docs/blog/posts/daily-blog-day-66.md
+++ b/docs/blog/posts/daily-blog-day-66.md
@@ -1,0 +1,185 @@
+---
+title: "Day 66: Plan for the Old Answer During the New Launch"
+date: 2026-06-25
+slug: "day-66-plan-for-the-old-answer-during-the-new-launch"
+description: "A practical GEO note for CMOs, Marketing Directors, and founders: launches and repositioning need an answer-market transition plan, because buyers may still encounter the old explanation in AI answers, snippets, citations, comparisons, and sales conversations."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - positioning
+  - launches
+geo_tactics:
+  - "Map the old answer before a launch or repositioning: old offer language, category labels, comparison claims, proof gaps, snippets, citations, and sales questions that may continue to shape buyer expectations."
+  - Publish continuity cues across launch notes, positioning pages, FAQs, redirects, comparison pages, and sales enablement so answer-led discovery can reconcile the old story with the new one.
+  - Review ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces after launch for old-new claim mismatch, citation residue, and buyer expectation drift without assuming every surface updates at the same speed.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 66: Plan for the Old Answer During the New Launch
+
+A launch does not replace the market's memory overnight.
+
+The website may have changed. The homepage may now describe a sharper offer. The sales deck may use a new category. The proof may point to a different buyer. The leadership team may be ready to tell a cleaner story.
+
+But buyers do not only meet the company through the new launch page. They meet it through ChatGPT summaries, Claude comparisons, Perplexity citations, Gemini answers, Google AI features, search snippets, old comparison pages, bookmarked sales decks, partner descriptions, customer language, and half-remembered explanations from previous conversations.
+
+That is where launch risk starts. Not because the new positioning is weak, but because the old answer is still circulating.
+
+For CMOs, Marketing Directors, and founders, GEO during a launch or repositioning is not only the work of publishing the new story. It is the work of planning the changeover between the old explanation and the new one, so buyers do not arrive with yesterday's expectation in tomorrow's sales conversation.
+
+<!-- more -->
+
+## The launch narrative is not the only narrative in market
+
+Most launch planning assumes a clean switch.
+
+Before the launch, the company is described one way. After the launch, it should be described another way. The brand refresh goes live, the offer page changes, the announcement is published, the sales team gets the new talk track, and the old language is treated as retired.
+
+Answer-led discovery is rarely that tidy.
+
+An answer engine may still find an older page that explains the company in the previous category. A cited answer may quote a comparison page that has not been rewritten. A search result may surface a snippet from a page that is technically live but strategically obsolete. A buyer may ask, "Is this the company that used to do X?" because a previous answer, review, article, or sales conversation framed the offer that way.
+
+None of this requires assuming a mysterious AI-only mechanism. It is a normal market transition problem made more visible by answer engines. Public material changes at one pace. Retrieval, ranking, citations, snippets, third-party pages, and buyer memory change at another.
+
+The commercial problem is the gap between those two clocks.
+
+If the new launch says, "We now help enterprise teams manage AI visibility across answer-led discovery," but old material still implies "content production agency," the buyer may evaluate the company through the wrong lens. If the new positioning targets funded B2B teams, but old comparisons still attach the company to generic SEO execution, the lead may arrive expecting a different price, scope, proof standard, or delivery model.
+
+The company has not merely failed to update a page. It has allowed two stories to compete for the same buyer.
+
+## The old answer creates revenue leakage
+
+Old-answer residue is easy to dismiss as a brand tidiness issue.
+
+It is more serious than that. It can distort the buying process.
+
+A buyer who encounters an old AI-generated explanation may ask the wrong internal question. Instead of asking whether the company can help with a strategic visibility problem, they ask whether it can produce cheaper content. Instead of evaluating the new category claim, they compare the company against the old competitor set. Instead of reading the latest proof, they look for evidence that suited the previous offer.
+
+That creates several practical failure modes:
+
+- the buyer arrives expecting the old service, then treats the new offer as upsell or scope creep;
+- an answer engine recommends the company for a category it is deliberately moving away from;
+- a comparison page still frames the market around competitors the company no longer wants to be judged against;
+- a cited source supports a claim that is technically true historically but commercially misleading now;
+- sales spends the first call correcting the market's memory instead of qualifying the actual opportunity;
+- leadership misreads weak conversion as a launch problem when the issue is old-answer interference.
+
+This is not solved by deleting everything old on launch day.
+
+Some old material should be retired. Some should be redirected. Some should remain live with explicit context because it still carries useful proof, search value, customer evidence, or category history. The point is not to erase the past. The point is to stop the past from explaining the present incorrectly.
+
+A good launch plan does not ask only, "What new page do we publish?"
+
+It also asks, "What old answer will buyers still find, and what should it teach them now?"
+
+## Map the old answer before the launch
+
+Before a positioning change, the team should inspect the market's current explanation of the company.
+
+This is not a vanity audit. It is a risk map for the changeover window.
+
+Useful questions include:
+
+| Area to inspect | What to look for | Why it matters |
+|---|---|---|
+| Current answer-engine summaries | How ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar surfaces describe the company | Shows the explanation buyers may already be carrying into the launch |
+| Search snippets and page titles | Old category labels, offer language, service names, and proof claims | These can continue to frame the company even after the new page goes live |
+| Comparison and alternative pages | Competitor sets, trade-offs, and category assumptions | Buyers may compare the new offer against the wrong alternatives |
+| Case studies and proof assets | Outcomes that imply the old service, buyer type, or delivery model | Proof can be useful but misleading if the conditions are not explained |
+| FAQs and sales enablement | Questions based on old expectations | Sales needs a clean way to bridge old understanding to new reality |
+| Third-party and partner material | External descriptions that repeat the previous positioning | Owned pages are not the whole answer market |
+
+The aim is not to create a massive tracking ritual. The aim is to name the residue before it surprises the team.
+
+If the company is moving from broad delivery to specialist advisory, where does the old delivery story still appear? If it is changing category language, which pages still use the previous label? If it is launching a higher-value offer, what public proof makes it look smaller than it is? If it is narrowing the buyer profile, which old assets still invite the wrong buyer to self-identify?
+
+Those questions turn the launch from a publishing event into a managed transition.
+
+## Add continuity cues, not just redirects
+
+Redirects matter, but they are not the whole changeover plan.
+
+A 301 can move a user or crawler from one URL to another. It does not automatically explain why the company changed, what remains true, what no longer applies, or how a buyer should interpret older proof.
+
+Launch material needs continuity cues.
+
+A continuity cue is a public bridge between the old answer and the new one. It helps buyers and answer-led systems reconcile the change without inventing the relationship themselves.
+
+Examples:
+
+- a launch note that says what changed, why it changed, and which buyer problem the company now prioritises;
+- an old service page redirected to the closest new explanation, with no vague homepage dump;
+- a retained case study updated with a short note explaining how the proof relates to the new offer;
+- an FAQ entry that answers, "Do you still do X?" with a clear yes, no, or "only in this context";
+- a comparison page revised to explain the new competitor set and the old one it replaces;
+- a sales handoff note that gives the team language for buyers who arrive with the previous story;
+- a launch email or customer note that gives partners the correct description to reuse.
+
+This is where GEO becomes practical. Answer engines compress public material. If the public material does not explain the change, the system may stitch the old and new claims together in a way no human marketer would approve.
+
+The goal is not to force every surface to say the new wording immediately. The goal is to publish enough connective tissue that the new story can be understood in relation to the old one.
+
+## Give sales a way to catch old-answer residue
+
+Sales will often see the changeover problem before the marketing dashboard does.
+
+A buyer asks why the new engagement costs more than the old package. A founder references a competitor that no longer belongs in the same frame. A procurement lead asks for proof tied to the previous offer. A prospect says, "I thought you mainly did X," because that is what an answer, article, or colleague told them.
+
+Those moments are not just sales objections. They are evidence of old-answer residue.
+
+During a launch, the sales team should capture a few simple fields:
+
+- what the buyer expected the company to do;
+- where that expectation came from, if they know;
+- which old term, offer, competitor, or proof point they referenced;
+- whether the new explanation resolved the confusion;
+- what public asset would have prevented the mismatch.
+
+This should not become admin theatre. A lightweight note is enough if it routes back into the launch review.
+
+The reason this matters is that answer-market transition is partly observable through buyer language. Dashboards can show snippets, citations, mentions, and query results. Sales conversations show whether the buyer's mental model has actually moved.
+
+If three qualified prospects in the first fortnight ask the same old-positioning question, the team has found a transition gap. The fix may be a clearer FAQ, a revised comparison page, a better launch note, a case-study annotation, or a sales enablement line that should also be made public.
+
+Private correction is useful. Public correction is what reduces the next mismatch.
+
+## Check the answer market after launch
+
+After the launch, the review should focus on old-new claim reconciliation.
+
+Do not ask only, "Are we visible?" Ask whether the visible explanation matches the new commercial reality.
+
+A practical post-launch check can stay focused:
+
+1. Run the core buyer questions in the answer-led surfaces that matter for the market.
+2. Save the answer, date, prompt, surface, and visible citations or sources where available.
+3. Mark whether the answer reflects the old position, the new position, or a confusing blend.
+4. Identify the public source that may be teaching the old claim.
+5. Decide whether the fix is retirement, redirect, rewrite, annotation, comparison update, proof update, or sales enablement.
+6. Recheck after enough time has passed for public changes to be crawled, surfaced, cited, or noticed by buyers.
+
+For ChatGPT, Claude, Perplexity, Gemini, and other synthesis or cited-answer surfaces, the focus is whether the public material gives enough context to describe the transition accurately. If the answer blends old and new claims, ask what connective explanation is missing.
+
+For Google AI features, keep the caveat clear: Google's AI features rely on core Search ranking and quality systems. The right response is not to chase an AI-only switch through llms.txt, special AI markup, arbitrary chunking, or excessive structured data. Start with the underlying Search-shaped reality: which pages are clear, current, helpful, accessible, and deserving of being understood as the strongest explanation?
+
+Across all surfaces, avoid treating one response as a verdict. A single answer is a sample. Repeated old-new mismatch is the signal.
+
+## The leadership move: plan the changeover window
+
+A repositioning should have a visibility migration plan in the same way it has a launch plan.
+
+That does not mean inventing a heavy programme. It means naming the small set of old answers that could damage the new story and deciding what each one should become.
+
+Before launch, map the old explanation. During launch, publish continuity cues. After launch, inspect answer-led discovery and sales language for residue. Keep useful proof, but annotate it. Retire what is genuinely obsolete. Redirect with intent. Update comparison pages before buyers use the old competitor set against the new offer. Give sales language that bridges the old answer to the new one without sounding defensive.
+
+For CMOs, Marketing Directors, and founders, the commercial question is simple:
+
+When a buyer asks an answer engine about the company during the changeover, does the answer help them understand the new reality, or does it drag yesterday's story into today's decision?
+
+The launch page is only one part of that answer.
+
+The old market memory needs a plan too.


### PR DESCRIPTION
## Summary

- Adds ZSA Build-in-Public Day 66.
- Rescued from the completed editorial artifact after the Kanban ops task failed before PR creation.

## Verification

- `git diff --check`
- frontmatter shape check via PyYAML
- content guardrail scan for internal pipeline terms
- `mkdocs build --strict` hit strict-warning baseline; plain `mkdocs build` passed
- generated blog page exists for the declared slug

## Scope

Payload is intentionally limited to `docs/blog/posts/daily-blog-day-66.md`.
