### PR TITLE
docs: add daily blog day 84

### DIFF
--- a/docs/blog/posts/daily-blog-day-84.md
+++ b/docs/blog/posts/daily-blog-day-84.md
@@ -1,0 +1,188 @@
+---
+title: "Day 84: A Good GEO Baseline Should Shrink the Scope"
+date: 2026-07-13
+slug: "day-84-good-geo-baseline-should-shrink-scope"
+description: "A buyer-facing GEO diagnostic memo for CMOs, Marketing Directors, and founders: a useful AI Visibility Baseline should reduce the work under consideration, not expand it. The right diagnostic separates fix now, test next, monitor, and do not fund yet so budget follows evidence rather than anxiety."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - diagnostics
+  - budget discipline
+  - commercial strategy
+geo_tactics:
+  - Use an AI Visibility Baseline to narrow the next investment, not to create a broad shopping list across content, technical work, tooling, positioning, monitoring, and workflow redesign.
+  - Classify findings into fix now, test next, monitor, and do not fund yet by buyer impact, repeated answer-engine pattern, competitor presence, answer quality, visible source evidence, technical retrievability, confidence, and implementation effort.
+  - Treat absence, weak citations, competitor inclusion, stale source use, technical retrievability gaps, and inconclusive prompt runs as different diagnostic findings that justify different interventions.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 84: A Good GEO Baseline Should Shrink the Scope
+
+A bad diagnostic makes the work bigger.
+
+It starts with a reasonable question: how visible are we in AI answers? Then it returns with a swollen list of recommendations. Publish more content. Buy a monitoring platform. Rewrite the homepage. Fix technical SEO. Create comparison pages. Improve structured data. Update old posts. Brief sales. Track competitors. Review citations. Run monthly prompts. Build a dashboard. Start a broader GEO programme.
+
+Some of those actions may be right. The problem is that the diagnostic has not decided which one matters first.
+
+For a CMO, Marketing Director, or founder, that is not a small failure. A baseline is supposed to reduce uncertainty before budget is committed. If it recommends content, tooling, technical work, positioning, monitoring, and workflow redesign all at once, it has not clarified the investment. It has expanded the anxiety.
+
+A good Generative Engine Optimization baseline should do the opposite.
+
+It should shrink the scope.
+
+<!-- more -->
+
+## The baseline is not a permission slip for every possible fix
+
+AI visibility work touches many parts of the business because answer-led discovery is not a single channel.
+
+A buyer may ask ChatGPT for category education, use Perplexity to inspect sources, meet Google AI features inside a search journey, ask Claude to compare routes, or use Gemini as part of a broader research flow. The answer may mention the brand, omit it, cite a competitor, summarise an old page, describe the offer too broadly, expose a technical source problem, or return a result too noisy to trust.
+
+Those observations do not all mean the same thing.
+
+A competitor appearing in a high-intent comparison prompt is different from the brand being absent in a broad educational prompt. A stale owned page shaping an answer is different from no visible citation. A weak technical source path is different from vague positioning. A single odd answer is different from a repeated pattern across commercially important prompts.
+
+The baseline should separate those conditions before prescribing work.
+
+Otherwise the buyer receives a catalogue of plausible interventions rather than a decision. The report may be long. The dashboard may be polished. The screenshots may be interesting. But the leadership question remains unanswered:
+
+> What should we fund first, and what should we explicitly not fund yet?
+
+That is the test.
+
+## Scope reduction is buyer value
+
+Restraint is not a lack of ambition. It is part of the value of the diagnostic.
+
+A leadership team does not buy a baseline because it wants more ways to spend money. It buys a baseline because it needs evidence before choosing the next move. The team may suspect that answer engines are shaping shortlists before buyers reach sales. It may see competitors appearing in AI answers. It may worry that old public material is being reused. It may be under pressure to fund GEO without knowing whether the first move should be content, technical cleanup, measurement, positioning, or sales enablement.
+
+The baseline earns its keep by narrowing that field.
+
+A useful report might say:
+
+- Do not buy a broad monitoring tool yet; the prompt set is not stable enough.
+- Do not brief ten new articles; the highest-risk gap is one comparison page.
+- Do not chase Google AI visibility through special markup; improve the underlying page quality, relevance, and source clarity.
+- Do not rewrite the whole site; one stale offer page is creating most of the confusion.
+- Do not start a six-month content programme; run a two-week source and competitor test first.
+- Do not fund a technical sprint yet; the issue is weak commercial positioning, not retrievability.
+
+Those are not negative findings. They are useful findings.
+
+They protect budget from being scattered across every surface that might matter. They also protect the team from mistaking a broad list of actions for strategy.
+
+## A simple decision table beats a bigger backlog
+
+The output of an AI Visibility Baseline should be small enough to act on.
+
+One practical way to force discipline is to translate findings into a decision table:
+
+| Finding | Safe conclusion | Smallest next move | What not to fund yet |
+|---|---|---|---|
+| The brand is absent from repeated high-intent comparison prompts, while two competitors recur with clear source support. | The commercial risk is competitor framing in a buyer decision moment, not generic low awareness. | Build or improve the comparison/route-choice asset that explains the buying criteria and why the category matters. | Do not fund a broad blog sprint or a model-count dashboard until the comparison gap is addressed. |
+| Answers mention the brand but describe the offer as a reporting tool rather than a diagnostic service. | Visibility exists, but the market frame is commercially wrong. | Rewrite the core offer explanation and supporting proof around diagnosis, judgement, and next-decision clarity. | Do not celebrate mention count as progress or buy more monitoring to watch the same misclassification. |
+| Source-visible answers cite an old page that no longer represents the offer. | The public record is teaching the wrong story. | Retire, redirect, consolidate, or supersede the stale source and make the current canonical explanation easier to find. | Do not publish more neighbouring pages that add another version of the story. |
+| Technical inspection shows key proof assets are hard to crawl, parse, attribute, or connect to buyer questions. | Technical retrievability may be limiting reuse, but it does not prove answer-engine causality by itself. | Fix access, structure, metadata, internal linking, canonical signals, and answer-ready page clarity for the priority assets. | Do not claim technical hygiene guarantees citations or rankings. |
+| One prompt run produces a strange omission, but repeated runs and related buyer scenarios are inconsistent. | The signal is not decision-grade yet. | Monitor the pattern, refine the prompt set, and rerun before changing public assets. | Do not fund a rewrite based on one dramatic screenshot. |
+| Google AI features do not surface the brand for a target query. | Treat the issue through normal search quality, relevance, and public evidence discipline. | Improve the underlying page usefulness, source quality, search-visible explanation, and fit to the query. | Do not treat llms.txt, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google AI visibility. |
+
+The table is not the whole strategy. It is the forcing function.
+
+It makes the diagnostic name the finding, the confidence level, the smallest credible next move, and the work that should stay unfunded for now.
+
+That last column matters. Without it, every recommendation becomes additive. With it, the baseline becomes a budget-control tool.
+
+## Different findings deserve different verbs
+
+A weak baseline uses one verb for every problem: optimise.
+
+Optimise for citations. Optimise for AI visibility. Optimise for answer engines. Optimise the site. Optimise the content. Optimise the technical layer.
+
+That language sounds active, but it hides the decision.
+
+A better baseline uses more precise verbs:
+
+- Fix when the finding is repeated, commercially material, and tied to a clear public source or buyer decision.
+- Test when the pattern is plausible but the confidence is not yet strong enough for a broad change.
+- Monitor when the observation may matter, but the cost of immediate action is higher than the evidence justifies.
+- Park when the issue is interesting but not connected to a current buyer moment, revenue risk, competitor pressure, or implementation path.
+- Retire when stale public material is creating more confusion than value.
+- Consolidate when multiple pages are competing to answer the same buyer question.
+- Clarify when answer engines and buyers can see the company but are learning the wrong category, fit, or route.
+
+Those verbs turn the baseline from a report into a decision system.
+
+They also stop the team from using the same fix for every output. Absence does not automatically mean more content. A citation gap does not automatically mean technical work. Competitor presence does not automatically mean a comparison page. Volatility does not automatically mean a dashboard. A bad answer does not automatically mean the website is wrong.
+
+The diagnosis has to decide.
+
+## What a good baseline should rule out
+
+The most commercially honest part of a baseline may be the work it refuses to recommend.
+
+That can feel uncomfortable because buyers often expect a report to contain a long action plan. Agencies often feel pressure to show ambition. Internal teams may want a larger programme because a larger programme looks more strategic.
+
+But the first diagnostic should not behave like a proposal for every service the provider can sell.
+
+It should be able to rule out low-value interventions:
+
+- A monitoring subscription before the team knows which buyer prompts are worth monitoring.
+- A bulk content sprint before the diagnosis identifies which buyer decision is publicly thin.
+- Technical changes framed as AI shortcuts when the evidence only supports ordinary source-quality improvements.
+- A full positioning rewrite when the problem is one poorly explained offer boundary.
+- A comparison-page programme when the competitor pattern appears only in low-intent prompts.
+- A monthly executive dashboard when the baseline itself is not versioned enough for trends.
+- A broader GEO retainer when the immediate need is a contained source, prompt, or page fix.
+
+This is not anti-growth. It is how a serious buyer learns whether the provider can distinguish opportunity from opportunism.
+
+A diagnostic that only says "more" is easy to sell and hard to trust.
+
+A diagnostic that says "not yet" earns more confidence.
+
+## The scope should expand only after evidence earns it
+
+There are moments when the baseline should lead to a larger programme.
+
+If repeated prompts show commercially important competitor displacement, if high-intent answer surfaces cite weaker third-party sources, if stale pages keep shaping the offer, if answer quality repeatedly creates bad-fit demand, if technical source problems affect the strongest proof assets, or if leadership needs recurring measurement across markets, then a broader GEO programme may be justified.
+
+But the expansion should be earned by the evidence.
+
+The sequence should be clear:
+
+1. Define the buyer questions and commercially important surfaces.
+2. Capture current visibility, source paths, competitors, answer quality, technical retrievability, and limitations.
+3. Separate repeated patterns from noise.
+4. Classify findings by buyer impact, confidence, effort, and reversibility.
+5. Choose the smallest next move that can change the highest-value issue.
+6. Decide what to monitor or park.
+7. Re-test before expanding the work.
+
+That sequence protects the buyer from overbuying. It also protects the provider from pretending certainty that the evidence does not support.
+
+No answer engine can be controlled deterministically. ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar surfaces vary by product, model, interface, geography, source visibility, freshness, and prompt context. Google's AI features in particular rely on core Search ranking and quality systems; they are not activated by llms.txt, special AI markup, arbitrary chunking, or over-focused structured data.
+
+That uncertainty is exactly why the baseline should narrow decisions rather than inflate them.
+
+## The executive question
+
+The best question to ask after a GEO baseline is not, "How many problems did we find?"
+
+It is:
+
+> Which work can we safely avoid because the evidence does not justify it yet?
+
+That question changes the value of the report.
+
+It forces the baseline to separate urgent from interesting, repeated from anecdotal, buyer-facing from internal, technical from commercial, and fixable from inconclusive. It makes the action plan smaller, sharper, and easier to defend. It gives the CMO, Marketing Director, or founder a way to protect budget without ignoring the shift in buyer behaviour.
+
+A good AI Visibility Baseline should leave the team with fewer open questions than it started with: what to fix now, what to test next, what to monitor, and what not to fund yet.
+
+That is the difference between a diagnostic and a shopping list.
+
+A shopping list expands the work.
+
+A diagnostic shrinks the scope until the next move is obvious enough to justify.


### PR DESCRIPTION
## Summary
- Adds Day 84 Build in Public post: “A Good GEO Baseline Should Shrink the Scope”
- Applies the approved final editorial artifact only
- Keeps the PR payload to a single blog post file

## Verification
- Reviewer verdict consumed: APPROVED
- Research audit consumed: OVERLAP_CLEAR
- Frontmatter/content schema check: PASS
- `mkdocs build`: PASS (completed with existing roamlinks/autolinks warnings)
- Payload check before PR: `docs/blog/posts/daily-blog-day-84.md` only
