### PR TITLE
docs: add daily blog day 81

### DIFF
--- a/docs/blog/posts/daily-blog-day-81.md
+++ b/docs/blog/posts/daily-blog-day-81.md
@@ -14,7 +14,7 @@ tags:
   - answer engines
 geo_tactics:
   - Audit the alternatives ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces add to buyer shortlists, separating known rivals from adjacent categories, substitute workflows, tools, agencies, communities, internal teams, and legacy vendors.
-  - Record why each unexpected alternative was included: shared buyer question, overlapping outcome claim, similar proof asset, pricing assumption, category wording, implementation model, audience, or third-party mention.
+  - "Record why each unexpected alternative was included: shared buyer question, overlapping outcome claim, similar proof asset, pricing assumption, category wording, implementation model, audience, or third-party mention."
   - Use the shortlist gap to clarify category language, comparison context, proof standards, sales enablement, and careful disqualification language without turning the exercise into a generic comparison-page programme.
   - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
 ---

--- a/docs/blog/posts/daily-blog-day-81.md
+++ b/docs/blog/posts/daily-blog-day-81.md
@@ -1,0 +1,166 @@
+---
+title: "Day 81: Watch the Alternatives AI Adds to the Shortlist"
+date: 2026-07-10
+slug: "day-81-watch-alternatives-ai-adds-to-shortlist"
+description: "A competitive GEO field note for CMOs, Marketing Directors, and founders: answer engines may place a company beside alternatives the business does not track, from adjacent categories and substitute workflows to internal teams and legacy vendors. Auditing those additions reveals how the market is being categorised before the buyer reaches sales."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - competitive visibility
+  - category strategy
+  - answer engines
+geo_tactics:
+  - Audit the alternatives ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces add to buyer shortlists, separating known rivals from adjacent categories, substitute workflows, tools, agencies, communities, internal teams, and legacy vendors.
+  - Record why each unexpected alternative was included: shared buyer question, overlapping outcome claim, similar proof asset, pricing assumption, category wording, implementation model, audience, or third-party mention.
+  - Use the shortlist gap to clarify category language, comparison context, proof standards, sales enablement, and careful disqualification language without turning the exercise into a generic comparison-page programme.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 81: Watch the Alternatives AI Adds to the Shortlist
+
+Your competitors are not only the companies on your sales team's battlecard.
+
+A buyer can ask ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led surface for options and receive a shortlist that includes familiar rivals, adjacent categories, substitute workflows, tools, agencies, communities, internal hires, old vendors, and "do nothing yet" routes. Some of those alternatives will look strange to the leadership team. Some will be commercially dangerous precisely because they make sense from the public evidence available to the answer engine.
+
+For CMOs, Marketing Directors, and founders, that gap matters. If answer engines build the alternative set differently from the business, sales inherits a different deal from the one marketing thought it was shaping. The buyer arrives with different category expectations, pricing anchors, proof demands, procurement questions, and objections before anyone has had a chance to qualify the opportunity.
+
+Generative Engine Optimization is not only about being visible in the category you choose. It is also about discovering the category AI thinks buyers are shopping in.
+
+<!-- more -->
+
+## Shortlist leakage starts before the form fill
+
+Most competitive work begins with the known set.
+
+The team names the obvious rivals. Product marketing maintains comparison notes. Sales tracks who appears in deals. Leadership watches the companies that pitch similar outcomes, bid for similar budgets, or show up in analyst, search, event, and social conversations.
+
+That work is necessary, but answer-led discovery can widen the frame.
+
+A buyer may not ask, "Which of these three vendors should we choose?" They may ask a broader question:
+
+- "How should a B2B brand improve visibility in AI answers?"
+- "Should we hire a GEO agency, a technical SEO consultancy, or a content team?"
+- "What are the best ways to understand how ChatGPT describes our category?"
+- "Can this be handled in-house?"
+- "Which tools help monitor AI visibility?"
+- "Is this a positioning problem, a web architecture problem, or a sales enablement problem?"
+
+Those questions do not map neatly to the company's internal competitor list. They invite the answer engine to construct a market map.
+
+That map might include direct competitors. It might also include a broader SEO agency, a product analytics platform, an AI visibility dashboard, a public relations firm, a research consultancy, a freelance strategist, a community playbook, an internal content hire, a legacy search vendor, or a sequence of manual audits. The answer engine is not trying to respect your category boundary. It is trying to satisfy the buyer's question from the evidence it can synthesise.
+
+That is where shortlist leakage begins.
+
+The company may be losing budget to alternatives it does not consider competitors. It may be compared against cheaper tools because its public material sounds like reporting. It may be compared against broad agencies because its specialist method is not explained clearly enough. It may be treated as optional advisory work because public pages do not show why the issue affects revenue, trust, qualification, or sales velocity. It may be excluded from a serious shortlist because the answer engine decided the buyer was really asking for software, not expert diagnosis.
+
+By the time the buyer reaches sales, the comparison has already been framed.
+
+## Unexpected alternatives are a market-map signal
+
+An unexpected alternative is not automatically an error.
+
+Sometimes it is noise: a weak answer, a stale source, a badly worded prompt, or an overconfident synthesis. One screenshot should not become a strategy. Different answer environments behave differently, and Google's AI features are shaped by core Search ranking and quality systems rather than a special switch for AI visibility.
+
+But repeated unexpected alternatives are worth studying.
+
+They show how public evidence is causing the market to be grouped. If several answer-led surfaces place a specialist consultancy beside a dashboard product, that may indicate that the public story overemphasises measurement and underexplains judgement, implementation, or strategic interpretation. If the company appears beside content agencies, the answer engine may be reading the offer as production rather than category diagnosis. If an in-house hire is repeatedly suggested, buyers may be asking whether the problem is operational enough to internalise. If old vendors appear, the market may still be using legacy language to understand a newer buying need.
+
+The useful question is not, "Why did the AI get our competitors wrong?"
+
+The useful question is, "What public evidence made that alternative plausible?"
+
+That question turns a frustrating answer into a commercial signal. It can expose category ambiguity, missing comparison context, unclear proof standards, weak positioning, or a buyer problem that the company has not named directly enough. It can also reveal a real buying route the team has ignored because it sits outside the official competitive set.
+
+A buyer does not care whether the alternative belongs in your taxonomy. They care whether it appears to solve the problem.
+
+## How answer engines infer the alternative set
+
+Answer engines build shortlist logic from the material available around the buyer's question.
+
+They may draw from company pages, search-visible snippets, third-party mentions, reviews, comparison articles, public case studies, FAQs, community threads, product pages, directories, documentation, and the wording other companies use to describe similar problems. They may connect options by outcome, role, price point, implementation path, industry, proof type, or adjacent category language.
+
+That means two companies can become alternatives even when they would never appear in the same sales battlecard.
+
+A tool can become an alternative to an agency if both promise visibility monitoring. An internal hire can become an alternative to a consultancy if the public problem sounds like a repeatable process rather than a specialist diagnosis. A broad SEO firm can become an alternative to a GEO specialist if the category page never explains what changes in answer-led discovery. A PR agency can become an alternative if the public narrative is mostly about reputation and mention volume. A legacy vendor can remain an alternative if old category language still dominates the sources buyers and answer engines encounter.
+
+The mechanism is simple: answer engines compress public evidence into a buyer-useful set of choices.
+
+If the public evidence does not make the distinction clear, the distinction may not survive the compression.
+
+This is why the alternative set matters more than a vanity visibility check. A company can be named in the answer and still be placed in the wrong buying contest. It can be recommended while being priced against the wrong substitute. It can be cited while the answer frames the decision around a workflow the company does not want to own.
+
+Visibility inside the wrong alternative set can create the wrong demand.
+
+## Run an alternative-set audit
+
+A practical GEO audit should include a structured look at the alternatives answer engines add.
+
+The goal is not to force every surface into the same list or to chase perfect consistency. The goal is to understand where the market map diverges from the company's own assumptions, then decide which divergences are useful, dangerous, or irrelevant.
+
+Start with buyer questions that resemble real discovery, not artificial prompts designed to flatter the brand. Ask for options, approaches, trade-offs, buying criteria, when to use a tool versus an agency, when to hire internally, what proof to look for, and how different categories solve the same commercial problem.
+
+Then classify the alternatives.
+
+| Alternative type | What to capture | Why it matters |
+|---|---|---|
+| Known competitors | Direct rivals the team already tracks | Confirms whether the expected market appears in answer-led discovery |
+| Adjacent categories | Broader or neighbouring categories that answer the same buyer question | Reveals whether the company is being pulled into a different budget or decision frame |
+| Tool or platform substitutes | Software, dashboards, analytics products, or automation routes | Shows whether the offer is being reduced to reporting, workflow, or self-serve tooling |
+| Agency or service substitutes | Content, SEO, PR, research, strategy, or implementation firms | Shows whether the specialist offer is being blended into a broader service market |
+| In-house alternatives | Hiring, internal teams, manual review, or owned operating processes | Reveals whether buyers see the problem as something to build, not buy |
+| Legacy/vendor alternatives | Older suppliers or established category players | Indicates whether outdated market language still frames the decision |
+| Community or playbook alternatives | Open-source methods, guides, templates, or informal expert routes | Shows where buyers may believe the problem can be solved without a commercial partner |
+
+For each entry, add a plain-language note: why was this included?
+
+That note is the valuable part. Was the alternative included because it promises the same outcome? Because it appears in third-party discussions? Because your page uses broad category language? Because the buyer question was really about measurement, not strategy? Because a competitor has clearer comparison material? Because your proof assets are strong on credibility but weak on the decision criteria buyers care about?
+
+The audit should produce a map of inference, not just a list of names.
+
+## What to do with the signal
+
+Unexpected alternatives do not all require the same response.
+
+Some should be accepted. If buyers genuinely consider an internal hire, a software platform, or a broader agency before choosing a specialist partner, the public material should acknowledge the choice and explain when each route is sensible. That does not mean publishing a hostile comparison page. It means giving the buyer enough context to understand the trade-off.
+
+Some should be corrected. If answer engines repeatedly place the company beside alternatives that do not solve the same problem, the public material may need clearer category language, sharper service boundaries, more specific proof, or better explanation of what the company does and does not replace.
+
+Some should be turned into sales enablement. If buyers arrive with a tool-versus-advisory comparison, sales should have language that explains the difference between measurement and judgement. If buyers compare the offer with an in-house hire, sales should be ready to discuss capability transfer, speed, objectivity, and the cost of learning in public. If buyers compare the company with a legacy vendor, sales should know which assumptions are outdated and which remain valid.
+
+Some should be left alone. Not every strange alternative deserves a campaign. A one-off answer can be noise. A low-intent prompt can produce a broad list. A market-adjacent option may not be worth fighting if it never appears in serious buyer situations.
+
+The discipline is to separate signal from irritation.
+
+Useful responses include:
+
+- clarify the category on high-intent pages so answer engines and buyers know which market the company belongs in;
+- add comparison language that explains routes, trade-offs, and decision criteria without attacking specific competitors;
+- publish proof that supports the buying contest the company wants to be evaluated in;
+- name carefully where a tool, internal hire, broad agency, or legacy route may be better;
+- update sales enablement around the alternatives buyers are actually bringing into conversations;
+- retire or revise public language that makes the offer sound like a different category.
+
+The point is not to control every answer. The point is to reduce avoidable ambiguity in the public record.
+
+## The category AI thinks buyers are shopping in
+
+GEO teams often ask whether answer engines can find the company.
+
+That is only the first layer. The deeper commercial question is whether the answer engine understands the buying contest the company wants to win.
+
+If AI surfaces place the brand beside an unexpected set of alternatives, do not treat that only as a visibility defect. Treat it as market-map evidence. The answer may be showing how buyers are framing the problem when they are not constrained by your website navigation, your sales deck, your internal category labels, or your preferred competitor list.
+
+That can be uncomfortable. It is also useful.
+
+A leadership team may discover that the market sees its offer as a tool replacement, a consulting substitute, a content problem, a research exercise, a reputation issue, an internal capability gap, or a legacy vendor upgrade. Each frame changes the budget owner, the proof required, the price anchor, the sales objection, and the next page the buyer needs.
+
+The companies that learn from those maps will be faster to clarify their position. They will know which comparisons deserve public explanation, which proof assets need to be stronger, which sales objections are being created before the first call, and which category boundaries need to be made visible.
+
+AI may choose the competitive set differently from the business.
+
+That gap is not trivia. It is where demand can leak, where pricing pressure can begin, and where positioning work becomes commercially urgent.
+
+GEO is not only being visible in the category you choose. It is discovering the category AI thinks buyers are shopping in, then making the public evidence strong enough for the right comparison to survive.


### PR DESCRIPTION
## Summary
- Adds the approved Day 81 Build-in-Public post: “Watch the Alternatives AI Adds to the Shortlist”
- Publishes the clean GEO angle on AI-built alternative sets and commercial category-map gaps

## Verification
- Content/frontmatter validation passed: required frontmatter, YAML parseability, title/date/slug, `<!-- more -->`, forbidden/internal terminology scan
- `git diff --check` passed
- `mkdocs build --clean` passed

## Payload
- Intended file only: `docs/blog/posts/daily-blog-day-81.md`
