### PR TITLE
docs: add daily blog day 83

### DIFF
--- a/docs/blog/posts/daily-blog-day-83.md
+++ b/docs/blog/posts/daily-blog-day-83.md
@@ -13,8 +13,8 @@ tags:
   - content governance
   - buyer decisions
 geo_tactics:
-  - Test every proposed GEO asset against the new buyer decision it adds: objection, comparison, timing trigger, qualification boundary, evidence need, market distinction, or next step.
-  - Treat near-neighbour drafts as a governance problem, not a writing problem: decide whether to publish, block, rework, consolidate, update an existing asset, or wait for a stronger signal.
+  - "Test every proposed GEO asset against the new buyer decision it adds: objection, comparison, timing trigger, qualification boundary, evidence need, market distinction, or next step."
+  - "Treat near-neighbour drafts as a governance problem, not a writing problem: decide whether to publish, block, rework, consolidate, update an existing asset, or wait for a stronger signal."
   - Prioritise distinct answer/retrieval jobs over article count so buyers and answer-led systems can find clearer material for category education, comparison, qualification, risk checking, and next decisions.
   - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
 ---

--- a/docs/blog/posts/daily-blog-day-83.md
+++ b/docs/blog/posts/daily-blog-day-83.md
@@ -1,0 +1,187 @@
+---
+title: "Day 83: Give the GEO Content Calendar a Stop Rule"
+date: 2026-07-12
+slug: "day-83-give-geo-content-calendar-stop-rule"
+description: "A build-in-public field note for CMOs, Marketing Directors, and founders: a GEO content calendar needs authority to block near-neighbour assets when they add no materially new buyer decision. Publishing restraint protects attention, sales language, and answer-led clarity by forcing every proposed page to earn its place."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - editorial strategy
+  - content governance
+  - buyer decisions
+geo_tactics:
+  - Test every proposed GEO asset against the new buyer decision it adds: objection, comparison, timing trigger, qualification boundary, evidence need, market distinction, or next step.
+  - Treat near-neighbour drafts as a governance problem, not a writing problem: decide whether to publish, block, rework, consolidate, update an existing asset, or wait for a stronger signal.
+  - Prioritise distinct answer/retrieval jobs over article count so buyers and answer-led systems can find clearer material for category education, comparison, qualification, risk checking, and next decisions.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 83: Give the GEO Content Calendar a Stop Rule
+
+The pressure to publish can make a content calendar look more strategic than it is.
+
+A CMO asks for momentum. A founder wants the market to see activity. A marketing director needs something useful for sales, search, social, email, and the next board update. The calendar fills quickly because the category is moving quickly.
+
+But a calendar is not a strategy if it keeps producing near-neighbour arguments. Ten essays that all circle the same decision do not give buyers ten useful steps forward. They consume budget, create review load, give sales no new language, and make the company's position feel more generic precisely when the market needs sharper distinctions.
+
+For Generative Engine Optimization, the useful unit of publishing is not another URL. It is a distinct decision the market can understand, reuse, compare, and retrieve.
+
+That means a mature GEO content system needs a stop rule.
+
+<!-- more -->
+
+## Consistency is valuable until it becomes repetition
+
+Publishing consistently still matters. Markets trust companies that explain their work in public. Buyers need current language for new problems. Answer-led systems need clear public material that describes the category, the company, the proof, the trade-offs, and the conditions where the offer fits.
+
+The problem begins when consistency becomes permission to paraphrase.
+
+A proposed article may have a new title, a fresh hook, and a slightly different example while still answering the same commercial question as last week's asset. It may use different words to tell buyers the same thing: pay attention, gather evidence, clarify ownership, improve the page, monitor the output, build the proof, update the source.
+
+That is not always bad. Some ideas deserve reinforcement across formats. A homepage, a sales page, a playbook, a case study, and a short field note can all carry related points for different moments.
+
+But the distinction has to be explicit. If the new asset does not add a materially different buyer decision, market distinction, answerable question, or public artefact, it should not pass automatically because the calendar has a gap.
+
+The stop rule is simple:
+
+> Do not publish a GEO asset unless it adds a decision the buyer, the market, or an answer-led system could use differently from the assets already live.
+
+That is not an anti-content position. It is a way to keep content commercial.
+
+## The question is not "can we write this?"
+
+Most content teams can write another article.
+
+They can turn a weak idea into a competent post. They can add a framework. They can attach a title to a familiar lesson. They can include examples, bullets, and a practical checklist. If the team is skilled, the result may even read well.
+
+That is exactly why the stop rule matters.
+
+The editorial question should not be, "Can this be written?" It should be, "What does this help a buyer decide that they could not already decide from our public material?"
+
+For a CMO, Marketing Director, or founder, that question changes the value of the calendar. It forces every proposed asset to defend its commercial role:
+
+- Which buyer decision does it support?
+- Which objection does it make easier to answer?
+- Which comparison does it clarify?
+- Which timing trigger does it make visible?
+- Which fit or no-fit boundary does it explain?
+- Which evidence need does it satisfy?
+- Which next step does it make easier for a serious buyer to take?
+
+If the answer is vague, the asset is not ready.
+
+A vague answer sounds like, "This is good for thought leadership," or, "We should say something about this," or, "It supports the theme," or, "The topic is trending." Those may be reasons to investigate. They are not reasons to publish.
+
+A strong answer sounds like, "This asset helps a buyer decide whether the work belongs with marketing, search, product, sales enablement, or the founder," or, "This page explains when a monitoring tool is enough and when judgement is needed," or, "This note gives sales language for the objection that AI visibility is only a content volume problem."
+
+That is a publishable role.
+
+## A practical GEO stop-rule framework
+
+A useful stop rule needs more than taste. Otherwise it becomes a senior person's preference disguised as strategy.
+
+Before a proposed GEO asset enters production, run it through six checks.
+
+| Check | Question to answer | If the answer is weak |
+|---|---|---|
+| Buyer decision | What will a buyer be able to decide after reading this? | Block until the decision is named in plain language. |
+| Novelty versus existing assets | Which live asset is closest, and what does this add that it does not? | Consolidate, update, or rework the idea instead of publishing a neighbour. |
+| Distinct answer job | What answer-led retrieval role does this serve: education, comparison, qualification, risk checking, evidence, timing, or next step? | Reframe the asset around a specific job, not a general topic. |
+| Commercial consequence | What budget, sales, positioning, qualification, or urgency problem does this help solve? | Hold the draft until the business consequence is explicit. |
+| Alternative action | Would an update, FAQ addition, sales note, comparison table, case evidence, or waiting period create more value? | Choose the smaller or better action. |
+| Decision | Publish, block, rework, consolidate, collect evidence, or wait? | Record the decision so the calendar learns. |
+
+The important part is the decision at the end. A stop rule that only produces comments is another review ritual. A stop rule must have authority to change the calendar.
+
+Sometimes the result is publish. The proposed asset adds a distinct question, a sharper commercial distinction, or a public artefact that buyers and answer-led systems can use.
+
+Sometimes the result is rework. The topic is valid, but the frame is lazy. The asset needs to move from "why this matters" into a real decision: when to act, who should own it, what to compare, what evidence to inspect, what not to buy, or how to judge progress.
+
+Sometimes the result is consolidate. The new idea belongs inside an existing page because the buyer would not experience it as a separate decision.
+
+Sometimes the result is collect evidence. The team has a promising claim but not enough public support, customer language, market examples, or internal proof to make the asset useful.
+
+Sometimes the result is wait. The market signal is too thin. Publishing now would turn a hunch into a position.
+
+And sometimes the result is block.
+
+That is a real strategic output.
+
+## Blocking a draft can be the most useful action
+
+Marketing teams often treat a blocked draft as failure: missed velocity, wasted time, awkward silence, a hole in the calendar.
+
+In a GEO programme, blocking can be a capability.
+
+It protects the public proposition from becoming mush. It prevents sales from inheriting five similar explanations with no new buying language. It stops the site from becoming a museum of small variations. It forces the team to notice when the calendar is serving internal momentum rather than market clarity.
+
+Blocking also creates better alternatives.
+
+A draft that fails the stop rule might become:
+
+- an update to a stronger existing page;
+- a new section in a comparison guide;
+- a sales enablement note for a specific objection;
+- an FAQ entry that answers the buyer's actual question;
+- a short proof collection task before publication;
+- a decision tree instead of another essay;
+- a wait-and-watch item until repeated market language appears;
+- a retired idea because the public material already covers the decision well enough.
+
+That is not doing less work. It is redirecting the work to the place where it changes something.
+
+The discipline is especially important for answer-led discovery. ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar surfaces are not looking for a content calendar. They are assembling answers from public material that appears useful to the question being asked. Google's AI features, in particular, rely on core Search ranking and quality systems rather than a special switch created by llms.txt, arbitrary chunking, special AI markup, or over-focused structured data.
+
+The grounded GEO point is more basic: distinct, well-scoped public assets give buyers and answer-led systems clearer material for category education, comparison, qualification, risk checking, and next decisions.
+
+Near-duplicate essays add little new utility. They may be readable. They may be true. They may even be on-brand. But if they do not create a new decision, they are weak strategic units.
+
+## Decision novelty beats article count
+
+Article count is easy to manage. Decision coverage is harder.
+
+A team can report that it published four pieces this month. That sounds productive until leadership asks what changed. Did buyers get a better explanation of the category? Did sales get language for a recurring objection? Did the company clarify a trade-off competitors blur? Did the public material help an answer-led system distinguish the offer from a tool, a broad agency, an internal hire, or a legacy route? Did it make a next step easier?
+
+If the answer is no, the calendar created motion without much market learning.
+
+A decision-led calendar would track a different set of questions:
+
+- Which buyer decisions are already well covered?
+- Which decisions are covered several times without much variation?
+- Which decisions are commercially important but publicly thin?
+- Which objections keep appearing in sales or answer-led outputs?
+- Which comparisons are buyers making before they arrive?
+- Which fit boundaries need to be made clearer?
+- Which claims need evidence before they deserve publication?
+- Which existing pages should absorb new material instead of spawning another URL?
+
+This does not mean every asset must be long or elaborate. A short page can carry a distinct decision. A table can clarify a buying route better than a 1,500-word essay. A revised paragraph on an existing page can be more valuable than a new post. A public artefact, calculator, checklist, prompt set, or comparison note may do more work than another field note.
+
+The format follows the decision.
+
+## The stop rule CMOs should ask for
+
+The executive version of the stop rule is blunt:
+
+> What new buyer decision does this asset add, and what should we do if it does not add one?
+
+That question protects budget and attention. It gives the marketing team permission to refuse content that looks busy but adds little. It gives sales a clearer public library. It gives founders a way to separate category-building from self-imitation. It gives answer-led systems less ambiguous material to work with.
+
+It also makes the calendar more honest.
+
+Some weeks, the strongest editorial decision will be to publish. The market needs a new explanation, a new comparison, a new proof point, or a new operating model.
+
+Some weeks, the strongest decision will be to improve what already exists.
+
+Some weeks, the strongest decision will be to wait until there is a real signal.
+
+That restraint is uncomfortable because content operations are often measured by visible output. But GEO work is not rewarded by volume alone. The public record has to make distinctions buyers can use.
+
+A mature GEO content calendar should therefore contain more than topics and dates. It should contain the authority to say no.
+
+Not because consistency does not matter.
+
+Because consistency only compounds when each new asset adds a decision worth compounding.


### PR DESCRIPTION
## Summary

- Adds Day 83 Build in Public post: "Give the GEO Content Calendar a Stop Rule".
- Applies the approved/revised editorial artifact only.
- Keeps the PR payload limited to `docs/blog/posts/daily-blog-day-83.md`.

## Checks

- `python3` frontmatter/content validation: pass
- `git diff --cached --check`: pass
- `mkdocs build --clean`: pass (existing MkDocs/roamlinks/autolinks warnings only; build completed)

## Payload check

- `git diff --name-only origin/main...HEAD`: `docs/blog/posts/daily-blog-day-83.md`
