### PR TITLE
docs: add daily blog day 67

### DIFF
--- a/docs/blog/posts/daily-blog-day-67.md
+++ b/docs/blog/posts/daily-blog-day-67.md
@@ -1,0 +1,166 @@
+---
+title: "Day 67: Spend the GEO Budget Where the Answer Changes the Sale"
+date: 2026-06-26
+slug: "day-67-spend-geo-budget-where-answer-changes-sale"
+description: "A practical GEO note for CMOs, Marketing Directors, and founders: AI visibility work should be funded around the buyer questions where answer-engine results can change revenue, qualification, competitive framing, or launch risk."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - budget allocation
+  - revenue strategy
+geo_tactics:
+  - Map high-intent buyer questions to commercial consequences before funding AI visibility work, so content, proof, measurement, and sales enablement follow revenue leverage rather than generic content volume.
+  - Prioritise answer moments that can change pipeline quality, deal urgency, competitor framing, launch risk, pricing expectations, procurement confidence, or sales qualification.
+  - Review ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces for the questions where a different answer would materially change the sale, not only for raw brand mentions.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 67: Spend the GEO Budget Where the Answer Changes the Sale
+
+Not every AI visibility gap deserves the same budget.
+
+A brand can be missing from one answer and barely feel it. It can be mentioned in another answer and still gain nothing. It can be described slightly incorrectly in a low-intent summary without changing demand. It can also be misframed in one high-intent buyer question and lose the sale before sales ever sees the lead.
+
+That difference matters.
+
+For CMOs, Marketing Directors, and founders, the next useful step in GEO is not simply "publish more content for AI". It is to decide which answer-led buyer moments have commercial consequence. The questions worth funding first are the ones where ChatGPT, Claude, Perplexity, Gemini, Google AI features, or similar surfaces can change who enters the pipeline, what they believe, which competitors they consider, how urgent the problem feels, and whether the sales conversation starts from trust or repair.
+
+GEO is becoming a budget allocation discipline. Spend where the answer can change the sale.
+
+<!-- more -->
+
+## Visibility is not the same as leverage
+
+A lot of AI visibility work starts with a broad anxiety: "Are we showing up?"
+
+That is understandable. If buyers are asking answer engines for recommendations, comparisons, definitions, vendor lists, implementation advice, and market explanations, leadership wants to know whether the company appears. Absence feels risky. Competitor presence feels worse. A screenshot of a missing mention can travel through Slack very quickly.
+
+But the question is too blunt for budget decisions.
+
+Some absences are commercially minor. A company may not appear in a broad informational answer that attracts students, journalists, or early curiosity rather than real buyers. It may be missing from a generic category overview where the buyer is not yet building a shortlist. It may be named in a low-value answer that creates no route to action. It may win a mention in a prompt no actual prospect would ask.
+
+Other answer moments are different. They sit close to revenue.
+
+A buyer asks which agency can help a B2B SaaS company improve AI visibility before a category launch. A Marketing Director asks how to evaluate GEO partners for a board recommendation. A founder asks whether the company needs a consultant, a content team, a technical SEO partner, or an internal hire. A procurement lead asks what proof should separate serious providers from content-volume vendors. A competitor comparison asks which option fits a funded team that needs strategic answer-market work rather than generic blog production.
+
+Those are not just visibility moments. They are commercial routing moments.
+
+If the answer is wrong there, the business may lose qualified demand, attract the wrong-fit buyer, give competitors the frame, or force sales to correct a misunderstanding that public material should have prevented.
+
+## Start with the buyer question, then assign the consequence
+
+The first move is to stop treating prompts as equal units.
+
+A prompt is only useful to the business if it represents a buyer question with a plausible commercial effect. The leadership task is to map the question to the consequence before deciding what work deserves budget.
+
+A simple triage can ask:
+
+| Buyer question type | Commercial consequence | What the GEO work may need |
+|---|---|---|
+| "Who should we shortlist for this problem?" | Pipeline creation and competitor inclusion | Category pages, comparison pages, clear positioning, credible proof |
+| "Is this company a fit for us?" | Sales qualification and wrong-fit avoidance | Fit criteria, not-for statements, use-case boundaries, budget or maturity signals |
+| "How is this company different from alternatives?" | Competitive framing and price defence | Trade-off pages, decision guides, customer proof, founder point of view |
+| "Can we trust this claim?" | Procurement confidence and internal buy-in | Evidence pages, case studies, methodology notes, third-party support |
+| "What changed after this launch or repositioning?" | Launch risk and expectation management | Continuity cues, updated FAQs, redirect intent, sales enablement, old-answer repair |
+| "What should we do next?" | Conversion route and deal momentum | Clear next steps, diagnostic assets, sales handoff context, offer pages |
+
+This table is not a reporting template. It is a budget filter.
+
+If the buyer question cannot plausibly change revenue, qualification, competitive perception, or risk, it should not receive the same investment as a question that can. The goal is not to ignore the long tail forever. The goal is to stop the long tail from consuming the resources needed for the answer moments that actually shape demand.
+
+## Fund the fix according to the consequence
+
+Once the consequence is clear, the remedy becomes more precise.
+
+The lazy answer to every AI visibility gap is content. Publish another article. Add another FAQ. Rewrite another landing page. Produce another glossary entry. Sometimes that is the right move. Often it is only one part of the fix.
+
+If the commercial consequence is pipeline creation, the work may be positioning and category eligibility. The company needs to be legible as a serious option when the buyer forms a shortlist. That may require a sharper offer page, clearer category language, comparison material, and proof that matches the buying moment.
+
+If the consequence is sales qualification, the work may be constraint publishing. The business needs answer engines and buyers to understand who the offer is for, who it is not for, what budget or maturity makes sense, and which adjacent problems should be routed elsewhere. More visibility without fit creates pipeline noise.
+
+If the consequence is competitive framing, the work may be public trade-offs. Buyers ask answer engines to compare options because they want the decision compressed. If the company does not publish the criteria it wants to be judged on, the answer may inherit the competitor's frame.
+
+If the consequence is procurement confidence, the work may be proof. A confident claim with weak supporting material is fragile when it appears in a cited answer, an internal memo, or a board recommendation. The fix may be a stronger case study, a methodology page, a source-backed explanation, or a clearer statement of evidence limits.
+
+If the consequence is launch risk, the work may be transition management. Old pages, old snippets, partner descriptions, sales decks, and comparison material can keep teaching the previous story after the company has moved on. The answer-market changeover needs continuity cues, not just a new homepage.
+
+The budget should follow the business consequence, not the surface symptom.
+
+## Measure commercial answer moments, not just mentions
+
+Mention tracking has a place. It can show where the company appears, where competitors appear, which sources are cited, and which answer surfaces deserve attention.
+
+But mention count is not enough to allocate spend.
+
+A useful GEO review should save the answer, prompt, surface, date, visible citations or sources where available, and the buyer question being tested. Then it should add one more field: commercial consequence.
+
+Does this answer affect shortlist inclusion? Does it change the buyer's understanding of the category? Does it qualify or disqualify the right people? Does it make the company look premium, tactical, risky, generic, specialist, outdated, or credible? Does it arm a competitor with the stronger explanation? Does it help sales or create repair work? Does it matter to a launch window, procurement step, or board-level decision?
+
+That turns AI visibility review from a scoreboard into a prioritisation tool.
+
+A brand mention in a low-intent answer may be a weak signal. A missing mention in a high-intent shortlist answer may be urgent. A citation that supports the wrong claim may be more dangerous than absence. A correct answer that leads to the wrong next step may still leak value. A competitor answer that explains trade-offs better than yours may reveal a positioning problem, not a prompt problem.
+
+The point is not to pretend every answer can be tied neatly to attribution. It cannot. The point is to separate answer moments that deserve executive attention from answer moments that merely create dashboard motion.
+
+## Different surfaces can change different parts of the sale
+
+Commercial triage also prevents the team from flattening every answer-led surface into one channel.
+
+ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led products can all shape buyer expectations, but not always in the same way. One answer may help a buyer understand the category. Another may provide cited source trails. Another may sit inside a Search-shaped journey. Another may be used by a team member drafting an internal recommendation. Another may influence a founder's first sense of who belongs on the shortlist.
+
+The budget question should therefore be specific:
+
+Which surface is likely to influence this buyer question, and what part of the sale could it change?
+
+For synthesis-heavy answers, the problem may be that the company is too hard to explain. For cited-answer surfaces, the problem may be that the supporting source is thin, stale, or not the page leadership would want a buyer to inspect. For Google AI features, keep the caveat clear: Google's AI features rely on core Search ranking and quality systems. The response is not to chase an AI-only switch through llms.txt, special AI markup, arbitrary chunking, or excessive structured data. The response is to improve the public material that core Search systems can understand, rank, and surface as helpful.
+
+Across all surfaces, the leadership standard should remain commercial. Do not ask only, "Did we appear?" Ask, "If this answer changed, would it change the sale?"
+
+## Build a short list of answer moments worth funding
+
+A practical GEO budget does not need to start with hundreds of prompts.
+
+Start with the twenty or thirty buyer questions most likely to alter commercial outcomes. Include questions buyers ask before they know the category, while forming a shortlist, when comparing alternatives, when checking proof, when qualifying fit, when preparing an internal recommendation, and when reacting to a launch or repositioning.
+
+Then score each question with a small set of filters:
+
+| Filter | Question to ask |
+|---|---|
+| Buyer intent | Is this a real question a serious prospect, evaluator, founder, or procurement stakeholder would ask? |
+| Revenue proximity | Could the answer affect pipeline, deal quality, urgency, pricing expectation, or conversion route? |
+| Competitive leverage | Could the answer include, exclude, or frame competitors in a way that changes the decision? |
+| Current risk | Is the existing answer missing, stale, overbroad, unsupported, or commercially misleading? |
+| Fixability | Can content, proof, page structure, comparison material, sales enablement, or public constraints realistically improve it? |
+| Ownership | Which team can act: marketing, content, product marketing, sales, leadership, technical SEO, customer marketing, or founder? |
+
+That last field matters. A high-value answer moment with no owner becomes another strategic anxiety. A high-value answer moment with a named owner becomes a funded action.
+
+The output should be a ranked answer-moment backlog. Not a generic content calendar. Not a pile of screenshots. A short list of buyer questions where a better public answer could change a commercial outcome, with the likely fix and owner attached.
+
+## The CMO move: make GEO a capital allocation conversation
+
+The strongest GEO programmes will not be the ones that create the most AI visibility tasks.
+
+They will be the ones that know which tasks deserve money, leadership attention, and scarce execution time.
+
+That requires a different executive conversation. Instead of asking, "How do we show up more in AI?" ask:
+
+- Which buyer questions can change revenue if the answer improves?
+- Which answer moments are close enough to the sale to fund now?
+- Which gaps create wrong-fit pipeline rather than useful demand?
+- Which competitor explanations are shaping the frame before sales arrives?
+- Which proof gaps make a strong claim hard to trust?
+- Which launch or repositioning questions could carry the old story forward?
+- Which fixes belong to content, proof, sales enablement, technical hygiene, or leadership positioning?
+
+That is a more disciplined conversation than treating every prompt run, mention, or citation as equal.
+
+For CMOs, Marketing Directors, and founders, the commercial point is simple: AI visibility work is not a content-volume contest. It is a decision about where answer-led discovery can change the buying journey.
+
+Spend first where the answer can create qualified demand, protect the frame, reduce sales friction, or prevent the wrong market memory from reaching the buyer.
+
+Everything else can wait its turn.


### PR DESCRIPTION
## Summary
- Adds the approved Day 67 Build in Public post on GEO budget allocation
- Publishes the revised artifact to `docs/blog/posts/daily-blog-day-67.md`
- Preserves the Google AI features caveat and required answer-engine surface framing

## Checks
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-67.md`
- Custom Day 67 content assertions for title/date/slug/marker/surfaces/Google caveat/internal framing
- `python3 -m compileall tools`
- `python3 -m mkdocs build`

## Payload
- Intended file only: `docs/blog/posts/daily-blog-day-67.md`
