### PR TITLE
docs: add daily blog day 77

### DIFF
--- a/docs/blog/posts/daily-blog-day-77.md
+++ b/docs/blog/posts/daily-blog-day-77.md
@@ -14,7 +14,7 @@ tags:
   - answer engines
 geo_tactics:
   - Map every commercially important answer-engine gap to a named owner, a decision, a due date, a public asset or source change, and a review point before it enters the work queue.
-  - Assign owners by the kind of failure exposed: marketing for comparison language, sales for recurring objections, product for positioning boundaries, leadership for category trade-offs, and technical or content teams for public source updates.
+  - "Assign owners by the kind of failure exposed: marketing for comparison language, sales for recurring objections, product for positioning boundaries, leadership for category trade-offs, and technical or content teams for public source updates."
   - Treat ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces as management inputs only when the organisation can say who is responsible for the fix and how the result will be checked.
   - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
 ---

--- a/docs/blog/posts/daily-blog-day-77.md
+++ b/docs/blog/posts/daily-blog-day-77.md
@@ -1,0 +1,164 @@
+---
+title: "Day 77: Give Every AI Visibility Fix an Owner"
+date: 2026-07-06
+slug: "day-77-give-every-ai-visibility-fix-an-owner"
+description: "A practical GEO operating-model note for CMOs, Marketing Directors, and founders: AI visibility findings only become commercially useful when every answer gap has a named owner, a decision route, a due date, a public asset or source change, and a review point."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - operating model
+  - ownership
+  - answer engines
+geo_tactics:
+  - Map every commercially important answer-engine gap to a named owner, a decision, a due date, a public asset or source change, and a review point before it enters the work queue.
+  - Assign owners by the kind of failure exposed: marketing for comparison language, sales for recurring objections, product for positioning boundaries, leadership for category trade-offs, and technical or content teams for public source updates.
+  - Treat ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces as management inputs only when the organisation can say who is responsible for the fix and how the result will be checked.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 77: Give Every AI Visibility Fix an Owner
+
+AI visibility work usually does not fail because the team missed another dashboard.
+
+It fails because the finding has no owner.
+
+A CMO, Marketing Director, or founder sees that ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led surface describes the company poorly, omits a useful proof point, overstates a competitor, confuses the category, or sends buyers toward the wrong explanation. Everyone agrees the answer matters. Everyone agrees something should change.
+
+Then the finding becomes a generic content chore.
+
+That is the failure mode. Generative Engine Optimization only becomes commercially useful when each answer gap is turned into an accountable operating item: named owner, decision required, due date, public asset or source change, and review point.
+
+This is not another action register. It is the ownership route that decides who can change the underlying evidence, which public surface should change, and when the result will be reviewed.
+
+Visibility without ownership is just a more modern way to produce unfinished work.
+
+<!-- more -->
+
+## A red flag is not a fix
+
+Most AI visibility reports can identify problems faster than an organisation can absorb them.
+
+The answer engine did not mention the brand. It used an old category label. It recommended competitors with clearer positioning. It cited a third-party source instead of the company's own explanation. It misunderstood the offer. It repeated an objection sales hears every week. It treated a feature boundary as a weakness. It explained the market in a way leadership would never approve.
+
+Those observations are useful, but they are not yet work.
+
+A report becomes work only when the business can answer five questions:
+
+1. Who owns this gap?
+2. What decision needs to be made?
+3. Which public asset, source, sales language, product explanation, or measurement rule should change?
+4. When will the change be made?
+5. How will we review whether the answer environment improved?
+
+Without those questions, the team gets a list of alerts. Marketing receives a vague instruction to "make content better". Sales assumes product should fix the positioning. Product assumes marketing should explain it more clearly. Leadership assumes the operating teams will resolve the trade-off. Technical teams wait for a specific page or source request.
+
+The answer gap remains visible, but nobody is accountable for closing it.
+
+That is how GEO turns into theatre: commercially serious observations, operationally unserious follow-through.
+
+## Different answer gaps belong to different owners
+
+The mistake is treating every AI visibility problem as a content production problem.
+
+Some fixes are content fixes. Many are not.
+
+If answer engines describe a competitor more clearly because that competitor owns the comparison language, marketing may need to build or revise comparison pages, category explainers, offer pages, and proof assets. The owner is not "the blog". The owner is the person responsible for how the market should compare options before a sales call.
+
+If answer engines repeat the same objection that sales hears from prospects, sales should own the objection pattern. The fix may be a better objection-handling asset, clearer qualification language, stronger proof for a common risk, or a change to how the website addresses implementation concerns. Marketing can publish the source, but sales owns whether the explanation matches the real conversation.
+
+If answer engines blur the boundary between what the product does and what it does not do, product needs to own the positioning boundary. That might require a clearer capabilities page, a public limitations note, better integration language, or a sharper explanation of which buyer situations the offer is designed for. A content team can draft it, but product must decide what is true.
+
+If answer engines frame the category in a way that makes the company sound adjacent, leadership owns the trade-off. The answer may expose a strategic choice: accept the market's current label, challenge it, split the category narrative, or invest in a clearer point of view. That is not a junior content ticket. It is a positioning decision.
+
+If answer engines rely on stale or weak public sources, technical and content owners may need to update pages, improve information architecture, remove conflicting material, strengthen source clarity, or make important explanations easier for buyers and systems to find. The work is still not magic markup. It is public evidence and accessible explanation.
+
+The point is not to create bureaucracy around every prompt result. The point is to stop routing commercially different problems into the same vague queue.
+
+## Ownership changes the quality of the diagnosis
+
+When no owner is named, the diagnosis stays shallow.
+
+The team asks, "How do we get mentioned more?" or "How do we make the answer better?"
+
+Those are weaker questions than:
+
+- Does marketing own a missing comparison criterion?
+- Does sales own an objection that has become public market language?
+- Does product own a confused capability boundary?
+- Does leadership own a category choice the market is not yet making clearly?
+- Does the website owner need to repair an outdated source?
+- Does measurement need to separate a genuine market gap from a noisy answer run?
+
+The owner changes what counts as evidence.
+
+Marketing may need competitor pages, search demand, campaign claims, and offer hierarchy. Sales may need call notes, objections, win/loss patterns, and buyer questions. Product may need roadmap boundaries, implementation constraints, and precise capability language. Leadership may need market positioning, commercial risk, and the appetite to take a stronger category stance. Technical and content teams may need crawlable public pages, source quality, internal linking, page freshness, and clear ownership of the source that answer engines can retrieve or buyers can verify.
+
+That is why ownership belongs near the start of the workflow, not at the end.
+
+If the team waits until after the report is written to decide who should care, the report will usually be written for everyone and owned by no one.
+
+## The fix should name the public surface
+
+A useful GEO operating model does not stop at "owner assigned".
+
+It names the surface that will change.
+
+For example:
+
+- Marketing owns a comparison-language gap and updates the comparison page, homepage section, sales deck language, and category explainer.
+- Sales owns a recurring objection and turns it into a public FAQ, a proof-led enablement asset, and a qualification note.
+- Product owns a positioning-boundary issue and updates the capabilities page, integration explanation, and implementation caveats.
+- Leadership owns a category trade-off and decides whether the company should lean into the existing label or publish a sharper point of view.
+- Technical or content owners repair the source path by updating stale pages, consolidating conflicting explanations, improving page hierarchy, and making the authoritative answer easier to find.
+
+The common thread is public evidence.
+
+Answer engines cannot reliably represent what the company has not made clear. Buyers cannot verify what the company has not explained. Sales cannot lean on proof that lives only in a private meeting. Leadership cannot complain about category framing if the public point of view is timid, fragmented, or out of date.
+
+This is why ownership matters commercially. It connects the observation to the part of the business that can change the evidence.
+
+The goal is not more content volume. The goal is a better public operating surface for the buyer and for the systems that summarise the market before the buyer reaches you.
+
+## Review is part of the fix
+
+An owner also needs a review point.
+
+Without review, the team can complete the task and still learn nothing.
+
+The review does not need to pretend that one prompt run proves causality. Answer engines are variable, and different surfaces behave differently. A sensible review asks whether the public evidence has improved and whether repeated observations move in the right direction across the buyer scenarios that matter.
+
+The review can be simple:
+
+- Re-run the relevant prompts after the public source changes have had time to settle.
+- Compare the answer wording against the previous observation.
+- Check whether the correct source, claim, category label, proof point, or caveat is now easier to retrieve.
+- Note whether competitors are still being advantaged by clearer public explanations.
+- Decide whether the issue is closed, needs another owner, or reveals a deeper positioning decision.
+
+That final point matters. Some answer gaps are symptoms. A weak comparison answer might start as a marketing issue and become a leadership issue. A repeated objection might start in sales and become a product explanation problem. A stale citation might start as a content problem and reveal that the organisation has no authoritative public source for a claim it uses every day.
+
+The operating model should allow the owner to change when the diagnosis changes.
+
+## The CMO question is not "what did the model say?"
+
+The better question is:
+
+"Who owns the fix if the answer is commercially damaging?"
+
+That question changes the posture of the work. It stops AI visibility from becoming a passive reporting function and turns it into a management system for public market evidence.
+
+For CMOs and founders, the operating checklist is short:
+
+- Is this answer gap commercially material?
+- Which owner can actually change the underlying evidence or explanation?
+- What decision is required before work begins?
+- Which public asset, source, sales language, product explanation, or measurement rule will change?
+- What is the due date?
+- When will we review the answer environment again?
+
+If the team cannot answer those questions, the finding is not ready for the content calendar.
+
+It is ready for ownership.


### PR DESCRIPTION
## Summary
- Adds Day 77 daily blog post: `docs/blog/posts/daily-blog-day-77.md`
- Publishes the approved GEO ownership-routing article for 2026-07-06

## Verification
- Content sanity check passed: title/date/slug/`<!-- more -->`, forbidden/internal terms absent, ownership-route terms present
- `python3 test_markdown.py` passed
- `mkdocs build` passed (with existing RoamLinks/nav warnings)
- `git diff --cached --name-only` showed only `docs/blog/posts/daily-blog-day-77.md`

## Payload
- One intended file only: `docs/blog/posts/daily-blog-day-77.md`
