### PR TITLE
docs: add day 88 blog post

### DIFF
--- a/docs/blog/posts/daily-blog-day-88.md
+++ b/docs/blog/posts/daily-blog-day-88.md
@@ -1,0 +1,167 @@
+---
+title: "Day 88: Find the Buyer Question Nobody Owns"
+date: 2026-07-17
+slug: "day-88-find-the-buyer-question-nobody-owns"
+description: "A market-opportunity field note for CMOs, Marketing Directors, and founders: a commercially important buyer question with no stable AI recommendation leader may be candidate recommendation white space, but only after demand, measurement quality, and market evidence are validated."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - competitive strategy
+  - market research
+  - commercial decision-making
+geo_tactics:
+  - Look for commercially important buyer questions where repeated answer-led tests show no stable recommendation leader, unstable evaluation criteria, and fragmented provider sets.
+  - Treat an apparently unowned question as candidate recommendation white space, not proof that buyers care or that a brand should immediately try to define the category.
+  - Validate the finding with demand evidence, prompt quality checks, relevant answer surfaces, wording and role variants, provider consistency, criteria stability, citations where visible, and sales or customer corroboration.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 88: Find the Buyer Question Nobody Owns
+
+Competitive GEO work often starts by asking who wins.
+
+Which provider is named? Which competitor appears first? Which brand is cited? Which page is reused? Which answer surface includes the company, and which one leaves it out?
+
+Those questions matter. But they can hide a more interesting commercial state: a buyer question that looks important, but has no stable recommendation leader.
+
+The answers hedge. The provider set changes. The criteria move around. One surface names a few agencies, another describes internal workflows, another recommends software, and another refuses to name anyone with confidence. No single company owns the question clearly.
+
+That is not automatically good news. It is not evidence that demand exists. It is not permission to declare a new category. It is not a guaranteed ranking opportunity.
+
+It is a candidate: recommendation white space that deserves validation before anyone spends to define it, contest it, test it, monitor it, or leave it alone.
+
+<!-- more -->
+
+## The empty winner column can be the finding
+
+A lot of AI visibility reporting is built to produce winners and losers. That is understandable. Leaders want to know whether the brand appears, whether competitors appear, and whether visibility is improving.
+
+But a commercially useful buyer question does not always produce a clean winner.
+
+A CMO might ask answer-led systems something like: “Who can help a B2B company understand why AI recommendations are sending the wrong type of leads into sales?”
+
+A stable market might produce a recognisable shortlist. The same kinds of providers appear across repeated tests. The evaluation criteria stay broadly consistent. The answers distinguish consultants, software platforms, content agencies, analyst firms, and internal operating models with enough clarity that a buyer can move forward.
+
+An unstable market behaves differently. One answer suggests SEO agencies. Another recommends analytics dashboards. Another describes brand strategy consultants. Another gives a general explanation but avoids naming providers. Another cites articles about AI visibility without connecting them to a buying route. The criteria switch between technical tracking, content production, positioning, lead quality, and sales enablement.
+
+For the buyer, that means the next step is unclear: hire a services partner, buy software, ask for advisory support, change the sales process, or keep researching.
+
+That pattern is easy to dismiss as noise. Sometimes it is noise. But sometimes it says something commercially useful: the market has not yet settled on who should be trusted for that buyer problem, what the evaluation criteria should be, or what kind of provider belongs in the consideration set.
+
+That is the new macro cluster: competitive GEO should not only measure who is winning established questions. It should also identify commercially important questions where no recommendation leader is stable enough to own the buying route.
+
+This is not the older failure mode where a brand is visible but routed to the wrong fit, category, surface, entity, or shortlist. It is not a stale-observation governance problem. It is not simple answer disagreement. The commercial question is narrower: is this buyer question an investable opening, or just an artefact of weak measurement or weak demand?
+
+## Apparently unowned does not mean commercially open
+
+The phrase “nobody owns this question” is dangerous if it is treated as a conclusion.
+
+Answer-led systems can fail to name a provider for many ordinary reasons:
+
+- the prompt is too vague;
+- the buyer role is unclear;
+- the question combines several jobs that should be separated;
+- the surface has limited or inconsistent retrieval for the topic;
+- citations are not visible;
+- the category language is immature;
+- the market is local, private, or relationship-led;
+- credible providers exist, but the public source set does not make them easy to recommend;
+- the question sounds commercially attractive to the company, but buyers do not actually ask it.
+
+Those states should not be collapsed into opportunity.
+
+A question can be unowned because the market has not been named well enough yet. It can also be unowned because nobody needs the thing being described, because the prompt is artificial, or because the answer surface is being asked to behave like a procurement analyst when the buyer would never use it that way.
+
+The discipline is to hold the finding in the middle for longer than most dashboards allow. Not “we are absent, therefore we have a problem.” Not “competitors are absent, therefore we have an opening.” Instead: “This looks like candidate recommendation white space. What would need to be true for it to deserve investment?”
+
+## Validate the buyer question before validating the answer
+
+Start with demand, not the dashboard.
+
+A commercially important buyer question should connect to evidence outside the answer itself. Sales calls should contain versions of it. Customer interviews should reveal the underlying pain. Search behaviour, community discussions, analyst language, procurement questions, internal stakeholder objections, or competitor messaging should suggest that the problem exists in the market.
+
+The exact wording does not need to appear everywhere. Buyers rarely phrase strategic problems with laboratory precision. But the business should be able to say why the question represents a real buying moment rather than an internal wish.
+
+Useful validation questions include:
+
+| Test | What it protects against |
+|---|---|
+| Buyer reality | Mistaking an internally attractive topic for a market question. |
+| Commercial consequence | Chasing a question that creates attention but not budget, urgency, or ownership. |
+| Sales corroboration | Treating a dashboard pattern as demand without hearing it in live conversations. |
+| Customer language | Building around company vocabulary instead of buyer vocabulary. |
+| Market adjacency | Entering a space where the provider type, budget owner, or buying route does not fit the business. |
+
+If the buyer question fails those tests, the answer-led ambiguity is useful but not investable. It may belong in a watchlist. It may suggest research. It should not trigger a full content, product marketing, or category-definition programme.
+
+## Then test whether the observation is real
+
+Only after the buyer question earns attention should the team inspect the answer pattern properly.
+
+That means repeating the question across relevant surfaces and variants instead of trusting one output. ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led experiences do not all serve the same buyer moment. Some are used for education, some for comparison, some for source inspection, some inside search journeys, and some as drafting or reasoning aids.
+
+A basic white-space diagnostic should check:
+
+- wording variants: broad, specific, problem-led, provider-led, and decision-led versions of the question;
+- role variants: CMO, Marketing Director, founder, procurement lead, sales leader, or category owner where relevant;
+- situation variants: early education, shortlist building, budget justification, vendor comparison, or internal business case;
+- provider consistency: whether the same companies or provider types recur;
+- criteria stability: whether the answer keeps using similar evaluation factors;
+- confidence and hedging: whether recommendations are direct, cautious, generic, or avoided;
+- competitor sets: whether the market is framed around agencies, consultancies, software, publishers, analysts, internal teams, or substitutes;
+- citations where visible: which sources are shaping the answer, and whether they support the recommendation being made.
+
+The goal is not to manufacture a universal score. The goal is to separate five different states:
+
+1. a genuinely crowded question, where the brand must contest a known buying route;
+2. a clearly owned question, where a competitor or provider type has strong recommendation momentum;
+3. an inconclusive observation, where the test quality is not good enough;
+4. a low-demand question, where ambiguity does not matter commercially;
+5. a candidate unowned question, where buyer relevance is real and the answer market has not settled.
+
+Only the fifth state is recommendation white space worth serious consideration.
+
+## Choose the right verb
+
+Once a question survives both demand validation and measurement checks, the leadership decision should become practical.
+
+The answer is not always “publish more”. Different findings deserve different verbs.
+
+| Finding | Better decision |
+|---|---|
+| Buyers ask the question, but the market lacks criteria. | Define: publish a strong point of view, evaluation guide, or commercial framework that makes the buying route clearer. |
+| Buyers ask the question, and a competitor is beginning to own it. | Contest: compare the criteria, show the trade-offs, and make the company’s fit explicit. |
+| Buyers may ask the question, but evidence is thin. | Test: run a bounded campaign, sales enablement asset, webinar, or landing page before allocating major budget. |
+| The answer pattern is unstable, but demand is not yet proven. | Monitor: keep a small set of prompts and market signals under review. |
+| The question is noisy, artificial, or commercially weak. | Leave it alone: do not convert ambiguity into a strategy. |
+
+This is where candidate recommendation white space becomes useful for a CMO or founder. It turns a vague “AI visibility opportunity” into a bounded commercial choice.
+
+If the company chooses to define the question, it should do so with substance: clear criteria, buyer situations, fit and no-fit signals, proof, trade-offs, and a decision route. If it chooses to contest, it should explain why the current frame is incomplete. If it chooses to test, the test should have a budget, an audience, and a stop rule. If it chooses to monitor, monitoring should not quietly become a backlog of unfunded anxiety.
+
+## Do not overfit the mechanics
+
+This work also needs restraint around technical claims.
+
+Google’s AI features are part of Google’s broader Search ecosystem and quality systems. There is no special AI-visibility switch that makes a weak market argument become a strong recommendation. llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility.
+
+For answer-led discovery more broadly, the useful work is not to chase a secret control. It is to make the public market layer easier to interpret: what the company does, who it helps, when it fits, when it does not, what criteria matter, what proof supports the claim, and what a serious buyer should do next.
+
+If a buyer question is commercially real and nobody owns the recommendation route, that clarity can become an advantage. But only if the company has earned the right to define the question.
+
+## The leadership question
+
+The sharper question is not “are we visible for this prompt?”
+
+It is:
+
+> Is this a commercially important buyer question with no stable recommendation leader, and have we ruled out weak demand, weak prompts, access limits, capture issues, ordinary answer variation, and category confusion before deciding what to fund?
+
+If the answer is yes, the opportunity may be real. Define it, contest it, or test it with a bounded plan.
+
+If the answer is no, the finding is still useful. It has stopped the team from spending money on a mirage.
+
+That is the value of looking for buyer questions nobody owns. The prize is not a prettier visibility report. The prize is knowing which market questions deserve to become part of the company’s strategy, and which ones should stay outside the budget.


### PR DESCRIPTION
## Summary
- Adds the Day 88 Build in Public post: "Find the Buyer Question Nobody Owns"
- Publishes the approved candidate recommendation white-space angle with demand-validation and measurement-quality caveats
- Keeps the payload scoped to one blog post

## Verification
- Reviewer verdict consumed: APPROVED
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-88.md` passed
- Targeted title/date/slug/`<!-- more -->`/frontmatter assertions passed
- `PYTHONPATH=. pytest -q tests/test_validate_frontmatter.py` passed (3 tests)
- `git diff --check` passed
- `mkdocs build` passed (existing nav/RoamLinks warnings only)

## Payload check
- Expected changed file: `docs/blog/posts/daily-blog-day-88.md`
