### PR TITLE
docs: add daily blog day 69

### DIFF
--- a/docs/blog/posts/daily-blog-day-69.md
+++ b/docs/blog/posts/daily-blog-day-69.md
@@ -1,0 +1,166 @@
+---
+title: "Day 69: Make the First AI Visibility Call Easy to Start"
+date: 2026-06-28
+slug: "day-69-make-first-ai-visibility-call-easy-to-start"
+description: "A practical GEO note for CMOs, Marketing Directors, and founders: answer-led discovery often sends buyers to you with partial context, so the public offer page should make the first AI visibility call easy to start without demanding a full data room up front."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - offer packaging
+  - conversion strategy
+geo_tactics:
+  - Design the public GEO offer page around a low-friction first call that starts with domain, priority offer, target buyers, and a small set of competitors or buyer questions.
+  - Separate required first-call inputs from optional evidence, so sales notes, Search Console data, analytics, proof assets, and prior research improve delivery without becoming a barrier to starting.
+  - "Treat the post-answer next step as part of GEO: buyers arriving from ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar surfaces need a commercially specific route from curiosity to diagnosis."
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 69: Make the First AI Visibility Call Easy to Start
+
+A buyer who arrives from an answer engine rarely arrives with a perfect brief.
+
+They may have asked ChatGPT for agencies working on AI visibility. They may have compared providers in Claude. They may have used Perplexity to understand GEO, Gemini to pressure-test a shortlist, or Google AI features while researching whether the problem is urgent enough to fund.
+
+By the time they reach your site, they may know enough to be interested and not enough to specify the work.
+
+That is the moment many public offer pages make too difficult. They ask for too much too early: every market segment, every data source, every internal stakeholder, every analytics view, every sales note, every content gap, every competitor, every technical detail, every proof asset.
+
+Some of that evidence will matter later. It should not all be the price of admission for the first conversation.
+
+For CMOs, Marketing Directors, and founders, a good GEO offer page should make the first AI visibility call easy to start. Ask for the minimum inputs needed to form a useful baseline. Then explain which optional evidence can improve the work once the buyer decides the problem is worth funding.
+
+<!-- more -->
+
+## Partial context is the normal starting point
+
+Answer-led discovery compresses the buyer journey.
+
+A prospect can move from curiosity to shortlist to internal recommendation without reading the same sequence of pages a traditional search journey might have produced. They may arrive with fragments: a category explanation, a competitor comparison, a recommendation list, a cited page, a concern about being invisible in AI answers, or a board-level question about whether the company is being described accurately.
+
+That does not mean they are unqualified. It means the public route into the conversation has to handle partial context.
+
+A first call should not require the buyer to already know:
+
+- every prompt their customers use;
+- exactly which answer engines matter most;
+- which citations are correct or harmful;
+- how Google AI features choose supporting sources;
+- whether the problem is content, positioning, technical SEO, proof, product marketing, or sales enablement;
+- which internal data sources will eventually be useful;
+- how to translate answer visibility into commercial priority.
+
+If the buyer knew all of that, they would not need a diagnostic conversation.
+
+The job of the offer page is to lower the threshold from "complete the whole strategy before we speak" to "bring enough context for us to start intelligently".
+
+## Four inputs are usually enough to begin
+
+A useful first AI visibility call can start with a small set of inputs.
+
+| First-call input | Why it helps |
+|---|---|
+| Domain | Shows what the public corpus currently teaches about the company, offer, pages, and source footprint |
+| Priority offer | Focuses the diagnostic on the revenue motion that matters now, not every possible product line |
+| Target buyers | Clarifies whose questions, objections, and comparison criteria should shape the review |
+| A few competitors or buyer questions | Gives the baseline a commercial frame: who the company is compared with and what buyers are trying to decide |
+
+That is enough to begin a useful conversation.
+
+The agency can use those inputs to inspect how the company is publicly described, which answer-led paths may matter, where the offer is clear or vague, which competitor frames appear, and whether the next step on the site helps a serious buyer move forward.
+
+The point is not to pretend the first call can solve the whole problem. It cannot. The point is to make the first call specific enough that the buyer can understand whether GEO work is commercially relevant before they assemble a full internal evidence pack.
+
+That distinction is important. Low friction does not mean shallow. It means the first step respects the buyer's uncertainty.
+
+## Optional evidence should improve the work, not block the call
+
+There is a second layer of evidence that can make GEO work better.
+
+Sales notes can reveal how prospects describe the problem before marketing sees it in aggregate data. Search Console can show which pages already earn demand and which queries are close to commercial intent. Analytics can show where answer-influenced traffic may be landing, even when attribution is imperfect. Customer proof can support claims answer engines are currently summarising weakly. Prior research can prevent the team from rediscovering what product marketing already knows.
+
+Those inputs are valuable.
+
+They are also not always available before the first conversation.
+
+A company may not have clean attribution for AI-influenced sessions. Sales notes may live in call recordings, Slack threads, or CRM fields nobody has normalised. Proof assets may exist but be scattered. Search Console access may require another stakeholder. A founder may be exploring the issue before the marketing team has built a formal case.
+
+If the offer page presents all of those materials as required, it creates the wrong commercial signal: "Come back when your house is already in order."
+
+A better structure is:
+
+| Required to start | Helpful after the first call |
+|---|---|
+| Domain | Search Console exports |
+| Priority offer | Sales call notes or CRM patterns |
+| Target buyers | Analytics and landing-page paths |
+| Competitors or buyer questions | Customer proof, case studies, analyst notes, prior research |
+
+This framing keeps the first step light while making the later work credible. It tells the buyer: we can begin with public signals and commercial context; deeper evidence improves the baseline, prioritisation, and execution plan once the work is worth doing.
+
+## The offer page is part of the GEO system
+
+GEO is often discussed as if the work ends when an answer engine names, cites, or recommends a company.
+
+It does not.
+
+The buyer still has to do something next. They click, search, compare, forward, ask another question, or decide the page is not worth their time. If the public offer page turns that moment into a vague contact form or a heavy diagnostic assignment, demand can leak after the answer has already created interest.
+
+That makes conversion architecture part of the GEO system.
+
+For an AI visibility offer, the page should make several things explicit:
+
+- who the offer is for;
+- what kind of commercial problem it diagnoses;
+- what a first call can usefully cover;
+- what the buyer needs to bring to start;
+- what evidence can improve the work later;
+- what the buyer will understand after the call;
+- what the next decision will be.
+
+This is not just sales enablement. It is answer-market continuity.
+
+If answer-led discovery sends a Marketing Director to a page about AI visibility, the page should not force them to translate the recommendation into an internal consulting brief. It should carry the momentum forward: "Here is the problem we can help diagnose, here is the minimum context we need, here is what we will look at, and here is what you will be able to decide afterwards."
+
+That is especially important because answer engines often generalise. They can explain the category, name possible providers, and summarise public claims. They are less reliable at knowing the buyer's internal constraints, budget politics, stakeholder pressure, sales objections, proof gaps, and launch timing.
+
+The first call bridges that gap. The page should make the bridge easy to cross.
+
+## Do not turn Google AI visibility into a magic checklist
+
+The low-friction first call should also protect the buyer from false prerequisites.
+
+Google's AI features rely on core Search ranking and quality systems. A buyer does not need to arrive believing that llms.txt, special AI markup, arbitrary content chunking, or over-focused structured data is a required switch for Google AI visibility.
+
+Some technical work may be useful. Clean crawlability, clear canonical pages, coherent internal linking, structured data where it accurately represents the page, strong content quality, and visible expertise can all matter in the broader Search ecosystem.
+
+But the offer page should not imply that the buyer must buy a magic AI-markup package before anyone can diagnose the commercial visibility problem.
+
+A useful first call can stay grounded:
+
+- What do answer-led surfaces currently appear to understand about the company?
+- Which buyer questions could change demand, qualification, trust, or competitor framing?
+- Which public pages support or weaken those answers?
+- Which missing explanations, proof points, or offer cues would help a serious buyer decide?
+- Which data sources would make the next phase more precise?
+
+That is a stronger commercial starting point than a technical superstition checklist.
+
+## A simple first-call promise
+
+The best public GEO offer pages make a simple promise:
+
+Bring your domain, the offer you care about, the buyers you need to influence, and a few competitors or buyer questions. We can start there.
+
+If the conversation shows there is a real commercial issue, then the team can gather more evidence: sales notes, Search Console data, analytics, proof assets, customer language, historical research, and internal priorities. Those materials can sharpen the baseline and improve the execution plan.
+
+But they should not be required before the buyer knows whether the work deserves attention.
+
+That is the commercial packaging lesson.
+
+Answer-led discovery often creates informed curiosity, not a perfect brief. The public offer should meet the buyer at that stage. Make the first step legible. Keep the required inputs small. Explain the optional evidence honestly. Show what decision the call will enable.
+
+GEO is not only about being found in AI answers. It is also about making the next step after being found easy enough that a serious buyer actually takes it.


### PR DESCRIPTION
## Summary
- Adds Day 69 Build in Public post for 2026-06-28.
- Publishes the approved final revision at `docs/blog/posts/daily-blog-day-69.md`.
- Quotes two `geo_tactics` frontmatter items containing `: ` so the repository frontmatter validator treats them as strings.

## Checks
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-69.md`
- targeted content assertions for title/date/slug/H1/`<!-- more -->`/Google caveat/forbidden legacy phrases
- `PYTHONPATH=. pytest -q tests/test_validate_frontmatter.py`
- `mkdocs build` (passes; existing RoamLinks/nav warnings remain)

## Payload
- `docs/blog/posts/daily-blog-day-69.md` only
