### PR TITLE
docs: add daily blog day 80

### DIFF
--- a/docs/blog/posts/daily-blog-day-80.md
+++ b/docs/blog/posts/daily-blog-day-80.md
@@ -1,0 +1,163 @@
+---
+title: "Day 80: Teach Answer Engines When Not to Recommend You"
+date: 2026-07-09
+slug: "day-80-teach-answer-engines-when-not-to-recommend-you"
+description: "A concrete GEO failure-mode analysis for CMOs, Marketing Directors, and founders: more AI visibility can create bad-fit demand when public pages only teach positive recommendation cues. Strong answer-led discovery should also explain who the company is not for, which constraints change the recommendation, and what a serious buyer should do next."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - buyer qualification
+  - pipeline quality
+  - answer engines
+geo_tactics:
+  - "Publish explicit no-fit signals on commercially important pages: buyer situation, constraints, maturity, budget or timing requirements, implementation dependencies, proof threshold, and alternatives that may be better in some cases."
+  - Teach ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces when not to recommend the company, so visibility supports qualification rather than sending every vaguely related buyer to sales.
+  - "Pair disqualification language with a useful next step: self-selection guidance, a diagnostic route, a lighter alternative, a partner path, or a clear reason to return when the buyer's situation changes."
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 80: Teach Answer Engines When Not to Recommend You
+
+The wrong recommendation can be worse than no recommendation.
+
+That sounds strange in a market where everyone is chasing more AI visibility. A company wants to be named by ChatGPT, Claude, Perplexity, Gemini, Google AI features, and every other answer-led surface that might shape a buyer's shortlist. Presence feels like progress. A mention feels like proof that the market is starting to recognise the offer.
+
+But visibility is only commercially useful when it sends the right demand.
+
+For CMOs, Marketing Directors, and founders, the problem is not simply whether answer engines mention the company. The sharper question is whether those answers help the buyer understand fit. Is this company right for my situation? What constraints would make it a poor choice? Which alternatives should I consider if I am earlier-stage, lower-budget, differently resourced, or solving a related but separate problem? What should I do next if I am a serious buyer?
+
+If the public record only says positive things, answer-led discovery may recommend the company too broadly. It may send curious but unqualified buyers into the pipeline. It may compress meaningful commercial boundaries into a generic endorsement. It may create meetings that feel like market interest but behave like sales waste.
+
+Generative Engine Optimization should not chase maximum mentions at any cost. It should help answer engines and buyers know when to recommend you, and when not to.
+
+<!-- more -->
+
+## More visibility can create worse demand
+
+Most teams treat AI visibility as an awareness problem first.
+
+Can the answer engine find us? Does it understand the category? Does it describe the offer accurately? Are we included alongside plausible alternatives? Are the cited or summarised sources current enough to represent the business?
+
+Those checks matter, but they are incomplete. They measure whether the company appears in the answer. They do not measure whether the resulting demand is commercially useful.
+
+A broad recommendation can look flattering while creating bad-fit pipeline. A buyer may be sent to the company even though they need a software platform rather than a specialist consultancy. A founder may enquire before they have enough market proof, budget, or internal ownership to act. A marketing team may believe the offer covers tactical content production when the real service is strategic GEO diagnosis and public-source engineering. An enterprise buyer may need procurement depth, implementation support, or proof standards that the company is not designed to provide.
+
+None of those outcomes are solved by louder positioning.
+
+If the website only publishes the strongest case for the company, answer engines have to infer the boundaries. They may infer them from competitor pages, third-party summaries, outdated snippets, category generalisations, or the absence of detail. A human buyer does something similar. When the no-fit logic is missing, both the machine and the person are left with a positive but incomplete picture.
+
+That is how AI visibility becomes a pipeline-quality problem.
+
+The company appears more often, but sales spends more time explaining who the offer is not for. Pricing pressure increases because buyers compare the firm against lower-cost alternatives that were never equivalent. Forecast quality weakens because early conversations sound interested but lack the conditions required to close. Trust erodes when the buyer discovers late that the recommendation was technically related but commercially unsuitable.
+
+The better goal is not to reduce visibility. The better goal is to make visibility discriminating.
+
+## Answer engines need negative space
+
+A useful recommendation depends on negative space.
+
+It is not enough for public material to say, "We help this kind of buyer with this kind of problem." It also needs to make clear where the recommendation stops. That boundary is not a defensive disclaimer. It is commercial qualification made public.
+
+Answer-led surfaces can summarise fit, constraints, trade-offs, implementation requirements, alternatives, and next steps when those signals are available. They may not preserve every nuance. Different systems will weigh public material differently. Google AI features are not controlled by a special AI switch, `llms.txt`, arbitrary chunking, or magic markup. But answer environments still work from public pages, search-visible explanations, third-party references, snippets, and the broader language around the category.
+
+If the public material never names the wrong buyer, the wrong stage, the wrong constraint, or the better alternative, the answer engine has less to work with.
+
+That creates a predictable failure mode: the company becomes easy to recommend and hard to qualify.
+
+The homepage says the outcome. The service page says the benefits. The proof page says the work can succeed. The case study says a client got value. All of that is useful. But if none of those surfaces explain where the offer is unsuitable, the recommendation becomes too smooth. It can travel into buyer situations where the company would not choose to sell, where delivery would be strained, or where a simpler alternative would protect the buyer better.
+
+Good GEO should teach the market the shape of the yes by making the no visible.
+
+## The no-fit signals worth publishing
+
+No-fit language does not mean writing a page that sounds reluctant to sell.
+
+It means giving buyers and answer engines enough practical detail to route demand honestly. The strongest version is specific, useful, and calm. It helps serious buyers self-qualify without making the company sound smaller than it is.
+
+Useful no-fit signals include:
+
+1. Buyer situation. Name the situations where the company is strongest, and the situations where it is not the right first move. A strategic GEO consultancy may be a strong fit for a leadership team trying to understand how answer-led discovery affects pipeline, but a weaker fit for a team that only wants bulk blog production.
+
+2. Constraints. State the constraints that change the recommendation: regulated approvals, procurement requirements, technical access, internal resource, geography, data quality, stakeholder availability, or delivery timelines. Constraints are often where deals become bad-fit late.
+
+3. Maturity. Explain the stage at which the offer creates value. Some buyers need foundation work before a specialist engagement makes sense. Others are too advanced for an entry-level diagnostic and need a deeper operating model or measurement programme.
+
+4. Budget and timing. Avoid hiding commercial reality until the sales call. If the work requires executive attention, implementation capacity, or a budget cycle, say so in buyer-friendly language. That does not mean publishing a rigid price table. It means helping the buyer understand whether the next step is realistic.
+
+5. Category alternatives. Say when another route may be better. A software tool, traditional SEO support, paid media, PR, sales enablement, product marketing, or internal content governance may be the right answer for some situations. Naming this does not weaken the offer. It makes the recommendation more credible.
+
+6. Implementation requirements. If success depends on access to leadership, analytics, web changes, sales feedback, subject-matter expertise, or approval routes, make that visible. Buyers should not discover the operating burden after they have already been persuaded.
+
+7. Proof threshold. Explain what evidence should make a buyer confident. That might include prompt-share diagnostics, answer-language patterns, source audits, sales objections, query classes, public-page gaps, or before-and-after answer reviews. It should be clear what would change the recommendation from "interesting" to "worth funding".
+
+8. Next step. A no-fit signal should not abandon the buyer. It should route them. If they are not ready, point them to a lighter diagnostic, a checklist, a prerequisite, a partner, an internal owner, or a reason to come back when their situation changes.
+
+These signals help the buyer before sales is involved. They also give answer-led surfaces more material to summarise when a user asks whether the company is the right choice.
+
+## Disqualification can increase trust
+
+Many teams avoid public disqualification because it feels commercially risky.
+
+They worry that saying "not for everyone" will shrink the market. They worry competitors will use the language against them. They worry a buyer will self-select out too early. They worry the page will feel negative, defensive, or overly complicated.
+
+Those risks are real if the language is clumsy. A page full of caveats can sound like fear. A list of exclusions can become a legal disclaimer. A harsh qualification gate can make the company feel difficult to buy from.
+
+But that is not the only option.
+
+The better approach is to frame disqualification as buyer guidance. The page is not saying, "Do not buy from us." It is saying, "Here is the situation where we can create the most value, here is where another route may serve you better, and here is how to decide."
+
+That kind of honesty can strengthen the recommendation.
+
+A serious buyer does not trust a company because every sentence is positive. They trust the company because the explanation sounds like it understands the real decision. It names trade-offs without sounding evasive. It recognises constraints without hiding behind them. It gives the buyer enough confidence to carry the recommendation internally.
+
+Answer engines benefit from the same clarity. When a user asks, "Is this agency right for a B2B SaaS company with no internal marketing owner?" or "Should we hire a GEO consultancy or start with technical SEO?" the answer environment needs more than a slogan. It needs public material that distinguishes strong fit from weak fit.
+
+That distinction is not anti-growth. It protects growth from being diluted by the wrong demand.
+
+## A checklist for public qualification
+
+A CMO, Marketing Director, or founder can test the public surface with a simple question:
+
+Could a buyer or answer engine explain when we are not the right recommendation?
+
+If the answer is no, the site is probably over-optimised for attraction and under-built for qualification.
+
+A practical review should ask:
+
+- Do our core pages name the buyer situations where we are strongest?
+- Do they explain the situations where another option may be better?
+- Do they make budget, timing, maturity, and implementation dependencies clear enough for self-selection?
+- Do they distinguish our offer from adjacent categories without turning the page into a comparison essay?
+- Do they explain what evidence should change a buyer's confidence?
+- Do they give no-fit buyers a useful next step instead of a dead end?
+- Do they avoid making every related problem sound like our problem to solve?
+- Do they help sales spend less time correcting bad assumptions?
+- Do they preserve pricing power by preventing weak equivalence with cheaper alternatives?
+- Do they make the recommendation more credible because the boundary is explicit?
+
+This is not only a content exercise. It is a revenue-quality exercise.
+
+Bad-fit demand has a cost. It consumes sales time, muddies forecasting, creates awkward pricing conversations, and teaches the team to mistake activity for traction. In answer-led discovery, that cost can scale quietly because the recommendation may happen before the company sees the buyer.
+
+Public disqualification is how the company starts qualifying earlier.
+
+## The goal is not maximum mentions
+
+Maximum visibility is a tempting metric because it is easy to understand.
+
+More mentions feel better than fewer mentions. Broader inclusion feels better than narrow inclusion. A dashboard moving upward feels like market progress.
+
+But leadership should ask a harder question: are those mentions creating the kind of demand the company can win, serve, and defend?
+
+If the answer is no, the GEO work is incomplete.
+
+The strongest public presence does not only teach answer engines why the company should be recommended. It teaches them the commercial limits of that recommendation. It shows the buyer the right situation, the wrong situation, the constraints, the alternatives, the proof standard, and the next step.
+
+That is how AI visibility protects revenue quality.
+
+Not every buyer should be sent to sales. Not every answer should recommend the company. Not every mention is progress.
+
+The goal is to be recommended for the deals the company can actually win.


### PR DESCRIPTION
## Summary
- Adds the approved Day 80 Build-in-Public post: "Teach Answer Engines When Not to Recommend You".
- Focuses on GEO as public qualification: fit boundaries, no-fit signals, alternatives, constraints, and buyer next steps.
- Keeps the PR payload limited to the new blog post file.

## Verification
- Frontmatter/YAML sanity check passed.
- Forbidden terminology/internal-source sanity check passed.
- `git diff --check` passed.
- `mkdocs build --clean` passed; the build emitted existing nav/roamlinks warnings, but completed successfully.

## Payload
- `docs/blog/posts/daily-blog-day-80.md`
