### PR TITLE
docs: add daily blog day 68

### DIFF
--- a/docs/blog/posts/daily-blog-day-68.md
+++ b/docs/blog/posts/daily-blog-day-68.md
@@ -1,0 +1,186 @@
+---
+title: "Day 68: Build a Cadence for Answer-Market Drift"
+date: 2026-06-27
+slug: "day-68-build-cadence-answer-market-drift"
+description: "A practical GEO note for CMOs, Marketing Directors, and founders: answer-led discovery changes over time, so teams need a lightweight cadence for spotting meaningful answer-market drift without overreacting to normal volatility."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - answer-market drift
+  - marketing operations
+geo_tactics:
+  - Build a recurring answer-market drift review that separates normal answer volatility from meaningful changes in category framing, competitor set, buyer objections, proof expectations, and recommended next steps.
+  - Review high-value buyer questions weekly, monthly, and after major launches or market moves, with clear thresholds for when marketing, product marketing, sales, leadership, or technical SEO should act.
+  - Compare ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces over time without assuming every surface updates on the same clock or deserves the same response.
+  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility.
+---
+
+# Day 68: Build a Cadence for Answer-Market Drift
+
+A single AI answer is a snapshot. A market is a moving system.
+
+That distinction matters for GEO.
+
+If a CMO, Marketing Director, or founder only checks answer-led discovery once, they may get a useful baseline. They may learn whether ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar surfaces understand the company, include the right competitors, cite the right material, and describe the buyer problem in a commercially useful way.
+
+But the baseline will decay.
+
+Answer engines change. Search results change. Competitors publish new proof. Analysts rename categories. Buyers ask sharper questions. Launches introduce new language. Old pages keep circulating. Sales hears new objections before marketing sees them in a dashboard.
+
+GEO is not a one-off audit or a panic around screenshots. It needs a lightweight operating cadence for answer-market drift: the recurring work of noticing when the public answer market has moved enough to change how buyers understand the category, compare options, trust claims, or choose the next step.
+
+<!-- more -->
+
+## Drift is not the same as noise
+
+The first leadership discipline is restraint.
+
+Answer-led surfaces are variable. One response may name a competitor that disappears in the next run. One prompt phrasing may produce a different ordering. One citation may rotate. One summary may be shorter, longer, or slightly differently worded without changing the buyer's practical understanding.
+
+That is noise.
+
+If the team treats every change as an emergency, GEO becomes screenshot theatre. Slack fills with isolated examples. Content teams chase tiny wording shifts. Leadership loses confidence because the system appears unmanageable. The business spends time reacting to samples instead of managing the market.
+
+Answer-market drift is different.
+
+Drift is a repeated or strategically important change in the answer environment. It changes the frame through which a buyer understands the problem, the company, the competitor set, the risk, the proof standard, or the next action.
+
+Examples:
+
+- the category label around the problem starts shifting from tactical execution to strategic risk;
+- a new competitor repeatedly appears in shortlist-style answers;
+- the company is still described through an old offer after a repositioning;
+- answer engines begin presenting procurement risk as the dominant objection;
+- buyer questions move from "what is this?" to "who can we trust to implement it?";
+- cited sources support the right claim but lead buyers to a weak or outdated proof page;
+- the recommended next step becomes a generic article when the business needs a diagnostic, demo, or sales conversation.
+
+Those changes can alter commercial reality. They are worth leadership attention.
+
+The point is not to make AI answers perfectly stable. They will not be. The point is to know which movements are noise and which movements change the sale.
+
+## Inspect the answer market on three clocks
+
+A useful cadence does not need to be heavy. It needs to match the speed of the decisions it protects.
+
+For most B2B teams, the answer-market review can run on three clocks: weekly, monthly, and event-triggered.
+
+| Cadence | What to review | Why it matters |
+|---|---|---|
+| Weekly | A small set of high-intent buyer questions close to pipeline, qualification, competitor comparison, and proof | Catches commercially material changes before they become sales friction |
+| Monthly | Category framing, competitor set, source patterns, repeated objections, citation quality, and next-step recommendations | Shows whether the market explanation is drifting in a direction leadership should respond to |
+| Event-triggered | Launches, repositioning, pricing changes, new proof, analyst coverage, competitor launches, funding, category news, or major Search changes | Tests whether the answer market has absorbed a meaningful market event or is still teaching the old story |
+
+The weekly check should be deliberately small. Ten to twenty buyer questions is enough if they are the right questions. These are the prompts a serious prospect, founder, Marketing Director, procurement stakeholder, or board adviser might actually use before a commercial decision.
+
+The monthly review can be broader. It should look for patterns: not whether one prompt changed yesterday, but whether the overall answer market is starting to describe the category, company, competitors, or buying criteria differently.
+
+The event-triggered check is where many teams are weakest. When the company launches a new offer, changes positioning, publishes a major proof asset, or enters a new category, the answer market should be inspected as part of the go-to-market work. The question is not only "did the announcement go live?" It is "what explanation will a buyer now get when they ask an answer engine what changed?"
+
+## Track the fields that reveal commercial drift
+
+Most AI visibility tracking starts with presence: did the brand appear, did a competitor appear, and which sources were visible?
+
+That is useful, but it is not enough to manage drift.
+
+A drift cadence should save a small set of fields that explain why a change matters:
+
+| Field | Question to answer |
+|---|---|
+| Buyer question | Which real buying question does this prompt represent? |
+| Surface | Was the answer from ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led product? |
+| Category frame | What problem category does the answer place us in? |
+| Competitor set | Which alternatives are included, excluded, or implied? |
+| Buyer objection | What risk, doubt, or concern does the answer foreground? |
+| Proof standard | What evidence does the answer make buyers expect? |
+| Source or citation pattern | Which public material appears to support the answer, where visible? |
+| Recommended next step | What action does the answer steer the buyer toward? |
+| Commercial consequence | Could this change affect pipeline, fit, urgency, pricing expectation, trust, or sales repair work? |
+| Owner | Who decides whether to act: marketing, product marketing, sales, leadership, technical SEO, or customer marketing? |
+
+This turns a loose screenshot folder into a management instrument.
+
+If the competitor set changes once, the team can note it. If it changes repeatedly across high-intent shortlist questions, product marketing may need to revisit comparison material. If the category frame downgrades the company from strategic advisory to generic content execution, leadership may need sharper positioning and proof. If the recommended next step points buyers to an educational page when they are ready for evaluation, marketing may need a stronger conversion route.
+
+The cadence should not ask, "Did anything move?" Something will always move.
+
+It should ask, "Did the movement change what a buyer believes or does?"
+
+## Set thresholds before the screenshots arrive
+
+The easiest way to overreact is to decide the response after seeing a scary answer.
+
+A better cadence defines thresholds in advance.
+
+For example:
+
+- Ignore isolated wording changes that do not alter the category, competitor set, proof expectation, buyer objection, or next step.
+- Watch a new competitor mention until it appears across several high-intent questions or a commercially important surface.
+- Act when the company is repeatedly excluded from shortlist answers where it has a strong right to belong.
+- Act when an answer describes the offer through retired language after a launch or repositioning.
+- Act when a cited or surfaced page supports a claim the business no longer wants buyers to use.
+- Act when answer engines consistently foreground an objection sales is also hearing from qualified buyers.
+- Act when the answer gives buyers a next step that leaks value, such as generic research instead of a diagnostic, proof asset, comparison page, or sales conversation.
+
+These thresholds protect the team from two opposite mistakes.
+
+One mistake is complacency: treating answer-led discovery as too unstable to manage, then missing a real market shift until sales feels it. The other is anxiety: treating every answer variation as a task, then turning GEO into low-leverage content churn.
+
+The leadership job is to keep the middle ground. Monitor enough to see meaningful drift. Respond only when the change can alter buyer understanding, demand quality, competitive framing, or conversion path.
+
+## Different surfaces drift on different clocks
+
+Do not flatten every answer-led surface into one channel.
+
+ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar products can all influence buyer understanding, but they do not necessarily change at the same pace or for the same reasons. Some surfaces may synthesise broad public material. Some may expose citation paths more clearly. Some may sit inside a Search-shaped journey. Some may be used by a founder exploring a category, while others may be used by a marketer preparing an internal recommendation.
+
+That means the cadence should compare surfaces without forcing them into the same interpretation.
+
+If Perplexity repeatedly cites an outdated comparison page, the fix may be source quality and page maintenance. If ChatGPT compresses the offer into a generic category, the fix may be clearer public positioning and repeated proof. If Gemini or Google AI features surface a Search-shaped answer that reflects weak underlying pages, the answer is not to chase an AI-only switch. Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and excessive structured data are not magic requirements for Google AI visibility. The practical response is to improve the public material that core Search systems can understand, rank, and treat as helpful.
+
+Across all surfaces, the same commercial test applies: is the buyer being moved toward the right understanding and next decision?
+
+If the answer is no, investigate the public material behind the pattern. If the answer is yes, do not manufacture work just because the wording changed.
+
+## Put drift into an operating rhythm
+
+Answer-market drift needs ownership because drift without ownership becomes background anxiety.
+
+A simple rhythm can work:
+
+1. Marketing or growth owns the weekly high-intent prompt set and captures notable changes.
+2. Product marketing reviews monthly shifts in category language, competitor inclusion, proof expectations, and buyer objections.
+3. Sales contributes repeated buyer language: questions, misconceptions, comparison frames, and objections heard in real conversations.
+4. Leadership decides whether a drift pattern is commercially important enough to fund.
+5. Technical SEO or web owners handle fixes related to crawlable pages, page clarity, internal linking, redirects, schema hygiene, and Search-shaped discoverability.
+6. Content, customer marketing, or founders publish the missing explanation, proof, comparison, constraint, or next-step asset.
+
+This is not a call for a large committee. It is a way to stop answer-led discovery from falling between teams.
+
+The output should be a short drift register, not a bloated report. For each meaningful pattern, record the buyer question, observed change, likely consequence, decision owner, proposed fix, and review date. If the pattern is noise, mark it as noise and move on.
+
+That last step matters. A mature GEO programme should be able to say, "We saw it, it does not matter yet." Not every movement deserves a brief, budget, or new asset.
+
+## The CMO move: manage the market explanation over time
+
+The commercial value of GEO is not only appearing in answer engines. It is shaping the public explanation buyers encounter before they speak to sales.
+
+That explanation changes over time.
+
+Competitors get clearer. Categories mature. Proof standards rise. Old claims weaken. Buyer objections move. Search-shaped surfaces adjust. Answer engines synthesise new material. Launches introduce language the market may or may not absorb.
+
+For CMOs, Marketing Directors, and founders, the practical question is:
+
+When the answer market drifts, will we know whether it matters?
+
+A one-off audit cannot answer that. A screenshot panic cannot answer that. A content calendar cannot answer that on its own.
+
+A cadence can.
+
+Review the questions that change commercial outcomes. Separate normal answer noise from meaningful drift. Assign ownership before the issue becomes sales repair work. Respond when the category frame, competitor set, objection, proof standard, or next step moves in a way that can change the buyer's decision.
+
+GEO becomes more useful when it stops chasing every answer and starts managing the market's explanation over time.

--- a/docs/blog/posts/daily-blog-day-68.md
+++ b/docs/blog/posts/daily-blog-day-68.md
@@ -16,7 +16,7 @@ geo_tactics:
   - Build a recurring answer-market drift review that separates normal answer volatility from meaningful changes in category framing, competitor set, buyer objections, proof expectations, and recommended next steps.
   - Review high-value buyer questions weekly, monthly, and after major launches or market moves, with clear thresholds for when marketing, product marketing, sales, leadership, or technical SEO should act.
   - Compare ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces over time without assuming every surface updates on the same clock or deserves the same response.
-  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
 ---
 
 # Day 68: Build a Cadence for Answer-Market Drift


### PR DESCRIPTION
## Summary
- Adds Day 68 daily blog post: “Build a Cadence for Answer-Market Drift”
- Applies the approved revision artifact to `docs/blog/posts/daily-blog-day-68.md`
- Keeps PR payload intentionally limited to that single blog post file
- Includes a YAML-only quote fix for one `geo_tactics` item so CI frontmatter validation treats it as a string; rendered content is unchanged

## Checks
- Content/frontmatter assertion passed: title/date/slug present, Google AI caveat present, banned terms absent, SHA-256 `014c27776049123f9ade3c6b7bdb0a22deedd72a8e354f6316db3f90d507d845`
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-68.md` passed
- `python3 -m mkdocs build --strict` attempted; aborted on existing site warnings/RoamLinks warnings in strict mode
- `python3 -m mkdocs build` passed
- Verified branch payload vs `origin/main` contains only `docs/blog/posts/daily-blog-day-68.md`
