### PR TITLE
docs: add daily blog day 70

### DIFF
--- a/docs/blog/posts/daily-blog-day-70.md
+++ b/docs/blog/posts/daily-blog-day-70.md
@@ -15,8 +15,8 @@ tags:
 geo_tactics:
   - Publish buyer-useful comparison architecture before ChatGPT, Claude, Perplexity, Gemini, Google AI features, or similar answer-led surfaces have to infer the criteria from competitors, third parties, and thin snippets.
   - Make the public surface explicit about decision criteria, trade-offs, fit boundaries, alternative categories, proof standards, buyer questions, and next-step routes.
-  - Treat comparison pages as buyer guidance, not attack pages: show when the company is the right choice, when it is not, and what evidence should decide the shortlist.
-  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility.
+  - "Treat comparison pages as buyer guidance, not attack pages: show when the company is the right choice, when it is not, and what evidence should decide the shortlist."
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
 ---
 
 # Day 70: Build the Comparison Before the Buyer Outsources It

--- a/docs/blog/posts/daily-blog-day-70.md
+++ b/docs/blog/posts/daily-blog-day-70.md
@@ -1,0 +1,222 @@
+---
+title: "Day 70: Build the Comparison Before the Buyer Outsources It"
+date: 2026-06-29
+slug: "day-70-build-comparison-before-buyer-outsources-it"
+description: "A practical GEO note for CMOs, Marketing Directors, and founders: buyers increasingly ask answer engines to compare options before sales is involved, so companies need public comparison criteria, honest trade-offs, fit boundaries, proof standards, and next-step routes that preserve how they should be evaluated."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - competitive comparison
+  - buyer decision strategy
+geo_tactics:
+  - Publish buyer-useful comparison architecture before ChatGPT, Claude, Perplexity, Gemini, Google AI features, or similar answer-led surfaces have to infer the criteria from competitors, third parties, and thin snippets.
+  - Make the public surface explicit about decision criteria, trade-offs, fit boundaries, alternative categories, proof standards, buyer questions, and next-step routes.
+  - Treat comparison pages as buyer guidance, not attack pages: show when the company is the right choice, when it is not, and what evidence should decide the shortlist.
+  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility.
+---
+
+# Day 70: Build the Comparison Before the Buyer Outsources It
+
+A buyer who wants to compare you with alternatives no longer has to wait for your sales team, your competitor's sales team, or an analyst report.
+
+They can ask ChatGPT for a shortlist. They can ask Claude to compare agencies. They can ask Perplexity for evidence. They can use Gemini or Google AI features while trying to understand which category the problem belongs in. They can bring an answer-led comparison into the first internal meeting before anyone from your company knows the deal exists.
+
+That changes the job of public marketing.
+
+For CMOs, Marketing Directors, and founders, the risk is not only that an answer engine fails to mention the company. The sharper risk is that it compares the company on the wrong terms: the wrong category, the wrong competitors, the wrong criteria, the wrong proof standard, or the wrong next step.
+
+If your public material only says positive things about yourself, the comparison still happens. It just gets built from whatever else the answer engine can find.
+
+Build the comparison before the buyer outsources it.
+
+<!-- more -->
+
+## Comparison is now part of the public surface
+
+Traditional B2B websites often separate positioning from comparison.
+
+The homepage makes the case. The product or service page describes the offer. The proof page supports the claim. The sales team handles competitive nuance privately: why this option is better for one buyer, weaker for another, more strategic than a low-cost alternative, more focused than a broad platform, or less suitable for a company at the wrong stage.
+
+That separation is less safe in answer-led discovery.
+
+A buyer may ask an answer engine:
+
+- "Which agencies should we consider for AI visibility?"
+- "How is GEO different from SEO?"
+- "Should we hire a content agency, a technical SEO team, or a specialist GEO partner?"
+- "What proof should we look for before funding this?"
+- "Which option is best for a B2B company with a complex buying committee?"
+- "When is this kind of work not worth doing yet?"
+
+Those are comparison questions. They do not wait for a private sales deck.
+
+If the company has not published the criteria, trade-offs, and fit boundaries that should govern the decision, the answer engine has to infer them. It may infer them from old category language. It may infer them from competitor pages. It may use generic SEO assumptions. It may summarise a third-party article that was not written for your market. It may flatten a specialist offer into a broad agency category because the public evidence gives it no better frame.
+
+GEO is therefore not just a visibility exercise. It is a comparison accuracy exercise.
+
+## A good comparison surface is not a hit piece
+
+The weak version of comparison content is an attack page.
+
+It chooses a competitor, lists the competitor's flaws, declares itself the obvious winner, and calls that strategy. Humans distrust it. Answer engines have little reason to treat it as balanced. Sales teams often dislike it because it creates a brittle argument that does not match the nuance of real deals.
+
+A stronger comparison surface is buyer-useful.
+
+It explains how the decision should be made. It gives the buyer a fair way to evaluate options. It makes honest trade-offs visible. It names the situations where the company is a strong fit, and the situations where another category may be better.
+
+That does not weaken the commercial case. It improves it.
+
+A serious buyer is rarely asking, "Who shouts loudest?" They are asking, "Which option fits our problem, constraints, maturity, budget, evidence needs, and urgency?"
+
+Public comparison architecture should help them answer that question.
+
+## Build the criteria before the market supplies its own
+
+The first layer is criteria.
+
+If you do not explain what buyers should compare, the market will choose for you. In GEO and AI visibility work, that can easily become a shallow list: content volume, keyword rankings, backlinks, technical audits, generic SEO retainers, or whether a vendor promises to "optimise for AI" without explaining what that means.
+
+A better comparison framework might ask:
+
+| Criterion | Why it matters in answer-led discovery |
+|---|---|
+| Buyer-question relevance | The work should start from the questions that can change pipeline, qualification, trust, or competitive framing |
+| Public-corpus clarity | Answer engines need consistent, accessible material about the company, offer, category, proof, and next step |
+| Commercial specificity | The comparison should reflect the actual buyer, sales motion, market, and revenue consequence, not a generic visibility checklist |
+| Proof standard | Claims need supporting evidence that a human buyer and an answer engine can both use |
+| Technical accessibility | Important material should be crawlable, indexable, well structured, and easy for core Search systems and other discovery surfaces to interpret |
+| Sales handoff | The public answer should route a qualified buyer towards the right next action, not leave them with an abstract explanation |
+
+These criteria change the shape of the conversation.
+
+Instead of "which agency writes more content?", the buyer can ask "which partner can help us make the public answer market describe our offer accurately enough to influence real decisions?"
+
+That is a different comparison.
+
+## Trade-offs make the recommendation more credible
+
+Comparison architecture also needs trade-offs.
+
+Every real option has them. A specialist partner may be stronger on AI visibility strategy and weaker on broad campaign production. A traditional SEO agency may be strong on technical hygiene and content operations but less focused on answer-market diagnosis. An internal team may know the product deeply but lack time, tooling, or cross-surface evidence. A platform may scale monitoring but still require strategic interpretation.
+
+Publishing those distinctions is not self-sabotage. It is how you stop the market from treating unlike options as identical.
+
+A useful comparison page can say:
+
+- choose a specialist GEO partner when the commercial risk is answer-led misframing, shortlist exclusion, weak proof, or unclear category position;
+- choose a broader SEO or content partner when the main problem is publishing throughput, technical site health, or long-term organic coverage;
+- build internally when the team already has the expertise, authority, and time to maintain the answer market;
+- use tooling when the need is ongoing monitoring, evidence capture, and repeated review, not a one-off strategic decision;
+- delay the work when the offer, audience, or proof base is still too unstable to make public comparison useful.
+
+This is not competitor-bashing. It is decision support.
+
+The buyer comes away with a clearer sense of when you are the right option and when you are not. Answer engines get cleaner material for category-choice, vendor-comparison, and shortlist questions. Sales gets fewer conversations that begin with the wrong premise.
+
+## Fit boundaries protect revenue quality
+
+Fit boundaries belong inside comparison architecture, but they should not become the whole story.
+
+The point is not merely to publish a list of who you do not serve. The point is to make the comparison commercially accurate.
+
+For example, a company might explain that it is a strong fit for:
+
+- B2B teams where answer-led discovery can influence shortlist, trust, or sales qualification;
+- leadership teams that need commercial interpretation, not just raw screenshots;
+- companies with enough public proof, positioning, and offer clarity to improve how answer engines describe them;
+- teams that want GEO connected to revenue moments rather than treated as a side channel.
+
+It might also explain that it is a weaker fit for:
+
+- companies looking only for cheap content volume;
+- teams that want guaranteed placement in every AI answer;
+- businesses without a clear offer or buyer segment yet;
+- teams that expect a single markup file, prompt trick, or technical switch to solve AI visibility.
+
+That final boundary matters.
+
+Google's AI features rely on core Search ranking and quality systems. It is not accurate to present llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google AI visibility. Technical accessibility can help public material be understood, but the commercial task is broader: make the company, category, proof, trade-offs, and buyer route clear enough for humans and answer-led surfaces to use.
+
+## Give answer engines the buyer questions you want compared
+
+The next layer is the question set.
+
+Comparison architecture should not only describe the company. It should expose the questions a serious buyer should ask before choosing.
+
+For a GEO or AI visibility offer, those questions might include:
+
+- Which buyer questions can change revenue, qualification, or competitive perception?
+- Which answer-led surfaces matter for this market: ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another route?
+- What public sources currently teach the market about the company?
+- Which competitors, alternatives, or adjacent categories should be part of the comparison?
+- What proof would make the claim credible to a CMO, founder, board member, procurement lead, or sales team?
+- Which pages should an answer engine and a human buyer reach after the initial answer?
+- What would make this work commercially premature?
+
+Those questions do two jobs.
+
+They educate the buyer. They also give answer engines a more accurate map of the decision. Instead of relying on generic category summaries, the public surface shows which factors should be used when comparing the company with alternatives.
+
+## Proof standards stop claims becoming interchangeable
+
+Claims become weak when every company can make the same one.
+
+"We help brands with AI visibility" is not enough. "We optimise for answer engines" is not enough. "We understand GEO" is not enough.
+
+A comparison-ready surface should define what proof counts.
+
+That may include:
+
+- examples of buyer questions and the commercial consequence attached to them;
+- methodology notes that explain how answer surfaces are reviewed without pretending a single screenshot proves the market;
+- case studies or anonymised patterns showing how misframing, weak proof, or wrong next steps affect sales;
+- clear distinctions between diagnosis, strategy, implementation, monitoring, and sales enablement;
+- evidence that the company understands core Search quality, technical accessibility, content strategy, and buyer decision-making rather than treating AI visibility as a magic layer.
+
+The aim is not to overload the page with evidence. The aim is to make the evidence standard explicit.
+
+If the buyer delegates comparison to an answer engine, the engine needs public material that says which claims are serious, which are shallow, and which proof should carry weight.
+
+## The comparison should end in a route, not a wall
+
+A buyer-useful comparison needs a next step.
+
+After reading or receiving an answer-led comparison, a serious buyer may not be ready to sign. But they should know what to do next.
+
+The public route might offer:
+
+- a diagnostic call for a priority offer, market, or competitor set;
+- a focused visibility review around high-intent buyer questions;
+- a comparison guide that helps leadership decide between specialist GEO work, broader SEO, content operations, tooling, or internal ownership;
+- a proof checklist for teams preparing a board or budget conversation;
+- a route for wrong-fit buyers to self-select out before sales time is wasted.
+
+This is where comparison architecture becomes commercial.
+
+The goal is not simply to be mentioned in an AI answer. The goal is for the comparison a buyer sees before sales to preserve the right decision logic, qualify the right prospects, and move serious buyers towards a useful next action.
+
+## The practical test
+
+A simple test for a CMO, Marketing Director, or founder is this:
+
+If a buyer asked an answer engine to compare us with our closest alternatives, would our own public material help it produce a fair, commercially accurate answer?
+
+If the answer is no, look for the missing pieces:
+
+- Are the decision criteria public?
+- Are the trade-offs honest?
+- Are fit boundaries clear without becoming the entire argument?
+- Are alternative categories explained fairly?
+- Are proof standards visible?
+- Are buyer questions named?
+- Is there a next-step route for the right prospect?
+
+If those pieces are missing, the comparison will still happen. It will just be assembled from weaker sources.
+
+That is the avoidable loss.
+
+In answer-led discovery, your buyer may outsource the comparison before they ever speak to you. GEO gives you a way to influence that comparison honestly: publish the decision architecture the market should use, then support it with proof, boundaries, and routes a serious buyer can act on.


### PR DESCRIPTION
## Summary
- Adds the approved Day 70 Build in Public post: “Build the Comparison Before the Buyer Outsources It”
- Publishes only `docs/blog/posts/daily-blog-day-70.md`
- Keeps the Google caveat intact: Google AI features rely on core Search ranking and quality systems, not `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required switches

## Verification
- Started from fresh `origin/main` in branch `docs/daily-blog-day-70`
- Copied from `/home/claw/.hermes/zsa-editorial-artifacts/day-70/revision/daily-blog-day-70.md`; repo copy only differs by quoting two `geo_tactics` YAML list items so CI parses them as strings
- Frontmatter/content assertions passed for title, date `2026-06-29`, slug, Day 70 H1, excerpt marker, Google caveat, string `geo_tactics`, and banned-term absence
- `/home/claw/.hermes/hermes-agent/venv/bin/python tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-70.md` passed
- `/home/claw/.hermes/hermes-agent/venv/bin/python -m mkdocs build --strict` still fails on existing repository warnings (RoamLinks/AutoLinks missing targets, nav warnings)
- `/home/claw/.hermes/hermes-agent/venv/bin/python -m mkdocs build` passed
- GitHub checks: `validate` passed; Cloudflare Pages passed

## PR payload
- `docs/blog/posts/daily-blog-day-70.md`
