### PR TITLE
docs: add daily blog day 71

### DIFF
--- a/docs/blog/posts/daily-blog-day-71.md
+++ b/docs/blog/posts/daily-blog-day-71.md
@@ -1,0 +1,194 @@
+---
+title: "Day 71: Turn AI-Generated Objections Into Market Intelligence"
+date: 2026-06-30
+slug: "day-71-turn-ai-generated-objections-into-market-intelligence"
+description: "A practical GEO note for CMOs, Marketing Directors, and founders: buyers increasingly arrive with objections shaped by answer engines, so teams need a sales-to-GEO feedback loop that captures those doubts, classifies their source, and repairs the public material that shaped them."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - sales enablement
+  - buyer objections
+geo_tactics:
+  - Capture buyer objections that appear after answer-led research, including the prompt or surface where possible, the commercial risk, the truth status, the likely public source gap, the owner, and the next repair.
+  - Classify AI-shaped objections as true gaps, stale narratives, competitor-shaped comparisons, missing-proof objections, or wrong-fit disqualifications before deciding whether marketing, sales, product, leadership, or web owners should act.
+  - "Treat sales calls as a source of market intelligence for GEO: if ChatGPT, Claude, Perplexity, Gemini, Google AI features, or similar surfaces package a doubt buyers repeat, the fix may belong in public content, proof pages, comparison material, FAQs, or sales enablement."
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 71: Turn AI-Generated Objections Into Market Intelligence
+
+A buyer can arrive on the first call with an objection your sales team did not create.
+
+They may have asked ChatGPT whether your category is mature. They may have asked Claude to compare vendors. They may have used Perplexity to look for proof, Gemini to pressure-test a shortlist, or Google AI features while researching whether the problem is worth funding.
+
+By the time they speak to you, the doubt may already be packaged:
+
+- "Isn't this just SEO with a new label?"
+- "Do we need a bigger content agency instead?"
+- "Will this work for our market if there are no clean attribution numbers?"
+- "Why would we fund this before we have more case studies?"
+- "Is your offer too specialist for a broader growth problem?"
+
+Those questions might be fair. They might be stale. They might be competitor-shaped. They might come from a missing proof point, an outdated page, a generic category summary, or a comparison the buyer asked an answer engine to assemble before sales was involved.
+
+For CMOs, Marketing Directors, and founders, the point is not to complain that AI answers are imperfect. The point is to treat AI-shaped objections as market intelligence.
+
+If buyers are bringing answer-led doubts into commercial conversations, the team needs a loop for capturing them, diagnosing where they came from, and repairing the public material that made the objection easy to believe.
+
+<!-- more -->
+
+## AI-shaped objections are different from normal sales objections
+
+Sales teams have always heard objections. Budget, timing, trust, authority, risk, fit, proof, and priority are not new.
+
+What has changed is the packaging layer before the call.
+
+A normal objection may come from the buyer's internal constraints: budget pressure, stakeholder scepticism, prior bad experience, procurement rules, or uncertainty about urgency. An AI-shaped objection may still connect to those realities, but it often arrives with an external explanation attached. The buyer has not only wondered whether the company can help; they have already received a synthesized account of the category, alternatives, proof standard, and likely risk.
+
+That changes the sales moment.
+
+The rep is no longer only responding to a buyer's private concern. They may be responding to a public-market summary the buyer now treats as neutral context. If that summary is wrong, thin, old, or incomplete, the team has two jobs: handle the conversation in front of them and fix the public sources that keep producing the same doubt.
+
+Without that second job, the objection repeats.
+
+Sales hears it as an anecdote. Marketing sees no clear signal. Product marketing may not know which comparison frame is spreading. Leadership may assume the issue is a rep enablement problem. Meanwhile, answer engines keep packaging the same risk for the next buyer.
+
+That is avoidable revenue leakage.
+
+## Capture objections in a form GEO can use
+
+The practical move is simple: turn repeated buyer doubts into a small objection intelligence register.
+
+This should not become a heavy admin workflow. It only needs enough structure to connect the sales moment to the public repair.
+
+| Field | Question to answer |
+|---|---|
+| Objection | What did the buyer actually say or imply? |
+| Surface or prompt | Did they mention ChatGPT, Claude, Perplexity, Gemini, Google AI features, a search result, a comparison article, or a specific question they asked? |
+| Commercial risk | Could this block budget, delay urgency, weaken trust, shift the competitor set, depress price, or disqualify the offer? |
+| Truth status | Is the objection true, stale, competitor-shaped, missing-proof, or a wrong-fit signal? |
+| Public source gap | Which page, claim, proof asset, comparison, FAQ, or explanation is absent, weak, outdated, or too generic? |
+| Owner | Who should act: sales, marketing, product marketing, customer marketing, leadership, product, or web/SEO? |
+| Next repair | What specific public or sales asset should change? |
+
+The important field is not only the objection. It is the diagnosis.
+
+"The buyer thinks GEO is just SEO" is useful, but incomplete. The team needs to know whether that belief came from thin category language, competitor positioning, old blog posts, answer summaries that flatten the distinction, or a sales deck that fails to explain the commercial difference.
+
+"The buyer wants proof" is also incomplete. What proof? Proof that answer-led discovery affects pipeline? Proof that the agency can diagnose the market? Proof that Google AI features do not require a magic technical switch? Proof that sales will be able to use the output? Proof that the work changes how executives make a decision?
+
+Objections become useful when they are specific enough to route.
+
+## Classify the doubt before you fix the page
+
+Not every objection deserves the same response.
+
+A team that treats every objection as a content gap will publish too much. A team that treats every objection as a sales technique problem will leave public confusion untouched. A team that treats every objection as a product issue will overbuild.
+
+Start with five categories.
+
+| Objection type | What it means | Typical response |
+|---|---|---|
+| True gap | The buyer is right; the offer, proof, product, or process is missing something material | Fix the substance first, then update public claims and sales language |
+| Stale narrative | The market is repeating an old version of the company, category, or offer | Update positioning, high-authority pages, comparison material, and sales openers |
+| Competitor-shaped comparison | The buyer is evaluating the company through criteria another vendor or category supplied | Publish fair decision criteria, trade-offs, fit boundaries, and alternative-category guidance |
+| Missing-proof objection | The claim may be true, but the buyer cannot see enough evidence to trust it | Add or route to proof: examples, methodology, case patterns, customer language, or diagnostic artefacts |
+| Wrong-fit disqualification | The objection reveals the buyer may not be a good fit | Make fit boundaries clearer and help sales exit cleanly |
+
+This classification prevents the team from responding with generic reassurance.
+
+If the objection is true, do not write around it. Fix the underlying issue. If the objection is stale, the job is public correction. If the objection is competitor-shaped, the team needs better comparison architecture. If the objection is missing-proof, the fix is evidence and routing. If the objection is a wrong-fit signal, it may save sales time rather than demand persuasion.
+
+The commercial discipline is knowing which one you are seeing.
+
+## The repair may sit in marketing, sales, product, or leadership
+
+AI-shaped objections cut across departments because answer-led discovery cuts across the buyer journey.
+
+Sales hears the objection first, but sales may not own the fix.
+
+Marketing may need to rewrite a service page because the public offer does not explain the business problem clearly enough. Product marketing may need to define the comparison criteria buyers should use. Customer marketing may need to expose a stronger proof pattern. Product may need to close a real capability gap. Leadership may need to sharpen the category point of view. Web or SEO owners may need to make an important page easier for core Search systems and answer-led surfaces to find and understand.
+
+A useful ownership map looks like this:
+
+| Owner | What they own |
+|---|---|
+| Sales | Record the buyer language, ask where the concern came from, test whether the objection is material, and feed patterns back quickly |
+| Marketing | Repair public explanations, FAQs, offer pages, and next-step routes |
+| Product marketing | Own category framing, competitor criteria, trade-offs, fit boundaries, and objection messaging |
+| Customer marketing | Supply proof that answers the doubt in a buyer-usable form |
+| Product or delivery | Fix true gaps that cannot be solved with messaging |
+| Leadership | Decide which objections are commercially important enough to change positioning, packaging, or investment |
+| Web/SEO | Maintain crawlable, accurate, accessible pages that core Search and answer-led surfaces can use |
+
+This is where GEO becomes operational rather than decorative.
+
+The goal is not to monitor AI answers for curiosity. The goal is to identify when answer-led summaries are shaping real objections in real sales conversations, then decide who should repair the source of the doubt.
+
+## Ask where the objection was learned
+
+Sales teams do not need to interrogate buyers. They do need better listening prompts.
+
+When a buyer raises a concern that sounds answer-shaped, useful follow-ups include:
+
+- "Where did that concern come up in your research?"
+- "Did you see that in a comparison, an AI answer, a search result, or a recommendation from someone internally?"
+- "What question were you trying to answer when that became a concern?"
+- "Was the issue that the category felt unclear, the proof felt weak, or the fit felt uncertain?"
+- "What would you need to see publicly before feeling confident taking this further?"
+
+These questions are not tricks. They help separate private hesitation from public-market confusion.
+
+If three qualified buyers arrive with the same misconception after using answer-led research, that is a signal. If one wrong-fit buyer objects because the offer is not what they need, that may be useful disqualification. If an objection appears only after a competitor comparison prompt, product marketing may need to inspect the comparison frame. If buyers repeatedly ask for a proof point the company already has but does not surface clearly, marketing has a routing problem.
+
+The sales call becomes a diagnostic input.
+
+## Do not turn the fix into AI superstition
+
+There is a tempting but weak response to AI-shaped objections: add special AI-facing material and hope the engines change.
+
+That is too narrow.
+
+For Google AI features, the caveat still matters: they rely on core Search ranking and quality systems. It is not accurate to present llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google AI visibility. Across answer-led surfaces more broadly, the more durable task is to improve the public material buyers and systems can both use.
+
+That may mean clearer service pages. Stronger comparison criteria. Better proof routes. More explicit fit boundaries. An FAQ that answers the objection directly. A case pattern that shows the problem in context. A sales enablement note that helps reps diagnose whether the objection is true, stale, competitor-shaped, missing-proof, or wrong-fit.
+
+The fix should match the diagnosis.
+
+If the public market is teaching buyers the wrong thing, repair the public market. If the sales team cannot explain the distinction, repair enablement. If the objection is true, repair the offer. If the buyer is wrong-fit, repair qualification.
+
+## The leadership test
+
+A practical leadership review can start with five questions:
+
+1. Which objections have appeared in more than one qualified sales conversation after answer-led research?
+2. Which of those objections can change revenue: budget, urgency, trust, competitor choice, price, or next step?
+3. Which objections are true, stale, competitor-shaped, missing-proof, or wrong-fit?
+4. Which public sources or missing sources make the objection easier to believe?
+5. Who owns the repair, and by when will sales know the answer changed?
+
+That last question matters.
+
+If marketing updates a page but sales does not know how to use it, the loop is incomplete. If sales logs objections but marketing never sees the pattern, the loop is incomplete. If leadership demands better AI visibility but never decides which objections are commercially material, the loop is incomplete.
+
+GEO should connect the loop.
+
+## Turn anecdotes into a feedback system
+
+A single buyer objection is not a strategy. A repeated objection with a source pattern, commercial risk, truth classification, and owner is different.
+
+That is market intelligence.
+
+Answer engines do not only send traffic, citations, or vendor names. They can shape the doubts buyers carry into the room. Sometimes those doubts reveal a real weakness. Sometimes they expose an old story still circulating. Sometimes they show that competitors have defined the comparison before you did. Sometimes they prove that your strongest evidence is not visible enough.
+
+CMOs, Marketing Directors, and founders should not treat those moments as random anecdotes.
+
+Capture the objection. Ask where it was learned. Classify the risk. Find the public source gap. Assign the owner. Repair the page, proof, comparison, FAQ, offer, product issue, or sales route. Then listen for whether the objection changes.
+
+That is the sales-to-GEO feedback loop.
+
+In answer-led discovery, the buyer may arrive with an objection before they arrive with intent. The companies that learn from those objections fastest will not just defend the call better. They will teach the market better before the next buyer asks.


### PR DESCRIPTION
## Summary
- Adds Day 71 Build in Public post: "Turn AI-Generated Objections Into Market Intelligence"
- Publishes the approved final artifact unchanged at `docs/blog/posts/daily-blog-day-71.md`
- Keeps PR payload to one intended blog post only

## Verification
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-71.md` — passed
- `python3 -m py_compile tools/validate_frontmatter.py tools/blog_hook.py tools/build_log.py` — passed
- Targeted content sanity check for date, H1/title, excerpt marker, sales-to-GEO thesis, and Google caveat — passed
- `git diff --cached --stat` / `git diff --cached --name-only` before commit — confirmed only `docs/blog/posts/daily-blog-day-71.md`
- `mkdocs build --strict` — failed due existing MkDocs/RoamLinks/nav warnings; no fatal content error found
- `mkdocs build` — passed

## Payload
- `docs/blog/posts/daily-blog-day-71.md`

## Post metadata
- Title: `Day 71: Turn AI-Generated Objections Into Market Intelligence`
- Date: `2026-06-30`
- Slug: `day-71-turn-ai-generated-objections-into-market-intelligence`
