### PR TITLE
docs: add day 73 build in public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-73.md
+++ b/docs/blog/posts/daily-blog-day-73.md
@@ -1,0 +1,176 @@
+---
+title: "Day 73: Write for the Buyer's Internal Memo"
+date: 2026-07-02
+slug: "day-73-write-for-buyers-internal-memo"
+description: "A practical GEO note for CMOs, Marketing Directors, and founders: answer-led discovery does not end with a citation, click, or concept page. Public content should give a serious buyer the language to explain the problem, decision, evidence, trade-offs, owner, and next step inside the organisation."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - buyer enablement
+  - internal decision-making
+geo_tactics:
+  - Audit high-intent public pages for whether they help a buyer turn an AI answer into an internal recommendation, not only whether they explain the category or win a citation.
+  - "Add memo-ready fields to strategic content: buyer question, proposed decision, commercial consequence, evidence and proof limits, trade-off, stakeholder or owner, risk of inaction, and next step."
+  - Give answer engines reusable, defensible language that a champion can forward to a founder, CFO, board adviser, sales leader, product owner, or marketing leader without overclaiming certainty.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 73: Write for the Buyer's Internal Memo
+
+A buyer can discover you through an AI answer and still fail to move the decision forward.
+
+That failure is not always caused by a weak landing page, a missing comparison, or a lack of proof. Sometimes the interested person simply cannot explain the recommendation internally. They have a useful answer in front of them, but not a defensible paragraph for the founder, CFO, board adviser, sales leader, product owner, or marketing director who now has to care.
+
+For CMOs, Marketing Directors, and founders, this is a practical GEO problem. Answer engines compress public material into the language buyers reuse. ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar surfaces can shape the summary someone forwards, even when that person does not click every source. If your public material does not equip that next hop, you may win visibility without helping the champion win agreement.
+
+A useful GEO asset should therefore be written for three readers: the answer engine, the buyer in the moment, and the buyer's internal memo.
+
+<!-- more -->
+
+## The next hop is where momentum often dies
+
+Most AI visibility work still over-focuses on the first moment of discovery.
+
+The questions sound like this:
+
+- Did the answer engine mention us?
+- Were we cited?
+- Did the buyer click?
+- Did the page explain the category clearly?
+- Did the comparison or objection handling look stronger than the competitor's?
+
+Those questions matter. But they do not cover the full buying path.
+
+A serious buyer rarely acts alone after one answer. They copy a paragraph into Slack. They summarise a recommendation for a founder. They ask the CFO whether the budget is plausible. They brief a product owner on why the market expectation is changing. They ask sales whether the issue is already showing up in calls. They turn a public explanation into an internal case for priority.
+
+That translation step is fragile.
+
+If the buyer has to invent the business case from scratch, momentum slows. If the answer gives them a vendor name but not a reason to act, the conversation becomes optional. If the page explains the topic but not the decision, the champion has interest without language.
+
+The commercial failure is not only "we did not get the click". It is "the buyer could not carry the argument into the room where the decision happens".
+
+## Answer engines compress your material into reusable language
+
+GEO is not only about being present in an answer. It is about what the answer can safely say because your public material made it clear.
+
+When answer-led discovery works well, public content gives the model enough structure to explain:
+
+- what category you belong to;
+- which buyer situation makes the issue relevant;
+- what commercial consequence is at stake;
+- where the evidence is strong, weak, or conditional;
+- which constraints or fit boundaries matter;
+- what trade-off the buyer should understand;
+- who should own the next conversation;
+- what a reasonable next step looks like.
+
+That structure matters because AI answers often become internal artefacts. A buyer may not forward your page. They may forward a model's synthesis of several pages. They may paste a comparison into a decision document. They may ask for a board-ready explanation of why the issue matters now.
+
+If your content only says "we help with AI visibility" or "this is what GEO means", the model has to fill in the commercial logic from elsewhere. It may borrow generic SEO framing. It may lean on competitor language. It may make the recommendation sound like a content experiment rather than a revenue, trust, positioning, or sales-efficiency issue.
+
+Memo-ready content reduces that risk. It gives the answer engine and the buyer better raw material for the internal explanation.
+
+## What a memo-ready GEO asset includes
+
+Memo-readiness does not mean turning every page into a long white paper. It means making the decision logic explicit enough that a buyer can reuse it.
+
+A simple audit table helps.
+
+| Memo field | Question your public content should answer | Why it matters |
+|---|---|---|
+| Buyer question | What is the serious question the buyer is trying to resolve? | Keeps the page anchored in a real commercial decision, not a content theme |
+| Proposed decision | What should the organisation consider doing, changing, funding, testing, or ruling out? | Gives the champion a recommendation shape, not just an explanation |
+| Commercial consequence | What pipeline, trust, qualification, positioning, conversion, or competitive risk is affected? | Connects AI visibility work to executive priorities |
+| Evidence and proof limit | What evidence supports the claim, and where should confidence be bounded? | Makes the memo defensible instead of breathless |
+| Trade-off | What cost, constraint, implementation burden, or strategic choice should be acknowledged? | Helps the buyer sound credible with sceptical stakeholders |
+| Owner or stakeholder | Who should care next: marketing, product marketing, sales, leadership, web, SEO, product, customer marketing, or finance? | Prevents interest from becoming orphaned work |
+| Risk of inaction | What happens if the team waits, ignores the issue, or lets the market define it? | Gives urgency without manufacturing panic |
+| Next step | What should the buyer read, ask, run, compare, brief, or book next? | Turns a good answer into forward motion |
+
+This framework is especially useful for emerging categories, technical services, and strategic marketing investments where the buyer may believe the issue matters but still need help explaining why it deserves attention now.
+
+The test is simple: if a qualified buyer copied the strongest paragraph from your page into an internal note, would it help them make a calm, credible case?
+
+If not, the content is not yet doing the whole job.
+
+## The memo should not sound like a sales pitch
+
+There is a trap here.
+
+Writing for the internal memo does not mean stuffing public pages with boardroom theatre, fake certainty, or inflated ROI claims. The buyer's internal memo has to survive contact with sceptical people. It has to be clear enough for a founder, practical enough for a marketing director, and bounded enough for a CFO or sales leader to take seriously.
+
+That means the content should include proof limits as well as proof points.
+
+For example:
+
+- Do not say that AI visibility automatically creates pipeline. Explain which answer moments can influence qualified demand, comparison framing, sales objections, or trust before a buyer reaches the site.
+- Do not imply that one technical switch controls Google AI visibility. Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility.
+- Do not pretend every company needs the same GEO programme. Explain fit boundaries: market complexity, sales cycle, category maturity, existing search demand, buyer education needs, and competitive answer quality.
+- Do not hide the trade-off. If the work requires subject-matter access, evidence gathering, web architecture, sales feedback, or leadership alignment, say so.
+
+This is not weaker positioning. It is stronger commercial language.
+
+A champion cannot forward a page that sounds like it will collapse under scrutiny. They need material that helps them say, "Here is the issue, here is why it matters, here is what we know, here is what we do not know yet, and here is the sensible next move."
+
+## Different stakeholders need different memo language
+
+The same AI answer may travel through several internal audiences.
+
+A founder may need to know whether the market is starting to describe the category without them. A CMO may need to know which buyer questions are being answered by competitors. A sales leader may need to know why prospects arrive with the wrong comparison in mind. A product owner may need to know whether public positioning matches the actual product boundary. A CFO may need to know why this is not just another content request.
+
+Public content cannot write every internal memo. But it can provide the ingredients each stakeholder needs.
+
+That changes the way a page is planned.
+
+Instead of asking only, "What keyword, prompt, or topic should this page target?", ask:
+
+- What sentence would a champion forward to leadership?
+- What objection would a finance or sales stakeholder raise?
+- What evidence would make the recommendation less speculative?
+- What boundary would stop the recommendation from sounding universal?
+- What next step is small enough to be approved?
+
+Those questions sharpen the page because they force the content to serve the real buying environment. The goal is not to make the buyer do your sales work. The goal is to remove avoidable translation burden from a serious buyer who already sees enough value to continue.
+
+## Memo-readiness is a useful GEO audit lens
+
+A practical GEO audit should include a memo-readiness pass.
+
+Take the pages most likely to be used in answer-led discovery: category pages, concept pages, comparison pages, service pages, objection-handling content, diagnostic pages, proof assets, and FAQs. For each one, ask whether it gives answer engines and buyers enough material to construct a responsible internal recommendation.
+
+The audit can be blunt:
+
+- Is the buyer question explicit?
+- Is the proposed decision clear?
+- Is the commercial consequence named?
+- Is the evidence specific enough to reuse?
+- Are proof limits or uncertainty handled honestly?
+- Are fit boundaries visible?
+- Is the trade-off acknowledged?
+- Is the owner or stakeholder implied or named?
+- Is the risk of inaction concrete?
+- Is the next step realistic?
+
+A page does not need to answer every field with the same weight. But if none of these fields are present, the page is probably optimised for explanation rather than internal movement.
+
+That is the distinction.
+
+A page can be accurate, visible, and well-written, yet still leave the champion unable to carry the decision forward. Memo-readiness asks whether the public asset can survive the next hop.
+
+## The better question
+
+The better question is not only, "Will an answer engine understand this page?"
+
+It is also, "If an answer engine uses this page to help a buyer explain the issue internally, will the buyer sound credible?"
+
+That standard changes the work. It rewards clear category roles, commercial consequences, bounded evidence, fit constraints, trade-offs, stakeholder language, and next steps. It discourages vague authority claims and technical switches presented as magic levers.
+
+For GEO teams, this is a useful shift. The goal is not just to be mentioned by the machine or visited by the buyer. The goal is to help a serious buyer carry a better explanation into the organisation.
+
+Because in many B2B decisions, the answer that matters most is not the one the model gives the buyer.
+
+It is the one the buyer can defend to everyone else.


### PR DESCRIPTION
## Summary
- Adds Day 73 Build-in-Public post: `Day 73: Write for the Buyer's Internal Memo`
- Frames memo-readiness as a GEO audit requirement for answer-led discovery
- Preserves the Google caveat: no `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data switch for Google AI visibility

## Checks
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-73.md` — passed
- Custom content assertions for title/date/slug, Google caveat, and placeholder markers — passed
- `mkdocs build --strict` — failed on existing site-wide warnings from RoamLinks/AutoLinks/nav warnings
- `mkdocs build` — passed

## Payload
- `docs/blog/posts/daily-blog-day-73.md` only
