### PR TITLE
docs: add daily blog day 78

### DIFF
--- a/docs/blog/posts/daily-blog-day-78.md
+++ b/docs/blog/posts/daily-blog-day-78.md
@@ -1,0 +1,173 @@
+---
+title: "Day 78: Retire the Pages That Teach the Wrong Story"
+date: 2026-07-07
+slug: "day-78-retire-pages-teach-wrong-story"
+description: "A practical GEO failure-mode analysis for CMOs, Marketing Directors, and founders: stale public pages are not harmless archive material. They can keep teaching buyers and answer engines the wrong category, offer, proof, and comparison story long after the business has moved on."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - source lifecycle
+  - content governance
+  - answer engines
+geo_tactics:
+  - Audit public pages for obsolete category labels, old offer descriptions, stale proof, duplicate source-of-truth pages, and superseded explanations that may still shape buyer or answer-engine understanding.
+  - Retire, redirect, consolidate, or clearly supersede public material that no longer represents the business, instead of letting outdated pages keep competing with current positioning.
+  - Make the canonical explanation obvious across ChatGPT, Claude, Perplexity, Gemini, Google AI features, search snippets, third-party references, and buyer-visible pages without relying on magic markup.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 78: Retire the Pages That Teach the Wrong Story
+
+Stale public pages do not sit quietly in the archive.
+
+They keep explaining the company.
+
+A CMO, Marketing Director, or founder may have moved the offer, sharpened the category, retired an old product line, changed the proof base, narrowed the ideal customer, or rebuilt the positioning around a better commercial truth. But if the public record still contains old explanations, duplicate pages, obsolete category language, forgotten campaign copy, abandoned docs, or superseded offer pages, the market may keep learning the previous version of the story.
+
+That is not just a content hygiene problem. It is a Generative Engine Optimization failure mode.
+
+Answer-led surfaces such as ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar tools can be influenced by public material, search results, third-party references, snippets, and the language buyers encounter before they ever speak to sales. Buyers can find the same stale pages directly. If those pages teach the wrong story, the company has not merely failed to publish enough. It has failed to decide which public explanations are still allowed to represent the business.
+
+<!-- more -->
+
+## The old page is still a market participant
+
+Most teams think about stale content as a maintenance backlog.
+
+The page is old. The design is dated. The screenshots are wrong. The copy mentions last year's offer. The taxonomy changed. The product names moved. The category language has been replaced. Everyone knows the page is not where the strategy lives now, so nobody treats it as urgent.
+
+But buyers and answer engines do not know which forgotten pages the company has emotionally disowned.
+
+They see public material.
+
+That public material can still answer questions such as:
+
+- What category does this company belong in?
+- What does the offer include?
+- Who is the service for?
+- Which competitors or alternatives should be considered?
+- What proof supports the claim?
+- Which page appears to be the canonical explanation?
+- Is this company still focused on the problem I am researching?
+
+If the old page answers those questions poorly, it can create commercial drag. A buyer may think the company serves a broader market than it now wants. An answer engine may repeat an obsolete label. A comparison page may preserve a competitor frame the company has outgrown. A campaign landing page may describe an offer that sales no longer wants to sell. A dormant explainer may look more specific than the current strategic page and therefore become the easier source to summarise.
+
+The page is not neutral because it is old. It is active because it is public.
+
+## Stale sources create bad-fit demand
+
+The commercial cost is not always a lost citation.
+
+Sometimes the cost is worse: the company gets represented clearly, but incorrectly.
+
+An outdated page can attract prospects who want the old offer. It can make the business sound like a generic vendor in a category it is trying to leave. It can make a premium advisory service look like a tactical content package. It can cause buyers to compare the company against the wrong alternatives. It can give sales a pipeline full of conversations that should have been filtered out earlier.
+
+That is why stale-source lifecycle work belongs in GEO.
+
+The goal is not to control every answer. No company can. The goal is to stop feeding the market contradictory public explanations and then acting surprised when answer-led discovery reflects the contradiction.
+
+A buyer does not care that the stale page came from an old campaign, an abandoned concept page, a previous positioning test, a legacy docs section, or a temporary landing page that never got cleaned up. They care about whether the business appears coherent and current when they research it.
+
+The same is true for answer engines. A surface may draw on a mixture of public pages, search ranking signals, citations, third-party mentions, and previously learned market language. If the available public record contains several versions of the company's story, the answer can collapse them into a version nobody in leadership would approve.
+
+That is how a stale page becomes a bad-fit demand generator.
+
+## Retirement is a strategic act, not a housekeeping chore
+
+Publishing more is the comfortable version of GEO work.
+
+Retiring material is harder because it forces decisions.
+
+The team has to ask whether an old page should remain visible, be redirected, be consolidated, be rewritten, be marked as superseded, or be removed from the buyer journey. That decision can expose real commercial tension:
+
+- Is the old offer still available, or is it confusing the pipeline?
+- Is the old category label still useful for search demand, or is it damaging strategic positioning?
+- Is the old proof still valid, or does it imply a capability the company no longer wants to emphasise?
+- Is the old explainer still accurate, or is it competing with a better canonical page?
+- Is the page serving buyers, or merely preserving internal history in public?
+
+Those are not cosmetic questions. They decide what the market is allowed to learn.
+
+A public source lifecycle should have more than a publish date. It should have a reason to remain public.
+
+Some pages deserve to live because they still explain the business well. Some deserve revision because the underlying idea is valuable but the details are stale. Some deserve consolidation because two pages are competing to answer the same buyer question. Some deserve a visible supersession note because the old context still matters, but should not be mistaken for the current offer. Some deserve a redirect because the buyer should be moved to the newer canonical explanation. Some deserve removal because they now create more misunderstanding than value.
+
+This is not about pretending the past never existed. It is about refusing to let the past outrank the current commercial truth.
+
+## Canonical does not mean magic markup
+
+A useful GEO programme needs canonical public explanations.
+
+That does not mean sprinkling special AI markup across the site and hoping answer engines obey. It means making the current explanation easier to find, easier to understand, and harder to confuse with obsolete material.
+
+For practical purposes, a canonical explanation should do a few jobs:
+
+1. State the current category and offer in language a buyer would recognise.
+2. Explain who the company is for and who it is not for.
+3. Replace or supersede older pages that answer the same question differently.
+4. Link related pages in a way that makes the current hierarchy obvious.
+5. Preserve only the historical material that still serves a buyer or proof need.
+6. Avoid creating duplicate pages that compete to define the same concept.
+
+That work can help across answer-led surfaces, but it should be framed carefully.
+
+ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar tools do not all retrieve, cite, rank, and summarise in the same way. Some answer experiences expose sources more visibly than others. Some may lean more heavily on search results. Some may answer from a broader learned understanding of the market. Buyers may also encounter snippets, third-party pages, directories, review sites, social posts, and cached market language before reaching the company's site.
+
+So the point is not that one file, tag, schema block, or chunking tactic flips an AI visibility switch.
+
+For Google specifically, the caveat matters: Google's AI features rely on core Search ranking and quality systems. `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility.
+
+The more durable principle is simpler: if the public web contains obsolete explanations of the business, those explanations can keep participating in how buyers and systems understand the company. Canonical source work reduces that confusion by making the current story clearer than the retired one.
+
+## A practical stale-source checklist
+
+The easiest way to start is not with a new content calendar.
+
+Start with a retirement review.
+
+For each commercially important category, offer, comparison, proof point, and buyer segment, ask:
+
+1. Which public page currently gives the best explanation?
+2. Which older pages answer the same question differently?
+3. Which pages still use an old category label or deprecated offer language?
+4. Which pages mention proof, clients, features, markets, or claims that no longer represent the business accurately?
+5. Which pages attract the wrong buyer because the old positioning is broader, cheaper, or more tactical than the current offer?
+6. Which third-party references repeat language the company has already moved away from?
+7. Which page should be treated as the canonical source for a buyer or answer engine trying to understand this topic?
+8. What should happen to the stale material: refresh, merge, redirect, noindex where appropriate, mark as superseded, or remove?
+
+The output should be a source-lifecycle decision, not a vague instruction to improve content.
+
+A useful review produces a list like this:
+
+- Keep: still accurate and commercially useful.
+- Refresh: accurate purpose, stale details.
+- Consolidate: duplicate or competing explanation.
+- Redirect: old page should point to a newer canonical page.
+- Supersede: historical context remains useful, but the page must clearly state that a newer explanation exists.
+- Retire: no longer represents the business and creates more confusion than value.
+
+That classification gives marketing, leadership, content, product, and sales a shared question: which public pages should still be allowed to speak for us?
+
+## The buyer should not have to reconcile your history
+
+A buyer researching your company is not your archivist.
+
+They should not have to infer which explanation is current. They should not have to notice that one page is three positioning cycles old. They should not have to reconcile an old landing page with a newer offer page. They should not have to guess whether a comparison, proof point, or category description still reflects the business.
+
+Answer engines should not have to do that work either.
+
+The public record will never be perfectly clean. Markets change. Offers evolve. Teams test language. Campaigns end. Product boundaries move. That is normal.
+
+But leaving obsolete pages to compete with current strategy is a choice.
+
+For CMOs and founders, the sharper GEO question is not only, "What should we publish next?"
+
+It is also, "What should we stop allowing the market to learn from?"
+
+Retirement is not a retreat from visibility. Done well, it is how the company protects the visibility it actually wants.
+
+The page that teaches the wrong story should not keep its job simply because nobody remembered to fire it.


### PR DESCRIPTION
## Summary
- Adds the approved Day 78 Build in Public post: `Day 78: Retire the Pages That Teach the Wrong Story`.
- Applies the final revision artifact from `/home/claw/.hermes/zsa-editorial-artifacts/day-78/revision/daily-blog-day-78.md` to `docs/blog/posts/daily-blog-day-78.md`.
- Keeps the public copy buyer-facing and focused on stale public source retirement/supersession as GEO work.

## Checks
- Frontmatter check: title/date/slug present; `<!-- more -->` present.
- Banned internal/repo terminology check: no banned terms found in title/intro/headings.
- Google caveat check: present; no claim that `llms.txt`, special AI markup, chunking, or over-focused structured data are required switches for Google AI visibility.
- Required answer surfaces checked: ChatGPT, Claude, Perplexity, Gemini, and Google AI features are named.
- `python3 test_markdown.py` passed.
- `mkdocs build` passed with existing site warnings about missing wikilinks/nav entries.

## Payload
- `docs/blog/posts/daily-blog-day-78.md` only.
