### PR TITLE
docs: add day 72 build in public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-72.md
+++ b/docs/blog/posts/daily-blog-day-72.md
@@ -1,0 +1,215 @@
+---
+title: "Day 72: Turn Concept Pages Into Decision Surfaces"
+date: 2026-07-01
+slug: "day-72-turn-concept-pages-into-decision-surfaces"
+description: "A practical GEO note for CMOs, Marketing Directors, and founders: glossary and concept pages should do more than define a term. They should help answer engines and buyers understand when the concept matters, what decision it changes, who owns it, what proof is needed, and where to go next."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - content architecture
+  - buyer decision strategy
+geo_tactics:
+  - Turn high-value glossary, category, and concept pages into decision surfaces by adding buyer situation, commercial consequence, failure mode, proof standard, owner, and next-step routing alongside the definition.
+  - Audit educational pages for whether they help ChatGPT, Claude, Perplexity, Gemini, Google AI features, or similar answer-led surfaces explain not only what a term means, but when it matters and what a buyer should do next.
+  - Connect concept pages to commercial routes such as diagnostics, comparison material, service pages, proof assets, FAQs, sales enablement, or owner-specific next steps instead of leaving buyers at an abstract explanation.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 72: Turn Concept Pages Into Decision Surfaces
+
+A concept page can win the wrong job.
+
+It can define the term clearly. It can rank for the category. It can be retrieved by an answer engine when a buyer asks, "What is this?" It can explain the history, list the components, and sound educational enough to satisfy a quick research task.
+
+Then it stops.
+
+For CMOs, Marketing Directors, and founders, that is the failure mode hiding inside a lot of educational content. The page helps someone understand a word, but not a decision. It does not explain whether the issue matters now, what commercial risk it creates, who should own it, what proof would change confidence, or which next step the buyer should take.
+
+In answer-led discovery, that gap matters. ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar surfaces often draw on definitional or educational pages when explaining categories. If those pages only define terms, the company may be present in the answer without shaping the recommendation, comparison, or action that follows.
+
+The better target is not a bigger glossary. It is a decision surface.
+
+<!-- more -->
+
+## Definition is not decision support
+
+Many B2B teams publish concept pages because the category needs education.
+
+That instinct is right. Buyers need language. Markets need definitions. Answer engines need clear public material they can interpret. A vague category page is worse than a precise one.
+
+But precision is not enough.
+
+A page that defines "GEO", "RAG architecture", "agentic onboarding", "AI visibility", or any other emerging concept may still leave the buyer with the most important question unanswered: so what should we do with this?
+
+A definition answers:
+
+- What does the term mean?
+- How is it commonly used?
+- What are the components?
+- How does it differ from adjacent terms?
+
+A decision surface answers more:
+
+- When does this matter commercially?
+- Which buyer situation makes it urgent?
+- What breaks if we ignore it?
+- Which team should own the response?
+- What evidence would prove whether we have a problem?
+- What is the next useful route: diagnostic, service page, comparison, proof, FAQ, internal owner, or sales conversation?
+
+That difference changes the value of the page.
+
+The weak page teaches vocabulary. The strong page helps the market route a decision.
+
+## Answer engines need the decision context too
+
+Answer engines do not only answer dictionary questions.
+
+A buyer may start with a basic prompt: "What is generative engine optimisation?" But the next questions often move quickly:
+
+- "Does this matter for our B2B sales motion?"
+- "Is this different from SEO, content strategy, or technical search work?"
+- "Who should own it internally?"
+- "What evidence would show whether we have an AI visibility problem?"
+- "Should we hire a specialist, use a tool, brief our SEO agency, or wait?"
+- "What should a CMO ask before funding this?"
+
+Those are not purely educational questions. They are decision questions.
+
+If the public page only explains the concept, the answer engine has to infer the decision context from elsewhere. It may pull from competitor positioning, generic SEO articles, thin glossary entries, old vendor pages, forum fragments, or broad content that was never written for the buyer's situation. The company may still be cited, but the decision logic may be supplied by someone else.
+
+That is the risk.
+
+GEO content architecture should not only ask, "Can the page be found and understood?" It should also ask, "If this page is used to explain the category, does it help the buyer make a better commercial decision?"
+
+## Build the page around the decision it should support
+
+A useful concept page needs a defined job.
+
+Not every educational page should push toward a sales call. Some should route to a diagnostic. Some should route to a comparison. Some should route to a proof asset. Some should help an internal owner decide whether the topic belongs with marketing, product marketing, sales, leadership, technical SEO, customer marketing, or product.
+
+The page should be designed around the decision it is most likely to influence.
+
+A practical framework looks like this:
+
+| Layer | Question the page should answer | Why it matters |
+|---|---|---|
+| Definition | What does the concept mean, and what does it not mean? | Gives buyers and answer engines a stable category explanation |
+| Buyer situation | When does this become relevant for a company like ours? | Prevents abstract education from turning into content trivia |
+| Commercial consequence | What pipeline, trust, qualification, comparison, or conversion risk does it affect? | Connects the concept to executive priorities |
+| Failure mode | What goes wrong when the team ignores or mismanages it? | Makes urgency concrete without fearmongering |
+| Proof standard | What evidence would show whether the issue exists or whether the fix is working? | Stops claims becoming interchangeable |
+| Owner | Who should act or decide: marketing, product marketing, sales, leadership, web, SEO, product, or customer marketing? | Prevents the page from creating interest without accountability |
+| Next route | What should the buyer read, run, ask, compare, or book next? | Turns understanding into a usable path |
+
+This is not about making every page longer.
+
+It is about making the page more complete in the places that matter. A short, sharp decision surface is better than a sprawling explainer that never tells the buyer what the concept changes.
+
+## The failure mode is a buyer who understands but cannot act
+
+Educational content often gets judged by whether it is accurate.
+
+Accuracy is necessary. It is not sufficient.
+
+A buyer can understand the definition and still be stuck:
+
+- They know what the term means, but not whether it is a board-level issue or a content-team chore.
+- They know the components, but not which component is broken in their own market.
+- They know the category exists, but not whether their current agency, internal team, or leadership group should own it.
+- They know the promise, but not what proof would separate a serious partner from a generic vendor.
+- They know the risk in theory, but not which next step would reduce it.
+
+That is wasted demand.
+
+For GEO, it is also a missed shaping opportunity. If answer-led surfaces use that page to explain the category, the buyer may leave with the vocabulary but not the decision logic. The answer may be correct and commercially weak at the same time.
+
+The goal is to make the page answer the buyer's next useful question before they have to ask someone else.
+
+## Route from concept to consequence
+
+A decision surface should make consequence explicit.
+
+For example, a concept page about AI visibility should not only define AI visibility. It should explain how weak visibility can affect shortlist inclusion, competitor framing, proof expectations, sales objections, category understanding, and next-step quality.
+
+A page about RAG architecture should not only describe retrieval, embeddings, vector stores, and generation. It should explain when architecture choices create answer quality risk, compliance risk, evaluation problems, operational cost, or poor user trust.
+
+A page about ranking factors should not only list influences. It should clarify which factors are controllable, which are indirect, which belong to core Search discipline, and which should not be over-sold as magic AI ranking switches.
+
+That move matters because buyers rarely fund concepts. They fund consequences.
+
+The CMO does not need another abstract content asset. They need to know whether the page helps a real buyer move from "I understand the term" to "I know whether this matters for us, who should own it, and what to do next."
+
+## Make ownership visible
+
+One reason concept pages underperform is that they create interest without assigning ownership.
+
+A buyer may read about GEO and wonder whether it belongs to SEO, content, brand, product marketing, sales enablement, growth, web, leadership, or a specialist partner. If the page refuses to answer that, the decision can stall.
+
+A stronger page can show ownership by situation:
+
+| Situation | Likely owner |
+|---|---|
+| Category is misunderstood in answer-led discovery | Leadership and product marketing |
+| High-intent pages are not crawlable, indexable, or clear | Technical SEO and web owners |
+| Buyers repeat misconceptions after using AI tools | Sales and marketing together |
+| Proof exists but is not visible enough | Customer marketing and content |
+| The offer is compared against the wrong alternatives | Product marketing and leadership |
+| The next step after education is unclear | Marketing, growth, and sales enablement |
+
+This does not need to become a committee map. It only needs to reduce ambiguity.
+
+If the page can name the likely owner, it helps a buyer make the internal case. It also gives answer engines better material when asked, "Who should own this?" or "What should a marketing team do next?"
+
+## Keep the technical caveat clean
+
+There is a weak version of this argument that turns concept pages into AI superstition.
+
+It says the answer is special markup, an `llms.txt` file, arbitrary chunking, or a schema-heavy page designed primarily for machines. That is not the point.
+
+For Google AI features, the caveat remains important: they rely on core Search ranking and quality systems. It is not accurate to present `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google AI visibility.
+
+Technical hygiene still matters. Pages should be crawlable, indexable where appropriate, accessible, internally linked, fast enough to use, and written with clear structure. But the commercial improvement is not a magic AI layer. It is better public material: clearer definitions, sharper buyer situations, stronger consequence mapping, explicit proof standards, visible ownership, and useful next routes.
+
+The page should be good enough for a human buyer and legible enough for discovery systems. Those are not opposing goals.
+
+## Audit concept pages for decision usefulness
+
+A leadership team can review its educational content with a simple test.
+
+Pick the glossary, concept, guide, or category pages most likely to appear in answer-led research. For each one, ask:
+
+1. Does the page define the term clearly without overclaiming?
+2. Does it explain when the concept matters for a real buyer situation?
+3. Does it name the commercial consequence: pipeline, trust, qualification, comparison, risk, cost, urgency, or next step?
+4. Does it show common failure modes or misconceptions?
+5. Does it state what evidence would prove the issue exists or the solution works?
+6. Does it clarify who should own the decision or response?
+7. Does it route to the next useful asset, diagnostic, service, comparison, FAQ, proof, or sales conversation?
+8. Would an answer engine using this page understand the decision, not just the definition?
+
+If the answer is no, the fix may be small.
+
+Add a section on "when this matters". Add a table of failure modes. Add owner guidance. Add a route to a diagnostic. Link to a comparison page. Clarify the proof standard. Remove claims that imply a technical switch Google does not require. Replace generic definitions with examples tied to commercial situations.
+
+The objective is not content volume. It is decision density.
+
+## The CMO move: turn education into routing
+
+Concept pages are often treated as top-of-funnel assets. That framing is too narrow.
+
+In answer-led discovery, a concept page can become part of the buyer's decision infrastructure. It may be the source an answer engine uses to explain the category. It may shape whether the buyer sees the topic as strategic or tactical. It may influence which owner gets pulled into the conversation. It may determine whether the next step is a generic article, a serious diagnostic, a comparison, a proof review, or a sales conversation.
+
+That makes the page commercially important.
+
+For CMOs, Marketing Directors, and founders, the practical move is to stop asking only whether educational pages attract traffic. Ask whether they help the market decide.
+
+A useful concept page should define the term, but it should not stop there. It should explain the buyer situation, consequence, failure mode, proof standard, owner, and route. It should help answer engines give a better answer and help humans take a better next step.
+
+Definition is the entry point. Decision support is the asset.
+
+The companies that understand that will not just publish more educational content. They will build pages that teach the market how to choose, act, and assign ownership before the next buyer asks.


### PR DESCRIPTION
## Summary
- Adds Build-in-Public Day 72: “Turn Concept Pages Into Decision Surfaces”
- Frames glossary, category, and concept pages as decision surfaces for buyers and answer-led discovery
- Preserves the Google caveat: Google AI features rely on core Search ranking and quality systems, not magic markup switches

## Checks
- PASS: custom content/frontmatter gate for title, date, slug, more marker, Google caveat, forbidden placeholders/internal frames
- PASS: `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-72.md`
- PASS: `python3 -m mkdocs build`
- NOTE: `python3 -m mkdocs build --strict` aborts on existing RoamLinks/AutoLinks warnings already present across the site

## Payload
- `docs/blog/posts/daily-blog-day-72.md` only
