### PR TITLE
docs: add daily blog day 79

### DIFF
--- a/docs/blog/posts/daily-blog-day-79.md
+++ b/docs/blog/posts/daily-blog-day-79.md
@@ -1,0 +1,239 @@
+---
+title: "Day 79: Teach Answer Engines Why This Problem Cannot Wait"
+date: 2026-07-08
+slug: "day-79-teach-answer-engines-why-problem-cannot-wait"
+description: "A practical GEO note for CMOs, Marketing Directors, and founders: answer engines may understand what a company does while making the problem sound optional. Public pages need priority triggers, commercial consequences, timing language, and decision routes so buyers understand why the issue deserves action now."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - buyer urgency
+  - commercial priority
+  - answer engines
+geo_tactics:
+  - Add priority triggers to commercially important pages: market shifts, competitor pressure, budget cycles, launches, regulatory risk, sales objections, category confusion, proof gaps, and repeated answer-engine wording that makes the problem sound optional.
+  - Connect each trigger to a business consequence, timing reason, and decision route so answer-led summaries can explain why the buyer should act now rather than merely understand the category.
+  - Review ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces for language that correctly describes the offer but drains urgency from the problem.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 79: Teach Answer Engines Why This Problem Cannot Wait
+
+A buyer can understand your category and still do nothing.
+
+That is the quiet commercial failure hiding inside a lot of AI visibility work.
+
+A CMO, Marketing Director, or founder may check ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led surface and find that the company is described reasonably well. The category is broadly right. The offer is not mangled. The answer mentions the right kind of problem. Nothing looks obviously broken.
+
+But the summary still makes the issue sound optional.
+
+It explains what the company does without explaining why the buyer should care this quarter. It describes the problem without naming the commercial pressure. It gives a neutral category definition where the buyer needed a priority argument. It makes the topic legible, but not urgent.
+
+That is a Generative Engine Optimization problem too.
+
+<!-- more -->
+
+## Visibility is not the same as priority
+
+Most teams are trained to look for presence first.
+
+Is the company named? Is the description accurate? Are competitors included? Are sources visible? Does the answer mention the right product, service, or category?
+
+Those checks matter, but they do not answer the commercial question.
+
+The commercial question is whether the answer helps a buyer, budget holder, or internal stakeholder understand why the problem deserves attention now.
+
+A neutral answer can be technically accurate and commercially weak. It can say that a firm helps B2B companies improve AI visibility, clarify positioning, or build better public explanations, while leaving the reader with no reason to prioritise the work over brand, pipeline, product, hiring, reporting, events, or the dozen other initiatives competing for budget.
+
+That is not only an answer-engine wording issue. It usually reflects the public pages the answer environment has learned from.
+
+If the public record treats the problem as an evergreen concept, answer-led summaries will often do the same. If the website explains the category but does not connect it to timing, risk, budget, competitive pressure, or decision moments, the resulting answer may sound like a useful idea for later.
+
+For a buyer, later often means never.
+
+## Answer engines synthesise urgency from public signals
+
+Urgency is not created by a schema field.
+
+It is synthesised from the claims, examples, comparisons, consequences, proof, market language, and next steps available in public material. A human buyer does the same thing. They read the page and ask, consciously or not:
+
+- Is this problem happening now?
+- Is it getting worse?
+- What happens if we wait?
+- Are competitors already moving?
+- Is there a budget or planning moment approaching?
+- Does this affect revenue, conversion, trust, procurement, sales velocity, or market position?
+- What decision should we make next?
+
+Answer-led surfaces can pick up similar signals when they summarise a company, category, or problem. They may not preserve every nuance, and different systems behave differently, but they are still working from public explanations, search-visible pages, third-party references, snippets, citations, and broader market language.
+
+If those materials only define the topic, the answer may only define the topic.
+
+That is the gap.
+
+Many websites are built to prove that a problem exists. Fewer are built to teach why it has become a priority. The first job makes the buyer informed. The second makes the buyer ready to decide.
+
+GEO should care about both.
+
+## The missing layer is priority language
+
+Priority language is the material that turns a passive explanation into a commercial prompt.
+
+It does not need to be sensational. In fact, it should not be. The goal is not fake scarcity, fear-mongering, or pretending every issue is existential. The goal is to make the real business timing visible.
+
+For example, a page about AI visibility may say:
+
+"Buyers increasingly use answer engines to research vendors."
+
+That is true, but weak. It explains the environment without giving the CMO a reason to move.
+
+A stronger public explanation might say:
+
+"If buyers are asking ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar tools to shortlist vendors before they reach your site, then unclear public positioning can move the comparison upstream of your sales process. The commercial risk is not only lower visibility. It is losing influence over the criteria buyers use before you know they are in-market."
+
+That second version does more than describe the trend. It names the timing, the consequence, and the decision pressure.
+
+The same principle applies across many commercial pages:
+
+- A market shift trigger: "The way buyers research this category has changed; the old page architecture was built for search clicks, not answer-led shortlists."
+- A competitor pressure trigger: "Competitors with clearer public comparison language may become the default examples in AI-shaped research."
+- A sales objection trigger: "If the same objection appears in discovery calls and answer-engine summaries, the market is learning the risk before sales can reframe it."
+- A budget cycle trigger: "If this work is not scoped before planning, it becomes another unfunded brand concern instead of a pipeline protection item."
+- A launch or repositioning trigger: "If the public record is not updated before the launch, answer-led summaries can keep explaining the previous offer."
+- A regulatory risk trigger: "If the category depends on trust, compliance, or auditability, vague public claims can make the buyer slow down rather than move forward."
+- A category confusion trigger: "If buyers cannot tell which problem you solve, answer engines may collapse you into the safer incumbent category."
+- A proof gap trigger: "If the claim sounds important but unsupported, the buyer may treat it as vendor language rather than a reason to act."
+
+These are not content ornaments. They are commercial signals.
+
+They tell both people and systems what kind of business moment the page is describing.
+
+## The consequence of waiting should be explicit
+
+A lot of B2B pages avoid consequences because teams do not want to sound negative.
+
+That caution is understandable, but it often leaves the buyer with an incomplete argument. The page says the solution is valuable, but not what delay costs. It says the category matters, but not what gets worse if the team postpones action. It says the company can help, but not why the problem belongs on the leadership agenda now.
+
+Answer engines can inherit that softness.
+
+They may summarise the problem as a useful capability, an emerging practice, a strategic consideration, or an area to explore. None of those phrases are wrong. They are just easy to ignore.
+
+For CMOs and founders, the practical fix is to name the consequence of inaction in plain business terms.
+
+Not every consequence is catastrophic. Most are ordinary, compounding forms of commercial drag:
+
+- Buyers compare the company against the wrong alternatives.
+- Sales has to re-educate prospects who arrive with the wrong criteria.
+- Procurement receives a weaker internal business case.
+- Competitors frame the category before the company does.
+- Campaign spend points people towards pages that do not create urgency.
+- Launch messaging fails to replace the old market story.
+- A proof gap makes the claim sound interesting but unprioritised.
+- Internal stakeholders treat the initiative as brand polish rather than revenue infrastructure.
+
+Those consequences should be visible where the buyer is learning the problem.
+
+If the public page says only "this is important", the summary may say only "this is important". If the public page says "this matters because delay creates these specific costs", answer-led surfaces have a better chance of preserving the priority logic.
+
+## Timing should be connected to a decision route
+
+Urgency without a next step becomes anxiety.
+
+A useful page should not only say why the problem matters now. It should show what kind of decision the buyer needs to make next.
+
+That decision route can be simple:
+
+1. Diagnose whether the issue is present.
+2. Identify the commercially important surfaces, prompts, pages, or buyer scenarios.
+3. Decide which public explanation, comparison, proof point, or route needs to change.
+4. Assign the work to the team that can change the underlying evidence.
+5. Review whether the public answer environment and buyer journey improve.
+
+The route matters because answer-led summaries often compress the journey. If the public material offers no decision path, the answer may reduce the topic to a general recommendation: review your content, improve your visibility, optimise your website, monitor AI answers.
+
+That language is too soft to win budget.
+
+A better page teaches the sequence. It says what to check first, what decision follows, what role is involved, and what output should exist at the end. It gives the CMO a way to turn concern into a meeting, a brief, a budget line, or a leadership decision.
+
+This is especially important when the buyer is not the only stakeholder.
+
+A Marketing Director may need to persuade a founder. A CMO may need to justify spend to the board. A founder may need to decide whether this is positioning work, pipeline work, website work, sales enablement, or all of the above. If answer-led discovery gives them only a neutral explanation, it does not help them make the internal case.
+
+The page should give them the argument they need to carry into the room.
+
+## Do not confuse urgency with magic markup
+
+This work is easy to misframe.
+
+The answer is not to add special AI markup, arbitrary chunking, or a technical file and assume the urgency problem is solved. Those tactics can become a distraction from the actual issue: the public explanation is not teaching the commercial reason to act.
+
+For Google specifically, the caveat should stay clear. Google's AI features rely on core Search ranking and quality systems. `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility.
+
+The more useful principle is editorial and commercial: make the public material better at explaining priority.
+
+That means:
+
+- Put the timing trigger near the problem, not buried in a sales deck.
+- Name the business consequence, not only the category trend.
+- Show where competitor pressure or buyer behaviour has changed.
+- Connect the issue to a planning, budget, launch, risk, or pipeline moment.
+- Include proof that the problem is real enough to act on.
+- Give the buyer a next decision, not only a conceptual explanation.
+- Keep the language specific enough that a summary can preserve the point.
+
+This is still GEO because it shapes the material that answer-led systems and buyers can use. It is not GEO theatre because it does not depend on pretending one technical switch controls every answer surface.
+
+## Audit for optional-sounding answers
+
+A practical review can start with one uncomfortable question:
+
+"Where do answer engines describe the problem correctly but make it sound non-urgent?"
+
+Look for summaries that use phrases such as:
+
+- "can help organisations improve"
+- "may be useful for companies considering"
+- "is an emerging area"
+- "businesses should be aware of"
+- "one option is to review"
+- "could support better marketing outcomes"
+
+Those phrases are not automatically bad. Sometimes they are appropriate. But if every summary sounds like a future consideration, the public priority layer may be missing.
+
+Then inspect the source material behind the topic. Ask:
+
+1. Does the page name a current market shift?
+2. Does it explain why the issue matters in this buying cycle?
+3. Does it connect the problem to revenue, conversion, trust, procurement, sales velocity, or competitive position?
+4. Does it show what delay costs?
+5. Does it mention competitor pressure, launch timing, budget planning, regulation, category confusion, sales objections, or proof gaps where relevant?
+6. Does it give the buyer a decision route?
+7. Could an internal champion use the page to justify action to someone else?
+
+If the answer is no, the page may be informative but commercially underpowered.
+
+That is the gap to fix.
+
+## The buyer should not have to invent the priority
+
+A buyer researching your company is already doing work.
+
+They are comparing options, testing assumptions, asking colleagues, reading summaries, checking proof, and deciding which problems deserve scarce attention. If your public material makes them invent the urgency themselves, many will not bother.
+
+Answer engines will not reliably invent it for you either.
+
+They can summarise the problem. They can name the category. They can mention the company. They can compare vendors. But if the available public record does not explain why the issue has become commercially time-sensitive, the answer may flatten the whole thing into a useful idea for later.
+
+For CMOs, Marketing Directors, and founders, the sharper GEO question is not only, "Do answer engines understand what we do?"
+
+It is:
+
+"Do they understand why this problem cannot wait?"
+
+If the answer is no, the fix is not louder content. It is clearer priority logic.
+
+Make the trigger visible. Name the consequence. Connect the timing. Give the decision route.
+
+The market should not have to guess why the problem matters now.

--- a/docs/blog/posts/daily-blog-day-79.md
+++ b/docs/blog/posts/daily-blog-day-79.md
@@ -13,7 +13,7 @@ tags:
   - commercial priority
   - answer engines
 geo_tactics:
-  - Add priority triggers to commercially important pages: market shifts, competitor pressure, budget cycles, launches, regulatory risk, sales objections, category confusion, proof gaps, and repeated answer-engine wording that makes the problem sound optional.
+  - "Add priority triggers to commercially important pages: market shifts, competitor pressure, budget cycles, launches, regulatory risk, sales objections, category confusion, proof gaps, and repeated answer-engine wording that makes the problem sound optional."
   - Connect each trigger to a business consequence, timing reason, and decision route so answer-led summaries can explain why the buyer should act now rather than merely understand the category.
   - Review ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces for language that correctly describes the offer but drains urgency from the problem.
   - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."


### PR DESCRIPTION
## Summary
- Adds the approved Day 79 Build in Public post: `docs/blog/posts/daily-blog-day-79.md`
- Preserves the approved GEO/commercial-priority angle and Google AI caveat
- Payload intentionally contains only the Day 79 blog post file

## Verification
- Content assertion passed: date `2026-07-08`, Day 79 title/slug, `<!-- more -->`, Google caveat, and no internal ops terms
- `python tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-79.md` passed
- `python3 -m mkdocs build --strict` fails on 90 existing MkDocs/RoamLinks warnings
- `python3 -m mkdocs build` passes with the same existing warning class
- GitHub PR checks pass: `validate`, `Cloudflare Pages`

## Payload
- `docs/blog/posts/daily-blog-day-79.md`
