### PR TITLE
docs: add daily blog day 82

### DIFF
--- a/docs/blog/posts/daily-blog-day-82.md
+++ b/docs/blog/posts/daily-blog-day-82.md
@@ -14,8 +14,8 @@ tags:
   - commercial strategy
 geo_tactics:
   - Map answer-led surfaces to buyer moments such as discovery, comparison, risk checking, objection formation, internal memo writing, and procurement validation before blending them into one AI visibility report.
-  - Build prompt sets around real buyer jobs, not generic brand checks: what the buyer is trying to decide, which surface they are likely to use, and what commercial consequence follows from the answer.
-  - Interpret each surface by role: source exposure, shortlist formation, comparative reasoning, risk language, search-adjacent discovery, or internal explanation rather than treating every mention as the same signal.
+  - "Build prompt sets around real buyer jobs, not generic brand checks: what the buyer is trying to decide, which surface they are likely to use, and what commercial consequence follows from the answer."
+  - "Interpret each surface by role: source exposure, shortlist formation, comparative reasoning, risk language, search-adjacent discovery, or internal explanation rather than treating every mention as the same signal."
   - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
 ---
 

--- a/docs/blog/posts/daily-blog-day-82.md
+++ b/docs/blog/posts/daily-blog-day-82.md
@@ -1,0 +1,169 @@
+---
+title: "Day 82: Match Each Answer Surface to a Buyer Moment"
+date: 2026-07-11
+slug: "day-82-match-each-answer-surface-to-a-buyer-moment"
+description: "A practical GEO buyer-scenario walkthrough for CMOs, Marketing Directors, and founders: ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar answer-led surfaces do not all shape the same commercial moment. Map each surface to the buyer decision it can influence before deciding what to measure, fix, or fund."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - buyer journey
+  - answer engines
+  - commercial strategy
+geo_tactics:
+  - Map answer-led surfaces to buyer moments such as discovery, comparison, risk checking, objection formation, internal memo writing, and procurement validation before blending them into one AI visibility report.
+  - Build prompt sets around real buyer jobs, not generic brand checks: what the buyer is trying to decide, which surface they are likely to use, and what commercial consequence follows from the answer.
+  - Interpret each surface by role: source exposure, shortlist formation, comparative reasoning, risk language, search-adjacent discovery, or internal explanation rather than treating every mention as the same signal.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 82: Match Each Answer Surface to a Buyer Moment
+
+A buyer does not use every AI surface for the same reason.
+
+They may see a Google AI feature while searching a problem. They may ask ChatGPT to explain the category. They may use Perplexity to inspect sources. They may ask Claude to stress-test an argument. They may use Gemini inside a broader research workflow. Each moment can influence the deal, but not in the same way.
+
+That distinction matters for Generative Engine Optimization. If a team treats "AI visibility" as one blended channel, it can measure activity without understanding commercial impact. A brand mention in one surface might shape first awareness. A weak comparison in another might create a sales objection. A cited source in a third might become the evidence a buyer forwards internally. Those are different jobs.
+
+For CMOs, Marketing Directors, and founders, the useful question is not only, "Are we visible in AI answers?"
+
+It is, "Which answer surface is shaping which buyer moment, and what decision does that change?"
+
+<!-- more -->
+
+## The same buyer can meet AI several times
+
+Imagine a marketing director who has been asked to improve how the company appears in AI answers.
+
+The first touch may not be a vendor search. It may be a broad query: "How should a B2B company improve visibility in ChatGPT and Google AI answers?" A Google AI feature or search-adjacent answer can frame the problem as technical SEO, content strategy, entity clarity, digital PR, measurement, or category positioning before the buyer has named a supplier.
+
+Later, the same buyer may ask ChatGPT for a plain-English explanation of what a GEO programme should include. That answer might define the work, set expectations, and create the first mental checklist.
+
+Then the buyer may use Perplexity to inspect sources. Which pages are cited? Which third-party explainers appear? Are competitors, directories, analyst notes, or owned assets shaping the answer? This is a different moment: the buyer is not only asking what to think, but why the answer deserves confidence.
+
+After that, the buyer may ask Claude to compare routes: hire an agency, buy a monitoring tool, ask the SEO team to own it, or build an internal operating model. The answer may produce objections that sales will later hear: cost, ownership, proof, speed, integration, risk, and whether the work is just another content sprint.
+
+By the time procurement or leadership is involved, the question has changed again. The buyer may need language for an internal memo, validation that the investment is not theatre, and a defensible explanation of what the company should fund first.
+
+That is one buying journey. It contains several answer surfaces and several commercial jobs.
+
+A single visibility score cannot explain it.
+
+## Answer-surface segmentation is a commercial discipline
+
+Answer-surface segmentation means assigning a role to each surface before interpreting the output.
+
+The point is not to rank every model by prestige or add every available system to a dashboard. The point is to understand where each surface can affect the buyer's decision.
+
+A practical map might look like this:
+
+| Buyer moment | Likely answer-surface role | What to inspect | Commercial consequence |
+|---|---|---|---|
+| Problem discovery | Search-adjacent answers and broad assistant explanations | How the problem is named, whether the category is framed as urgent, optional, technical, strategic, or experimental | Shapes whether the buyer treats the issue as a board-level risk, a marketing project, or a curiosity |
+| Category education | ChatGPT, Gemini, Claude, and similar assistants | Definitions, recommended approaches, buyer criteria, assumptions about ownership | Creates the buyer's first checklist and internal vocabulary |
+| Source validation | Perplexity, Google AI features, cited answers, and source-visible flows | Which owned, third-party, competitor, directory, or outdated sources support the answer | Determines which public assets carry authority into the buying process |
+| Comparison | Assistants asked for trade-offs, routes, or alternatives | Whether the company is compared with agencies, tools, internal teams, legacy vendors, or adjacent categories | Changes price anchors, shortlist logic, and objection patterns |
+| Risk checking | Claude-style analytical prompts, procurement questions, and sceptical follow-ups | Risks, implementation burdens, proof gaps, fit boundaries, and failure modes | Creates or resolves the objections that slow the deal |
+| Internal memo writing | Long-form assistant synthesis and buyer-created summaries | Whether the answer gives reusable language for leadership, sales, finance, product, or the founder | Determines whether interest can turn into a funded next step |
+
+This is not a universal map. Different markets will need different rows. A regulated enterprise category may place more weight on risk checking and procurement validation. A founder-led B2B service may care more about discovery, comparison, and internal memo language. A local or regional service may need to separate geography and search context more carefully.
+
+The discipline is to make the role explicit.
+
+If a surface has no buyer moment attached to it, the team may still monitor it as research. But it should not be allowed to dominate budget, reporting, or panic.
+
+## A mention is not always the same signal
+
+This is where blended AI visibility metrics become misleading.
+
+Suppose a company is mentioned in ChatGPT when a buyer asks for broad category guidance, absent from a Perplexity answer that cites sources, present in a Google AI feature for a narrow educational query, and compared against self-serve tools in Claude when the buyer asks about implementation routes.
+
+Is that good or bad?
+
+The answer depends on the buyer moment.
+
+The ChatGPT mention may help with early category awareness, but if the explanation is generic, it may not create urgency. The Perplexity absence may be more serious if buyers in that market use source-visible answers to validate authority. The Google AI feature may be valuable if it appears beside a high-intent search journey, but it should be interpreted through normal search quality and relevance rather than a supposed magic AI switch. The Claude comparison may be commercially important if it creates the tool-versus-advisory objection sales now has to handle.
+
+One surface is shaping understanding. One is exposing source authority. One is connected to search behaviour. One is forming objections.
+
+Counting them as four equivalent visibility observations flattens the useful part.
+
+A better GEO report would separate the findings:
+
+- Discovery framing is present, but weak on urgency.
+- Source-visible validation is missing credible third-party support.
+- Search-adjacent visibility exists for educational questions, but not yet for high-intent commercial questions.
+- Comparison answers are pulling the offer into a tool-versus-service frame that sales must be ready to address.
+
+Those observations lead to different work. They might require better category pages, stronger public proof, clearer comparison language, more explicit fit boundaries, revised sales enablement, or a different prompt set.
+
+They do not all require "more AI content".
+
+## Start with buyer jobs, then choose what to measure
+
+The easiest way to avoid model-count theatre is to start with buyer jobs.
+
+Before a team decides which surfaces to track, it should name the decisions buyers actually make:
+
+- How do they first describe the problem?
+- What alternatives do they consider before naming vendors?
+- What evidence do they trust when an answer cites sources?
+- What comparison questions do they ask before speaking to sales?
+- What risks or objections do they test privately?
+- What paragraph do they need to send to a founder, CFO, CMO, sales leader, or board adviser?
+- What would make them delay, disqualify, or downgrade the category?
+
+Only after those questions are clear should the surface list be built.
+
+This changes the measurement conversation. ChatGPT might be included because it shapes category explanation. Perplexity might be included because source visibility matters in that market. Claude might be included because buyers use it for analytical comparison and risk language. Gemini or Google AI features might be included because the buyer journey is tightly connected to search, Workspace, or existing Google behaviour. Another surface might be excluded from executive reporting because it does not map to a meaningful buyer moment yet.
+
+That is not a smaller ambition. It is a sharper one.
+
+The business is no longer asking, "How many systems did we test?" It is asking, "Which buyer decisions can we see more clearly because we tested these systems?"
+
+## What to fix depends on the moment that failed
+
+Answer-surface segmentation also stops teams from applying the same fix to every weak answer.
+
+If discovery framing fails, the public category language may be too vague. The answer engine may not have enough clear material to explain why the problem matters now, who owns it, and what commercial risk follows from ignoring it.
+
+If source validation fails, the issue may be public evidence. The company may need stronger owned pages, better third-party references, clearer case material, updated entity pages, or removal of stale language that keeps being reused.
+
+If comparison fails, the problem may be market positioning. The buyer may be seeing the company beside tools, broad agencies, internal hiring, or legacy suppliers because the public material has not explained the trade-offs between routes.
+
+If risk checking fails, the content may be too promotional. Buyers and answer engines need bounded claims, fit constraints, implementation realities, proof limits, and honest failure modes. Otherwise sceptical prompts will invent the caution for you.
+
+If internal memo writing fails, the asset may explain the topic but not the decision. It may need clearer commercial consequence, stakeholder language, next steps, and a paragraph a serious buyer can reuse without sounding breathless.
+
+The fix follows the failed buyer moment.
+
+That is much more useful than treating every poor answer as a generic visibility defect.
+
+## The board-level question
+
+For leadership, the point of GEO is not to win a screenshot.
+
+The point is to understand where AI-mediated research is changing buyer behaviour: how prospects describe the problem, which routes they compare, what evidence they trust, which objections they form privately, and what language they carry into the internal decision.
+
+That requires a different baseline. Not a blended channel called "AI". Not a trophy roster of models. Not a single visibility number that hides the moment each answer influenced.
+
+A serious baseline should say:
+
+- Which buyer moments matter commercially?
+- Which answer surfaces can influence those moments?
+- What prompts approximate those situations?
+- What outputs count as useful, risky, misleading, or irrelevant?
+- What public assets support the answer?
+- What decision would change if the pattern repeated?
+
+That is the standard that makes AI visibility useful to a CMO, Marketing Director, or founder.
+
+Different answer surfaces do not play the same commercial role. Some introduce the problem. Some organise the category. Some expose sources. Some create comparisons. Some test risk. Some help the buyer explain the decision internally.
+
+Treating all of that as one channel hides the work that matters.
+
+Match the surface to the buyer moment first.
+
+Then decide what to measure, what to fix, and what deserves budget.


### PR DESCRIPTION
## Summary
- Adds Day 82 Build in Public blog post: “Match Each Answer Surface to a Buyer Moment”
- Keeps the public angle focused on answer-surface segmentation by buyer moment
- PR payload is intentionally limited to `docs/blog/posts/daily-blog-day-82.md`

## Checks
- `python3 -m py_compile tools/blog_hook.py tools/build_log.py`
- custom frontmatter/content validation for title, date, slug, H1, forbidden terms, and Google AI caveat
- `python3 -m mkdocs build --clean`

## Notes
- No dedicated frontmatter validator script was present in the repo; used the repo hook syntax check plus a targeted validation script.
