### PR TITLE
docs: add day 87 build in public post

### DIFF
--- a/docs/blog/posts/daily-blog-day-87.md
+++ b/docs/blog/posts/daily-blog-day-87.md
@@ -14,9 +14,9 @@ tags:
   - commercial decision-making
 geo_tactics:
   - Treat every captured AI answer as a time-bound observation, not permanent market truth, before using it to support budget, positioning, sales, or competitive decisions.
-  - Record only the context needed to interpret or retest the observation: prompt wording, surface, observable model or version where available, geography or buyer context where relevant, source state, and capture date.
+  - "Record only the context needed to interpret or retest the observation: prompt wording, surface, observable model or version where available, geography or buyer context where relevant, source state, and capture date."
   - Assign each observation a review-by date or event trigger, such as a model replacement, important launch, material public-page change, repeated competitor movement, or board and budget decision.
-  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
 ---
 
 # Day 87: Put an Expiry Date on Every AI Answer

--- a/docs/blog/posts/daily-blog-day-87.md
+++ b/docs/blog/posts/daily-blog-day-87.md
@@ -1,0 +1,136 @@
+---
+title: "Day 87: Put an Expiry Date on Every AI Answer"
+date: 2026-07-16
+slug: "day-87-put-an-expiry-date-on-every-ai-answer"
+description: "A practical GEO measurement note for CMOs, Marketing Directors, and founders: answer-engine observations are time-bound management evidence. Record the capture context and define the review-by date or event trigger before an old AI answer is allowed to authorise a current commercial decision."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - measurement
+  - answer engines
+  - commercial decision-making
+geo_tactics:
+  - Treat every captured AI answer as a time-bound observation, not permanent market truth, before using it to support budget, positioning, sales, or competitive decisions.
+  - Record only the context needed to interpret or retest the observation: prompt wording, surface, observable model or version where available, geography or buyer context where relevant, source state, and capture date.
+  - Assign each observation a review-by date or event trigger, such as a model replacement, important launch, material public-page change, repeated competitor movement, or board and budget decision.
+  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility.
+---
+
+# Day 87: Put an Expiry Date on Every AI Answer
+
+An AI answer is not a permanent piece of market truth. It is an observation made under specific conditions.
+
+That distinction matters when the answer leaves the analyst's screen and enters management reporting. A screenshot from ChatGPT, Claude, Perplexity, Gemini, or a Google AI feature can feel more durable than it is. It gets pasted into a deck. It becomes evidence for a budget request. It supports a sales enablement claim. It shapes a positioning argument. It informs a competitor response.
+
+Then the market moves, the public source set changes, the prompt changes, a model changes, a competitor launches, or the company itself updates its story. The old answer may still be useful history. It should not automatically remain current authority.
+
+<!-- more -->
+
+## The commercial problem is not that old answers are false
+
+A captured answer can be accurate on the day it was collected and still become unsafe for today's decision.
+
+That is the point many AI visibility reports miss. The question is not simply whether the answer was real. It was. The more important leadership question is whether it is current enough for the decision now being made.
+
+A CMO might be deciding whether to shift budget into a new GEO workstream. A Marketing Director might be rewriting sales language because several answer-led surfaces framed the offer in a certain way. A founder might be responding to a competitor that appeared unusually often in buyer prompts. In each case, the observation has a commercial consequence.
+
+If the evidence is old, unlabelled, or detached from its capture context, the team can end up treating a historical artefact as a current market signal. That is how stale internal evidence starts steering spend, claims, sales language, positioning, and competitive response.
+
+Historical does not mean wrong. It means the observation has changed state. It needs to be read as history unless it is retested or explicitly judged current for the decision at hand.
+
+## Every observation needs a validity rule
+
+AI-answer evidence should have a simple lifecycle:
+
+| State | Meaning | Management use |
+|---|---|---|
+| Captured | The answer was observed under recorded conditions. | Useful as evidence that this answer occurred, not yet a standing decision rule. |
+| Current for this decision | The observation is recent and relevant enough for the specific choice being made. | Can inform budget, positioning, sales, content, or competitive action. |
+| Retest trigger / review-by | A date or event says when the observation must be checked again. | Blocks the team from reusing old evidence without refreshing it. |
+| Superseded or historical | A newer observation, changed market condition, or expired review point has moved it out of current use. | Preserved for context, trend notes, and learning, but not used as live authority. |
+
+The important phrase is “for this decision”. A low-risk wording check may tolerate older evidence than a board-level budget decision. A competitor launch may make last month's answer too old. A material repositioning may make yesterday's screenshot stale if the source state has changed. A repeated pattern across surfaces may deserve a different review cadence from a one-off answer captured during exploration.
+
+There is no fixed calendar rule that works across all situations. The validity rule should be tied to the decision, the volatility of the market, and the events that would make the observation commercially unsafe to reuse.
+
+## Capture enough context to retest, not enough to create theatre
+
+The answer record does not need to become compliance admin. It needs to preserve the context that changes interpretation.
+
+A practical observation record might include:
+
+| Field | Why it matters |
+|---|---|
+| Decision supported | Prevents a generic screenshot from being reused for a different commercial question. |
+| Prompt wording | Small wording changes can produce meaningfully different answer behaviour. |
+| Surface | ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led experiences do not play identical roles. |
+| Observable model or version | Use it where visible, but do not pretend stable identifiers are always available. |
+| Geography, language, or buyer context | Relevant when location, market, sector, or buyer situation changes the expected answer. |
+| Capture date | Separates the observation from the decision date. |
+| Source state | Notes whether important public pages, third-party references, or cited sources have materially changed since capture. |
+| Review-by date or event trigger | Defines when the observation must be refreshed before further decision use. |
+| Current state | Captured, current for this decision, retest required, superseded, or historical. |
+
+The discipline is not to record everything. The discipline is to record the details that help a team interpret, reproduce, or responsibly retire the observation.
+
+That also keeps the report honest about limits. Some surfaces expose citations; some do not. Some show model information clearly; some do not. Personalisation, geography, account state, retrieval behaviour, and prompt wording can all matter. A good record labels what is known, what is unknown, and what would require a retest.
+
+## Review triggers beat arbitrary expiry windows
+
+Expiry should be driven by decision risk and market change, not by a universal calendar rule.
+
+Useful triggers include:
+
+- a model, surface, or visible answer experience changes in a way that could affect the result;
+- the company launches, repositions, renames, changes its offer, or materially updates a key public page;
+- a competitor changes category language, publishes major proof, launches a new offer, or starts appearing repeatedly in relevant answer observations;
+- a board, budget, campaign, sales enablement, or pricing decision is about to rely on the evidence;
+- the public source set has changed enough that the old answer may no longer represent the current corpus;
+- repeated prompt runs show a materially different pattern from the stored observation.
+
+This turns AI visibility measurement from a static evidence pile into a living decision system. The report does not just say what was seen. It says when that observation must stop carrying authority.
+
+That distinction is especially important for executive reporting. Leadership does not need every prompt transcript in the board pack. It needs to know which observations are current enough to act on, which require retesting before money moves, and which are now historical context.
+
+## Do not confuse Google caveats with answer expiry
+
+Google's AI features need careful handling in this conversation.
+
+The right caveat is still the boring one: Google's AI experiences are connected to core Search ranking and quality systems. There is no magic requirement that a brand must publish `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data to become visible in Google AI answers.
+
+That does not remove the need for observation expiry. It means the validity rule should be about evidence discipline, not mythical switches. If a Google AI feature produces a useful answer today, record the surface, prompt, date, location or context where relevant, visible sources where available, and the decision it supports. Then define what would require a retest before the answer is used again.
+
+The same principle applies across answer-led surfaces. A captured answer is a management input. It is not a standing market fact.
+
+## The decision memo should show the expiry, not hide it
+
+A useful GEO memo should make the state of the observation visible. For example:
+
+| Observation | Decision | Captured | Current use | Retest trigger |
+|---|---|---:|---|---|
+| Answer engines describe the offer as a strategic advisory service, not a software tool. | Use in sales positioning review. | 2026-07-16 | Current for this review. | Retest before public repositioning, major offer change, or next board pack. |
+| A competitor appears as an alternative in several buyer-research prompts. | Decide whether to update comparison language. | 2026-07-16 | Current for investigation, not yet budget authority. | Retest if pattern repeats after competitor launch or after source updates. |
+| A prior screenshot showed weak category fit. | Historical context for trend discussion. | Earlier capture | Superseded until retested. | Retest before using it to justify campaign changes. |
+
+The exact fields can change. The operating principle should not: no answer observation should travel through the organisation without its capture context and its expiry condition.
+
+This is how a management team avoids the false confidence of old screenshots. It can still learn from them. It can still compare them with newer answers. It can still preserve them as part of the market record. But it cannot let them authorise current decisions unless their validity has been checked.
+
+## The leadership question
+
+The better board question is not, “What did the AI answer say?”
+
+It is: “Is this observation still current enough for the decision we are about to make?”
+
+That question changes the quality of GEO reporting. It forces teams to connect answer evidence to commercial use, capture context, review triggers, and responsible retirement. It prevents old observations from becoming permanent internal folklore.
+
+AI visibility work is most valuable when it helps leaders act with proportion. Sometimes the right action is to fix a public explanation. Sometimes it is to investigate a competitor pattern. Sometimes it is to change sales language. Sometimes it is to do nothing until the signal repeats.
+
+But before any of those choices, the team needs one rule: every AI answer used for management should carry an expiry condition.
+
+Captured. Current for this decision. Retest required. Superseded or historical.
+
+Without that lifecycle, the organisation is not managing AI visibility. It is managing yesterday's screenshot as if the market had stopped moving.


### PR DESCRIPTION
## Summary
- Adds Day 87 Build in Public post: "Put an Expiry Date on Every AI Answer"
- Publishes the approved GEO measurement angle on time-bound answer observations, capture context, and review-by/event triggers

## Checks
- Frontmatter/title/date/slug/content validation passed
- `git diff --check` passed
- `python3 -m py_compile tools/blog_hook.py tools/build_log.py` passed
- `mkdocs build` passed with existing project warnings

## Payload
- One post only: `docs/blog/posts/daily-blog-day-87.md`
