### PR TITLE
docs: add daily blog day 75

### DIFF
--- a/docs/blog/posts/daily-blog-day-75.md
+++ b/docs/blog/posts/daily-blog-day-75.md
@@ -1,0 +1,163 @@
+---
+title: "Day 75: Version the Baseline Before You Trust the Trend"
+date: 2026-07-04
+slug: "day-75-version-the-baseline-before-you-trust-the-trend"
+description: "A practical GEO governance note for CMOs, Marketing Directors, and founders: AI visibility trends are not decision-grade unless the measurement baseline is versioned. Prompt sets, model rosters, model versions, geography, scoring methods, and overlap windows must be comparable before leadership treats movement as market signal."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - measurement governance
+  - Prompt Share of Voice
+  - answer engines
+geo_tactics:
+  - "Version the measurement baseline behind every AI visibility report: prompt set, buyer scenarios, model roster, model versions, surfaces, geography, language, scoring rules, and source or citation capture."
+  - Run overlap windows when adding, replacing, or retiring answer engines or model versions so Prompt Share of Voice and citation movement can be separated from tooling churn.
+  - Label visibility changes as like-for-like movement, baseline-change movement, answer-engine drift, competitor momentum, or inconclusive until repeated runs support the interpretation.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 75: Version the Baseline Before You Trust the Trend
+
+A rising AI visibility chart can be true and still be useless.
+
+That sounds harsh, but it is one of the most important governance problems in Generative Engine Optimization. A CMO, Marketing Director, or founder may look at a report that says Prompt Share of Voice improved, citations increased, or competitor presence fell across ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces. The line moves. The dashboard looks cleaner. The conclusion feels obvious.
+
+But if the baseline changed underneath the report, the trend may not be market movement at all.
+
+It may be a new prompt set. A different model roster. A changed model version. A retired surface. A new geography. A scoring adjustment. A citation-capture change. A missing overlap window. Or simply the normal noise of repeated prompt runs being presented with too much confidence.
+
+Before leadership trusts the trendline, the baseline needs a version number.
+
+<!-- more -->
+
+## Trendlines lie when the measurement setup moves
+
+AI visibility measurement is not a static search ranking report with one stable list of pages and positions. It is a repeated observation of synthesis systems that change often, answer differently by prompt, and draw from shifting public evidence.
+
+That does not make measurement pointless. It makes governance essential.
+
+A company might see visibility rise because its public material became clearer, competitors lost answer coverage, or buyers are asking more commercially specific questions. Those are useful signals. They can justify content investment, comparison work, sales enablement, technical cleanup, or sharper positioning.
+
+But the same chart can rise for less strategic reasons:
+
+- The prompt set changed from broad category questions to more favourable buyer scenarios.
+- A new model was added that already knew the brand better.
+- An older model version was retired before the team compared old and new behaviour.
+- The report began counting citations differently.
+- The geography or language setting changed.
+- Google AI features were mixed into the same trendline as answer engines with different mechanics.
+- A one-off prompt run was treated as a directional truth.
+
+If those changes are not labelled, the organisation can mistake measurement churn for market progress.
+
+That is expensive. It can make a board report sound stronger than it is. It can make an agency look effective for the wrong reason. It can make a marketing team cut investment just as a competitor is gaining genuine answer coverage. It can make a founder overreact to a dip that came from a model update rather than a demand problem.
+
+The commercial issue is not whether every number is perfect. It is whether the team knows which numbers are comparable.
+
+## A GEO baseline is part of the report, not admin around it
+
+The baseline is the measurement contract behind the chart.
+
+For GEO work, that contract should define what was asked, where it was asked, which systems answered, how results were captured, how they were scored, and what changed since the last reporting period.
+
+That sounds operational, but it is a leadership requirement. Without it, a visibility report cannot answer the question executives actually care about:
+
+"Did our market position change, or did our measurement setup change?"
+
+A useful baseline should version at least seven things.
+
+First, the prompt set. The exact prompts, buyer roles, category terms, comparison questions, urgency levels, and decision stages need to be stable enough for like-for-like comparison. If the team adds more bottom-of-funnel prompts, the report should say so. If the language shifts from "best tools" to "which agency should a CMO choose", that is not a small editorial tweak. It changes the observable market.
+
+Second, the model and surface roster. ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led surfaces do not behave as one channel. They have different retrieval patterns, product interfaces, citation behaviours, and answer styles. Adding or removing one changes the sample.
+
+Third, model versions where they can be identified. A new version can change synthesis, recall, citations, and competitor framing even when the prompt stays identical. Treating that as ordinary market movement is sloppy governance.
+
+Fourth, geography and language. A buyer in London asking an English-language question may see different sources, competitors, and assumptions than a buyer in the US, Germany, or Singapore. If regional settings matter to the business, they belong in the baseline.
+
+Fifth, source and citation capture. A report that tracks mentions only is not comparable with a report that also scores citations, source quality, page ownership, or whether the answer uses a primary source versus an aggregator.
+
+Sixth, scoring method. Prompt Share of Voice, citation share, sentiment, source quality, factual correctness, and competitor inclusion are different measures. If the weighting changes, the trendline needs a new baseline version.
+
+Seventh, the overlap window. When a model or surface changes, keep old and new measurement running side by side for long enough to understand the difference. Otherwise the team cannot tell whether the chart moved because the market moved or because the ruler changed.
+
+## Version changes should be visible to leadership
+
+The practical test is simple: could a leadership team read the report and see, without asking the analyst, whether this month is comparable with last month?
+
+If the answer is no, the report is not ready for budget decisions.
+
+A versioned GEO report does not need to bury executives in technical notes. It needs a small, disciplined change log attached to the trend:
+
+- Baseline v1.3: same prompt set, same surfaces, same scoring, same geography.
+- Baseline v1.4: added a new Claude model version; old and new versions running in overlap for 30 days.
+- Baseline v1.5: expanded buyer prompts to include procurement and board-adviser questions; trendline marked as non-like-for-like from previous prompt set.
+- Baseline v1.6: citation scoring changed to separate owned sources, third-party sources, competitor sources, and uncited mentions.
+
+That kind of note changes the leadership conversation.
+
+Instead of saying, "Visibility is up 18%," the team can say, "Like-for-like visibility is up 6%. The larger movement comes from adding a new model version that appears to cite our category page more often. We are keeping both versions in overlap before treating the wider gain as a trend."
+
+Instead of saying, "Competitor mentions fell," the team can say, "Competitor mentions fell in broad prompts, but stayed flat in high-intent comparison prompts. The baseline is unchanged, so we are treating this as a real difference in buyer-scenario coverage rather than a measurement artefact."
+
+Instead of saying, "Google AI visibility is weak, so add special AI markup," the team can say, "Google's AI features rely on core Search ranking and quality systems. We are not treating llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google AI visibility. The action is to improve the underlying public evidence, page quality, and relevance signals we can actually support."
+
+The point is not to make the report sound cautious for the sake of it. The point is to prevent false certainty from driving expensive work.
+
+## The overlap window is where confidence is earned
+
+One of the most useful habits in AI visibility reporting is also one of the easiest to skip: run the old and new baseline together.
+
+When a model roster changes, do not simply replace the old view and declare the next chart comparable. Keep both views alive for an overlap period. Watch how the new model behaves against the same prompts. Compare citation patterns. Compare competitor inclusion. Compare source quality. Compare factual stability. Compare whether the same buyer scenario produces a different category frame.
+
+That overlap does not eliminate noise, but it creates context.
+
+If the new model consistently mentions a company more often across repeated runs while the old model stays flat, the report can label the movement as model-version sensitivity, not necessarily market gain. If both old and new baselines improve across the same buyer prompts, confidence increases that the public evidence or market position may be changing. If the new surface cites more third-party explainers while the old one relied on owned pages, the action may be source strategy rather than headline rewriting.
+
+This matters because prompt runs are noisy. A single answer can be stale, oddly phrased, uncited, overconfident, or shaped by the exact wording of the question. Repeated observation helps, but repeated observation only works if the team knows what stayed constant.
+
+Versioning is what makes repetition useful.
+
+## What to do before optimising
+
+The tempting move is to see a visibility drop and immediately publish, rewrite, mark up, or chase the missing citation.
+
+Sometimes action is right. But if the baseline changed, optimisation may be premature.
+
+Before changing the site, the content plan, the comparison pages, or the reporting narrative, ask four questions.
+
+1. Is this a like-for-like comparison?
+
+If the prompt set, model roster, model version, surface mix, geography, language, source capture, or scoring method changed, say so before interpreting the movement.
+
+2. Did the same movement repeat?
+
+One run is an observation. Repeated runs across stable prompts and comparable surfaces are closer to a signal. The goal is not fake precision; it is disciplined confidence.
+
+3. Which part of the result moved?
+
+A brand mention, a citation, source quality, competitor framing, factual accuracy, and answer wording are not the same thing. A strong report separates them instead of compressing everything into a single good-or-bad score.
+
+4. What decision will this inform?
+
+A board update, budget shift, content sprint, sales enablement change, technical cleanup, and agency performance review need different confidence thresholds. The higher the consequence, the more important baseline versioning becomes.
+
+This is where measurement governance becomes commercially useful. It protects the team from chasing noise, but it also protects real gains from being dismissed as anecdotal.
+
+## The better board question
+
+The next time an AI visibility report lands in front of leadership, do not only ask whether visibility moved.
+
+Ask whether the baseline moved.
+
+Ask which prompts, models, surfaces, versions, geographies, languages, scoring rules, and citation methods stayed constant. Ask where overlap was used. Ask which changes are like-for-like, which are measurement changes, which are answer-engine drift, and which may reflect genuine market movement.
+
+Then decide what to fund, fix, test, or ignore.
+
+A GEO trend is only useful if it can survive that scrutiny. Otherwise the company is not managing AI visibility. It is managing the illusion of a stable chart.
+
+Version the baseline first.
+
+Trust the trend second.


### PR DESCRIPTION
## Summary
- Adds Build in Public Day 75: “Version the Baseline Before You Trust the Trend”
- Applies the approved Day 75 revision artifact to `docs/blog/posts/daily-blog-day-75.md`
- Keeps the post focused on baseline versioning, like-for-like GEO trend comparability, model/surface drift, citation capture, and the Google AI features caveat

## Checks
- Content/veto checks passed for required GEO terms, Google caveat, banned terminology, and macro-cluster fit
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-75.md` passed
- `python3 -m mkdocs build --strict` failed only on existing site warnings (unlisted pages, existing absolute blog hook nav URLs, unresolved roamlinks/autolinks)
- `python3 -m mkdocs build` passed

## Notes
- The source artifact body was preserved; one frontmatter list item was quoted so the repo’s frontmatter schema validator treats `geo_tactics` as `list[str]`.
