### PR TITLE
docs: publish daily blog day 85

### DIFF
--- a/docs/blog/posts/daily-blog-day-85.md
+++ b/docs/blog/posts/daily-blog-day-85.md
@@ -14,7 +14,7 @@ tags:
   - commercial strategy
 geo_tactics:
   - Inspect commercially meaningful prompts for how answer-led surfaces classify the offer, which criteria they apply, which alternatives they present, and whether the pattern repeats across buyer moments.
-  - Treat category compression as a commercial failure mode: the brand may be visible while buyers inherit the wrong price anchor, procurement route, implementation expectation, success metric, and competitor set.
+  - "Treat category compression as a commercial failure mode: the brand may be visible while buyers inherit the wrong price anchor, procurement route, implementation expectation, success metric, and competitor set."
   - Repair public category language with clearer offer boundaries, examples, comparisons, proof, fit and no-fit cues, and third-party references; do not imply that any single page guarantees answer-engine inclusion.
   - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
 ---

--- a/docs/blog/posts/daily-blog-day-85.md
+++ b/docs/blog/posts/daily-blog-day-85.md
@@ -1,0 +1,178 @@
+---
+title: "Day 85: When AI Puts You in the Wrong Buying Category"
+date: 2026-07-14
+slug: "day-85-when-ai-puts-you-in-wrong-buying-category"
+description: "A concrete GEO failure-mode mini teardown for CMOs, Marketing Directors, and founders: answer engines can mention a company while placing it in the wrong buying category. Category compression changes evaluation criteria, price anchors, procurement routes, expectations, and competitors before sales ever enters the conversation."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - category positioning
+  - buyer journey
+  - commercial strategy
+geo_tactics:
+  - Inspect commercially meaningful prompts for how answer-led surfaces classify the offer, which criteria they apply, which alternatives they present, and whether the pattern repeats across buyer moments.
+  - Treat category compression as a commercial failure mode: the brand may be visible while buyers inherit the wrong price anchor, procurement route, implementation expectation, success metric, and competitor set.
+  - Repair public category language with clearer offer boundaries, examples, comparisons, proof, fit and no-fit cues, and third-party references; do not imply that any single page guarantees answer-engine inclusion.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, or over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 85: When AI Puts You in the Wrong Buying Category
+
+The dangerous answer is not always the one that ignores you.
+
+Sometimes the brand appears. The summary sounds positive. The buyer can see the company name in ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led surface. Marketing can screenshot the mention and call it progress.
+
+But the answer has quietly put the offer in the wrong buying category.
+
+A diagnostic becomes a dashboard. A managed service becomes software. A specialist partner becomes a generic agency. A strategic workflow becomes a one-off audit. A category-defining offer becomes a familiar line item the buyer already knows how to price, compare, delay, and delegate.
+
+For a CMO, Marketing Director, or founder, that is not a small wording problem. It changes the deal before the buyer reaches sales. The buyer inherits the wrong evaluation criteria, the wrong price anchor, the wrong procurement route, the wrong implementation expectation, and the wrong competitor set.
+
+The company is visible, but it is being evaluated as something else.
+
+That is category compression.
+
+<!-- more -->
+
+## Visibility can still send the buyer into the wrong frame
+
+A lot of AI visibility work starts with a binary question: are we mentioned or not?
+
+That question is useful, but it is not enough. Presence does not prove that the answer has understood the commercial shape of the offer.
+
+Imagine a buyer asking an answer engine for ways to understand why pipeline quality is falling after a positioning change. The company being evaluated sells a diagnostic service: it interviews sales, inspects public category language, reviews answer-led discovery prompts, checks competitor framing, and returns a small set of commercial decisions. The value is not the report itself. The value is narrowing the cause of confusion so leadership can decide what to fix, test, or stop funding.
+
+The answer engine mentions the company, but describes it as a marketing analytics dashboard.
+
+That sounds adjacent enough to pass a casual visibility check. It may even feel flattering. The company is being named in a buying conversation.
+
+But the frame has shifted.
+
+The buyer now expects logins, charts, integrations, monthly reporting, seats, feature comparisons, and software pricing. They compare the company with platforms. They ask whether the tool connects to their CRM. They wonder why a service-led diagnostic costs more than a dashboard subscription. They may route the evaluation to marketing operations instead of the CMO. They may assume implementation is a technical rollout rather than a leadership decision about category, offer, proof, and sales language.
+
+The lead is not cold. It is misframed.
+
+Sales can try to correct that on the call, but by then the buyer has already brought the wrong mental model into the room.
+
+## The commercial damage is in the inherited criteria
+
+Wrong-category answers matter because categories carry default buying rules.
+
+A buyer shopping for software asks different questions from a buyer choosing a diagnostic partner. A buyer comparing agencies uses different criteria from a buyer evaluating a managed workflow. A buyer looking for an audit expects a different relationship from a buyer funding an ongoing operating rhythm.
+
+Category compression changes the default checklist.
+
+If a diagnostic is presented as a dashboard, the buyer may ask:
+
+- How many integrations are included?
+- Can my team export the data?
+- How does the subscription compare with lower-cost tools?
+- Will this replace our existing reporting stack?
+- Why do we need senior advisory time if the product shows the answer?
+
+Those are rational questions for the wrong category.
+
+If a managed workflow is presented as a one-off audit, the buyer may ask:
+
+- Can we just run this once?
+- Why would there be a review cadence?
+- Why does the work involve sales, product, and leadership rather than only marketing?
+- Can a cheaper freelancer produce the same document?
+
+Again, rational questions for the wrong category.
+
+The answer engine has not merely used an imprecise label. It has imported a buying system. That system affects budget, urgency, stakeholder ownership, implementation effort, and perceived alternatives.
+
+This is why "we were mentioned" can be a dangerously shallow success metric. A mention inside the wrong category can create demand that looks promising in reporting and exhausting in sales.
+
+## A mini teardown: the dashboard that should have been a diagnostic
+
+Take the generalized dashboard-versus-diagnostic example.
+
+The company wants to be understood as a commercial diagnostic partner for answer-led discovery. Its work helps leadership understand whether AI-shaped buyer research is presenting the company accurately, putting it in the right category, and sending prospects toward useful next decisions.
+
+In public, however, its language is mixed. One page says "AI visibility dashboard." Another says "monitor your brand across AI search." A case-style page talks about "monthly tracking." A comparison page lists features beside software tools. The homepage mentions strategic diagnosis, but the clearest repeated phrases are tracking, reporting, monitoring, and dashboard.
+
+An answer engine has to compress that public material into a short answer. It chooses the familiar bucket: tool.
+
+Now the buyer asks for "best AI visibility dashboards for B2B brands" and the company appears beside software vendors. The answer may not be malicious or wildly inaccurate. It is synthesising from the source-visible language available to it. The problem is that the public corpus has made the wrong category easier to infer than the right one.
+
+A practical teardown would separate four layers:
+
+1. What category did the answer assign?
+2. Which buying criteria followed from that category?
+3. Which public sources or repeated phrases made that category plausible?
+4. What category boundary needs to be made clearer?
+
+The repair is not "publish more content" as a reflex. The repair is to make the intended buying frame harder to miss.
+
+That might mean replacing loose dashboard language with diagnostic language where the business truly sells diagnosis. It might mean adding a page that explains when a baseline, sprint, managed workflow, or software tool is the right route. It might mean showing examples of decisions produced, not only outputs delivered. It might mean naming no-fit situations so answer engines and buyers do not treat the offer as a universal platform. It might mean improving third-party descriptions that keep calling the company an agency, a tool, or a consultant when the real offer is more specific.
+
+The point is not to control every answer. You cannot.
+
+The point is to stop feeding public language that makes the wrong category the easiest summary.
+
+## Run a category-compression check
+
+A useful check starts with commercially meaningful prompts, not vanity prompts.
+
+Do not only ask whether the brand appears. Ask questions that reveal the frame around the brand:
+
+- "What type of company is [brand]?"
+- "When would a CMO hire [brand]?"
+- "Is [brand] a tool, agency, consultancy, diagnostic service, or managed workflow?"
+- "What should a buyer compare [brand] with?"
+- "What criteria should a Marketing Director use to evaluate [brand]?"
+- "What alternatives should a founder consider if they are trying to solve [problem]?"
+- "What kind of budget or implementation effort should a buyer expect?"
+
+Then inspect the answers for category signals.
+
+Look at the nouns used to classify the offer. Look at the verbs used to describe what the buyer does with it. Look at the alternatives suggested. Look at the criteria applied. Look at whether the answer treats the work as a tool purchase, a content project, an audit, a service relationship, a strategic diagnostic, or an operating workflow.
+
+The pattern matters more than a single odd result. Repeat the check across important buyer moments and answer-led surfaces. A Google AI feature inside a search journey, a ChatGPT category explanation, a Perplexity answer with visible sources, a Claude comparison prompt, and a Gemini research flow may each expose different evidence and assumptions. Do not flatten them into one score.
+
+Also separate source-visible confusion from opaque summarisation. If the answer cites or surfaces pages that use the wrong category language, the repair route is clearer. If the answer gives no visible source trail, you can still inspect the public material that makes the wrong frame plausible, but you should be more careful about causal claims.
+
+## Repair the boundary, not just the wording
+
+Category repair is not a synonym swap.
+
+If the public explanation says "diagnostic" once and "dashboard" everywhere else, the answer engine is not being unreasonable when it chooses dashboard. If the sales deck says strategic partner but the site only proves article production, the market will not infer a deeper offer because leadership intended one. If third-party references describe the company as a generic agency, owned pages need enough clarity and proof to make the more specific frame credible.
+
+The repair should touch the boundary of the offer:
+
+- What problem does this category solve that adjacent categories do not?
+- What decision does the buyer make after using it?
+- What is included, and what is explicitly not included?
+- What should the buyer compare it with, and what should they not compare it with?
+- Which proof shows the intended category in practice?
+- Which examples demonstrate the working relationship, not only the deliverable?
+- Which third-party descriptions or directory entries are reinforcing the wrong bucket?
+
+For GEO work, that boundary has to be public enough to be reused. Answer-led surfaces can draw on public pages, search results, third-party references, snippets, citations, and broader web signals. Clearer category language, offer boundaries, examples, comparisons, proof, and fit cues can support better understanding.
+
+Support is the right word. It does not guarantee inclusion, phrasing, ranking, or citation.
+
+The same limitation applies to Google AI features. Google's AI experiences rely on core Search ranking and quality systems. `llms.txt`, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility. Technical hygiene can matter, but it does not replace the underlying job: make the public explanation accurate, useful, and worthy of being understood.
+
+## The leadership question
+
+The useful question is not only:
+
+> Are answer engines mentioning us?
+
+The better question is:
+
+> When they mention us, what buying category do they put us in?
+
+That question is sharper because it connects visibility to revenue reality. It tells the CMO whether demand is arriving with the right expectations. It tells the Marketing Director which pages, comparisons, examples, and proof points are doing category work. It tells the founder whether the market is learning the company as the business actually sells it.
+
+A wrong-category mention can still look like progress in a report. It can still produce screenshots. It can still create traffic, leads, and sales conversations.
+
+But if the buyer arrives expecting the wrong thing, the commercial system has already been bent.
+
+Before celebrating mention volume, inspect the frame. If the category is compressed, repair the boundary first.


### PR DESCRIPTION
## Summary
- Publish Day 85 blog post from the approved final artifact
- Add only `docs/blog/posts/daily-blog-day-85.md`
- Preserve approved copy; the only repo-side adjustment is YAML quoting for one `geo_tactics` item so CI frontmatter validation parses it as a string

## Verification
- Reviewer verdict consumed: APPROVED
- Validated title/date/slug/frontmatter, Google caveat, `<!-- more -->`, and forbidden internal terms
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-85.md` passed
- `python3 -m py_compile tools/blog_hook.py tools/build_log.py` passed
- `mkdocs build --strict` failed on existing site warnings
- `mkdocs build` passed
- PR payload verified as exactly `docs/blog/posts/daily-blog-day-85.md`
- PR checks passed: `validate`, `Cloudflare Pages`

## Notes
- Strict-mode warnings are existing roamlinks/nav warnings; non-strict build completes successfully.
