### PR TITLE
docs: add daily blog day 76

### DIFF
--- a/docs/blog/posts/daily-blog-day-76.md
+++ b/docs/blog/posts/daily-blog-day-76.md
@@ -1,0 +1,179 @@
+---
+title: "Day 76: Don’t Buy the Biggest Model List"
+date: 2026-07-05
+slug: "day-76-dont-buy-biggest-model-list"
+description: "A practical GEO buying checklist for CMOs, Marketing Directors, and founders: do not reward model-count theatre when evaluating AI visibility vendors or internal dashboards. Reward the discipline that explains which answer surfaces matter, why they matter commercially, and what decision each observation can change."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - vendor evaluation
+  - procurement
+  - answer engines
+geo_tactics:
+  - Ask every AI visibility vendor or internal dashboard to map model and surface coverage to buyer questions, commercial markets, competitor situations, and decisions the business can actually make.
+  - Separate coverage breadth from coverage usefulness: ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led surfaces should be included because they change buyer understanding, not because they make the model list look larger.
+  - Require interpretation rules before trusting cross-model comparisons: answer role, source or citation behaviour, overlap, market relevance, and actionability should be clear before model-count claims influence budget.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 76: Don’t Buy the Biggest Model List
+
+A model list can look impressive and still fail the buying test.
+
+This comes up often in Generative Engine Optimization work. A CMO, Marketing Director, or founder compares AI visibility vendors, internal dashboards, or agency reports and sees a claim like: we track 8 models, 13 models, 20 models, every major answer engine, every surface that matters.
+
+Breadth sounds reassuring. Nobody wants a narrow view of a market that is being shaped across ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led surfaces. But model count is not the strategy. It is only useful when each surface is tied to a buyer question, a market, an interpretation rule, and a decision.
+
+Adding another model to a tracker is only useful if it changes what the business can understand or do.
+
+<!-- more -->
+
+## The model list is not the measurement strategy
+
+The easy procurement mistake is to treat coverage breadth as a proxy for quality.
+
+A vendor says it tracks more models than another vendor. An internal team shows a dashboard with a larger roster than last quarter. A report includes more answer-led surfaces than the previous report. The number rises, so the work appears more complete.
+
+Sometimes that is true. More coverage can reveal blind spots. It can show that a company appears in one buying context but not another. It can expose citation differences, competitor patterns, geography effects, or source weaknesses that a single surface would miss.
+
+But breadth only matters when it is decision-relevant.
+
+If the report cannot explain why each model or surface is included, the list becomes theatre. It may make the dashboard look sophisticated without making the business smarter. It may create a false sense of coverage while ignoring the questions buyers actually ask before they shortlist, compare, justify, or reject a company.
+
+The buying question is not, "How many models do you track?"
+
+The better question is, "Which buyer situations does this coverage help us understand, and which commercial decisions can it change?"
+
+That is a different standard. It turns model coverage from a trophy list into an operating choice.
+
+## Different surfaces matter for different reasons
+
+GEO measurement does need breadth. A buyer may ask ChatGPT for a shortlist, use Perplexity to explore sourced explanations, see Google AI features while searching the category, ask Gemini inside a broader research flow, or test Claude for a more analytical comparison.
+
+Those surfaces are not interchangeable. They can differ in retrieval behaviour, answer style, citation habits, source visibility, interface context, geography, and the amount of confidence they create in a buyer.
+
+But the practical point is not simply that every answer engine is different. That observation is too easy to turn into another dashboard slide.
+
+The practical point is that each surface needs a job in the measurement plan.
+
+For example:
+
+- One surface may matter because senior buyers use it for first-pass category education.
+- Another may matter because it exposes citations and source paths that influence what the team should improve.
+- Another may matter because it is strong at competitor comparisons.
+- Another may matter because it appears inside a search journey where the company already invests budget.
+- Another may matter because regional buyers rely on it more heavily than the head office assumes.
+
+In each case, the model or surface earns its place because it informs a commercial question. It is not included merely because it exists.
+
+That distinction matters when budgets get tight. A business can waste money watching a large panel of answer outputs without knowing whether the observations affect positioning, content priorities, comparison pages, source development, sales enablement, regional strategy, or executive reporting.
+
+Coverage without a decision path is noise with a nicer interface.
+
+## What to ask before you trust the model list
+
+Before buying a GEO vendor, approving an internal dashboard, or treating an AI visibility report as decision-grade, ask for the logic behind the model and surface roster.
+
+A useful checklist starts here.
+
+### 1. Which buyer questions does each surface test?
+
+A serious measurement plan should connect coverage to buyer situations.
+
+Does the surface test broad category discovery, named-brand evaluation, competitor comparison, procurement risk, local availability, technical proof, founder credibility, pricing expectation, implementation concern, or board-level justification?
+
+If the vendor cannot map a model to a buyer question, the model may still be interesting. But it is not yet commercially justified.
+
+### 2. Which markets and geographies does the roster represent?
+
+A model list can look global while measuring a narrow market.
+
+Ask whether prompts, locations, language settings, competitors, sources, and interpretation rules match the markets that drive revenue. A UK-focused service, a US enterprise category, and a multi-region software company may need different coverage priorities.
+
+The point is not to add every possible region. The point is to avoid treating a generic model roster as if it represents the commercial market you actually sell into.
+
+### 3. What role does each answer surface play in the buying journey?
+
+Some answer surfaces shape early understanding. Some help buyers compare options. Some reinforce or challenge search results. Some are better at surfacing citations. Some are useful for seeing how a problem is explained before the buyer knows which vendor category to search.
+
+Ask the vendor to name the role.
+
+If every model is described with the same sentence, the team probably has a coverage list, not a coverage strategy.
+
+### 4. How are sources and citations interpreted?
+
+A mention without source context can be misleading.
+
+Did the answer cite an owned page, a customer story, a partner page, a directory, a competitor comparison, analyst material, a social profile, an outdated blog post, or no visible source at all? Did the answer use primary evidence, third-party summaries, or generic category material?
+
+This is where Google deserves careful handling. Google's AI features rely on core Search ranking and quality systems. They should not be sold as if there is a separate magic switch for AI visibility. Do not accept recommendations that treat llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as required shortcuts for appearing in Google AI features.
+
+The useful question is more grounded: what public evidence, page quality, relevance, clarity, and source authority make the answer more likely to represent the company accurately?
+
+### 5. What overlap exists between models, and what is actually comparable?
+
+A large roster can double-count similar signals or mix unlike signals into one number.
+
+If five models produce similar answers from similar source patterns, the dashboard should not pretend that five independent market truths have been discovered. If Google AI features, chatbot answers, sourced answer engines, and model-only responses are blended into one score, the report should explain what is comparable and what is not.
+
+The buyer does not need a lecture on every technical difference. They do need to know whether a chart is showing repeated evidence, complementary evidence, or incompatible observations being averaged together.
+
+### 6. What decision can each observation change?
+
+This is the most important procurement question.
+
+If a surface shows weak visibility, what would the business do differently? Improve a category page? Build a comparison asset? Strengthen third-party proof? Fix outdated descriptions? Support a regional landing page? Adjust sales enablement? Investigate competitor language? Change nothing until repeated runs confirm the pattern?
+
+If the answer is unclear, the observation may not deserve budget attention yet.
+
+A good GEO report should make the next decision easier. A weak report makes the dashboard larger.
+
+## Model-count theatre creates bad buying incentives
+
+When buyers reward the largest list, vendors learn to sell the largest list.
+
+That creates predictable problems.
+
+First, it rewards breadth before interpretation. The vendor spends more time proving that the dashboard watches many systems than explaining which systems matter to the buyer's market.
+
+Second, it makes the buyer feel covered while leaving commercial blind spots untouched. A company can track many answer engines and still miss the procurement questions that actually influence shortlisting.
+
+Third, it encourages shallow scoring. If every model has to collapse into one score, the report may flatten different answer roles, citation behaviours, and buyer contexts into a number that looks clean but hides the reason to act.
+
+Fourth, it can create unnecessary work. Teams start chasing isolated misses across a broad panel instead of prioritising repeated, decision-relevant patterns in the surfaces their buyers are likely to use.
+
+This does not mean buyers should choose the smallest dashboard. It means they should buy the explanation, not the count.
+
+The vendor with fewer surfaces and stronger reasoning may be more useful than the vendor with a larger roster and weaker interpretation. The internal team that can explain why it watches a smaller set may produce better decisions than the team that keeps adding models to avoid looking incomplete.
+
+Breadth is valuable when it is disciplined. It is expensive when it is decorative.
+
+## A better buying standard
+
+The better standard is simple: every model or surface in the measurement plan should earn its place.
+
+It should earn its place by answering at least one of these questions:
+
+- Does this surface represent a real buyer research behaviour?
+- Does it expose a source, citation, or evidence pattern we can act on?
+- Does it show a competitor comparison we need to understand?
+- Does it reveal a regional or market-specific blind spot?
+- Does it change the priority of content, proof, positioning, or sales enablement work?
+- Does it help leadership separate meaningful market signal from dashboard noise?
+
+If yes, include it and interpret it carefully.
+
+If no, do not let it win budget merely because it makes the model list longer.
+
+For CMOs, Marketing Directors, and founders, this is the procurement discipline GEO now needs. AI visibility measurement is becoming crowded with dashboards, claims, panels, and model rosters. Some of that breadth will be useful. Some of it will be theatre.
+
+The difference is not the number of models.
+
+The difference is whether the coverage explains which buyer situations matter, why each surface is commercially relevant, how the observations should be interpreted, and what decision the business can make next.
+
+Do not buy the biggest model list.
+
+Buy the measurement discipline that turns coverage into decisions.

--- a/docs/blog/posts/daily-blog-day-76.md
+++ b/docs/blog/posts/daily-blog-day-76.md
@@ -14,8 +14,8 @@ tags:
   - answer engines
 geo_tactics:
   - Ask every AI visibility vendor or internal dashboard to map model and surface coverage to buyer questions, commercial markets, competitor situations, and decisions the business can actually make.
-  - Separate coverage breadth from coverage usefulness: ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led surfaces should be included because they change buyer understanding, not because they make the model list look larger.
-  - Require interpretation rules before trusting cross-model comparisons: answer role, source or citation behaviour, overlap, market relevance, and actionability should be clear before model-count claims influence budget.
+  - "Separate coverage breadth from coverage usefulness: ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led surfaces should be included because they change buyer understanding, not because they make the model list look larger."
+  - "Require interpretation rules before trusting cross-model comparisons: answer role, source or citation behaviour, overlap, market relevance, and actionability should be clear before model-count claims influence budget."
   - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
 ---
 


### PR DESCRIPTION
## Summary
- Adds the approved Day 76 Build-in-Public blog post.
- Keeps the PR payload scoped to one new file: `docs/blog/posts/daily-blog-day-76.md`.

## Checks
- `python3` content/frontmatter assertions: passed
- `python3 -m py_compile tools/blog_hook.py tools/build_log.py tools/llms-txt-generator.py tools/local-llms-txt-generator.py`: passed
- `mkdocs build`: passed (with pre-existing RoamLinks/nav warnings)

## Scope
- One-file blog post PR only.
