### PR TITLE
docs: add daily blog day 74

### DIFF
--- a/docs/blog/posts/daily-blog-day-74.md
+++ b/docs/blog/posts/daily-blog-day-74.md
@@ -1,0 +1,176 @@
+---
+title: "Day 74: Treat AI Answers as Market Language, Not Just Visibility Reports"
+date: 2026-07-03
+slug: "day-74-treat-ai-answers-as-market-language-not-just-visibility-reports"
+description: "A practical GEO field note for CMOs, Marketing Directors, and founders: answer engines do more than mention, cite, or omit a company. Their wording shows how the market is being taught to describe the category, compare competitors, compress buyer problems, and frame the commercial reason to care."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - market intelligence
+  - positioning
+geo_tactics:
+  - Capture the exact wording used by ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces for your category, competitors, buyer problems, caveats, and recommended next steps.
+  - Classify repeated answer language by category label, problem frame, competitor reason, commercial consequence, missing phrase, objection, and stakeholder vocabulary before deciding which page or asset to change.
+  - Compare answer-language patterns against sales calls, win/loss notes, customer vocabulary, analyst language, and internal positioning so content changes are based on market signal rather than one prompt screenshot.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 74: Treat AI Answers as Market Language, Not Just Visibility Reports
+
+A company can stare at AI visibility reports and still miss the useful signal.
+
+The common question is simple: did ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led surface mention us? Were we cited? Did a competitor appear above us? Did the answer point to a source we control?
+
+Those are valid questions. But they are not enough for a CMO, Marketing Director, or founder trying to understand how a market is being shaped before a prospect reaches sales. The wording inside the answer is often more valuable than the presence check. It shows which category labels the market may inherit, which buyer problems are being compressed, which competitors are framed as credible, and which phrases could become the internal language of demand.
+
+The answer is not only a visibility event. It is market language in motion.
+
+<!-- more -->
+
+## The mention count is the shallowest read
+
+Most teams begin GEO work by treating answer engines like a new reporting surface.
+
+They ask:
+
+- Are we visible?
+- Are we cited?
+- Which competitors appear?
+- Which pages are used?
+- Did the answer get the facts right?
+
+That work matters. A company cannot manage answer-led discovery if it has no idea whether it appears, whether its facts are being represented correctly, or whether competitors dominate the default explanation.
+
+But the first report often flattens the signal into a scoreboard. A mention becomes good. An omission becomes bad. A citation becomes a win. A competitor appearing becomes a threat.
+
+That is too blunt.
+
+An answer can mention you while teaching the market the wrong category. It can omit you while revealing a phrase your buyers are starting to use. It can cite a competitor while exposing the criteria answer engines think matter. It can describe the problem in a way that makes your current homepage sound adjacent rather than central.
+
+If the team only asks whether it appeared, it loses the positioning intelligence sitting in plain text.
+
+## Answer language is a form of market research
+
+Answer engines are not neutral dashboards. They are synthesis systems. They compress public material, query intent, source patterns, model behaviour, and category language into a paragraph that a buyer may treat as a starting point.
+
+That paragraph can reveal how the market is being explained.
+
+For leadership, the useful question is not only, "Did the model know about us?" It is:
+
+- What words did it choose for the category?
+- Which business problem did it think the buyer was trying to solve?
+- Which companies did it frame as credible, and why?
+- Which caveats did it repeat?
+- Which buyer roles did it name?
+- Which outcomes did it make sound commercially important?
+- Which phrases appeared across multiple answer engines or prompts?
+- Which words were missing, even though sales and customers use them constantly?
+
+That is market intelligence.
+
+It is not perfect intelligence. One prompt screenshot is not a strategy. A single answer can be noisy, stale, overconfident, or shaped by the exact wording of the question. But repeated answer language across prompts, surfaces, and buyer scenarios is worth studying because it can show what the public corpus makes easy for the model to say.
+
+If the model repeatedly describes the category as a technical SEO problem, the market may not hear the positioning story as a revenue, trust, or sales-efficiency issue.
+
+If it repeatedly names competitors because they are clearer about buyer situations, the problem may not be citation scarcity. It may be category clarity.
+
+If it repeatedly uses a phrase your sales team hates, the answer is telling you which language may enter the buyer's internal conversation before your team gets a chance to correct it.
+
+## What to capture before changing anything
+
+The temptation is to move straight from answer output to content edits.
+
+The model did not mention the company, so rewrite the page. The competitor appeared, so publish a comparison. The answer used an awkward label, so change the headline. The citation went to the wrong source, so add more structured data.
+
+That is premature.
+
+Before changing pages, capture the language itself. Not just the URL. Not just the citation. Not just the ranking order. The wording.
+
+A useful answer-language review should include:
+
+- Category labels: what the answer calls the space, service, product, methodology, or problem.
+- Problem framing: which pain it thinks the buyer is trying to solve.
+- Competitor reasons: why named companies are treated as credible, distinct, risky, or relevant.
+- Commercial consequences: whether the answer connects the issue to revenue, pipeline, conversion, trust, efficiency, risk, or strategic timing.
+- Caveats and constraints: what the answer says is uncertain, conditional, expensive, difficult, overhyped, or unsuitable.
+- Missing phrases: language customers, sales teams, analysts, or founders use that the answer does not surface.
+- Stakeholder vocabulary: whether the answer speaks to CMOs, founders, sales leaders, product owners, technical teams, procurement, or a generic "business" reader.
+- Recommended next steps: whether it routes the buyer toward diagnosis, comparison, experimentation, content, technical work, governance, or waiting.
+
+This is not a vanity exercise. It changes what the team does next.
+
+A page rewrite is different if the problem is category confusion. A comparison brief is different if the answer engine already knows the competitors but cannot explain the criteria. A sales enablement update is different if the model is popularising a phrase that prospects now repeat on calls. A positioning review is different if the answer language consistently makes the company sound like a tool vendor when the offer is strategic advisory.
+
+## Repetition matters more than the dramatic screenshot
+
+One of the fastest ways to waste budget is to overreact to a single strange answer.
+
+Answer-led surfaces vary. Prompt wording matters. Sources update. Model behaviour shifts. Some answers are specific and useful; others are generic or wrong. Treating one screenshot as a board-level truth creates the same problem as treating one sales call as a full market study.
+
+The better practice is to look for repeated language patterns.
+
+Run the same buyer scenario across several answer engines. Vary the prompt by role, urgency, category maturity, company type, and decision stage. Capture the exact wording. Then classify what repeats.
+
+If one answer uses an odd phrase once, note it and move on.
+
+If five surfaces repeatedly describe the category as "AI SEO software" when the buyer problem is actually strategic visibility, content evidence, and answer-market positioning, that is a positioning signal.
+
+If several answers keep naming competitors because they have clearer public explanations of a use case, that is a content architecture signal.
+
+If the answer engines consistently omit the phrase your best customers use when describing the pain, that is a vocabulary signal.
+
+If the answers keep warning about measurement reliability, implementation cost, or unclear ownership, that may be an objection signal. But it should still be handled as language intelligence first, not an automatic sales-script rewrite.
+
+The discipline is simple: do not confuse volatility with meaning. Repeated phrasing matters. Isolated phrasing needs context.
+
+## The commercial use is diagnosis, not instant optimisation
+
+Answer-language intelligence should change action, but only after diagnosis.
+
+The point is not to chase every answer engine sentence. The point is to understand what the market may be learning from public information before a human conversation begins.
+
+For a CMO, this can shape content briefs. If answer engines consistently explain the category in low-value terms, the next content asset should not merely target a keyword. It should make the commercial consequence legible.
+
+For a founder, it can sharpen positioning. If models and competitors keep using a broader category label that hides the company's real difference, the problem may be the public narrative, not the answer engine.
+
+For a Marketing Director, it can improve comparison pages. If answer engines name competitors without explaining why a buyer should choose one approach over another, the gap is not only visibility. It is criteria.
+
+For sales leadership, it can inform talk tracks. If prospects arrive using language that clearly came from AI-assisted research, the team needs to know which phrases help, which confuse, and which create false expectations.
+
+For product marketing, it can expose missing buyer vocabulary. If the public site uses internal terms while answer engines and customers use plainer commercial language, the site may be technically accurate but market-invisible in the moments that matter.
+
+None of this requires treating answer engines as oracles. It requires treating them as observable surfaces where market language is being compressed and redistributed.
+
+## What we are building toward
+
+Inside our own work, this is why answer tracking cannot stop at presence, citations, and source paths.
+
+Those fields are useful. They tell us where a company appears, which public assets may be influencing synthesis, and whether facts are being represented with enough stability to trust the trend.
+
+But the strategic layer is the language review: what the answer actually says, which labels it repeats, how it frames the buyer's problem, where competitors gain credibility, and which phrases should influence positioning, content, and sales enablement.
+
+That is the difference between a report that says "you appeared in three answers" and a diagnostic that says "the market is being taught to see this category as a tooling problem, while your commercial value depends on making it a board-level visibility and demand-quality problem".
+
+The first is a metric. The second can change strategy.
+
+## A better leadership question
+
+The next time an AI visibility report lands on the table, do not start with the screenshot.
+
+Start with the language.
+
+Ask what the answer engines are teaching the market to call the problem. Ask which competitors are being made credible by the explanation. Ask which buyer pain is being simplified, exaggerated, or missed. Ask whether the wording matches how your best customers describe urgency. Ask which phrases might show up in the next sales call, board note, or founder-to-founder recommendation.
+
+Then decide what to change.
+
+Sometimes the answer will point to a page update. Sometimes it will point to a comparison gap, a positioning issue, a sales enablement fix, a proof weakness, or a category vocabulary problem. Sometimes it will tell you not to touch the site yet because the signal is too inconsistent.
+
+That is the real value of answer-language review.
+
+Not just: did we appear?
+
+What language is shaping the buyer's mental model before we ever enter the room?


### PR DESCRIPTION
## Summary
- Adds the Day 74 Build in Public post: `docs/blog/posts/daily-blog-day-74.md`
- Uses the approved final artifact unchanged
- Payload is intentionally limited to one blog post file

## Checks
- `python3` YAML/frontmatter validation: passed
- `python3 -m mkdocs build --strict`: failed only because of existing site-wide warnings/RoamLinks/nav warnings
- `python3 -m mkdocs build`: passed
- Payload guard: `git diff --name-status origin/main...HEAD` shows only `A docs/blog/posts/daily-blog-day-74.md`
