### PR TITLE
docs: add daily blog day 89

### DIFF
--- a/docs/blog/posts/daily-blog-day-89.md
+++ b/docs/blog/posts/daily-blog-day-89.md
@@ -13,10 +13,10 @@ tags:
   - prompt strategy
   - commercial strategy
 geo_tactics:
-  - Audit prompt portfolios as market definitions: each question encodes a buyer, category, competitor set, problem, commercial moment, and intended management decision.
+  - "Audit prompt portfolios as market definitions: each question encodes a buyer, category, competitor set, problem, commercial moment, and intended management decision."
   - Classify prompts as active, watchlist, or historical so obsolete questions can remain useful context without governing current budget, content, positioning, sales, or partnership decisions.
   - Retire prompts from active KPI reporting when the offer, ICP, category, sales qualification, competitor set, market language, or strategic priority changes materially.
-  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
 ---
 
 # Day 89: Retire the Prompts That Measure Your Old Strategy

--- a/docs/blog/posts/daily-blog-day-89.md
+++ b/docs/blog/posts/daily-blog-day-89.md
@@ -1,0 +1,214 @@
+---
+title: "Day 89: Retire the Prompts That Measure Your Old Strategy"
+date: 2026-07-18
+slug: "day-89-retire-prompts-that-measure-old-strategy"
+description: "A GEO measurement-governance mini teardown for CMOs, Marketing Directors, and founders: prompt portfolios can keep rewarding visibility for old categories, unwanted buyers, obsolete competitors, and deprecated offers. Retire stale questions from current KPIs while preserving useful history in a labelled archive."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - measurement governance
+  - prompt strategy
+  - commercial strategy
+geo_tactics:
+  - Audit prompt portfolios as market definitions: each question encodes a buyer, category, competitor set, problem, commercial moment, and intended management decision.
+  - Classify prompts as active, watchlist, or historical so obsolete questions can remain useful context without governing current budget, content, positioning, sales, or partnership decisions.
+  - Retire prompts from active KPI reporting when the offer, ICP, category, sales qualification, competitor set, market language, or strategic priority changes materially.
+  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility.
+---
+
+# Day 89: Retire the Prompts That Measure Your Old Strategy
+
+A GEO dashboard can improve while the business gets worse at measuring the market it now wants.
+
+The issue is not that the answers are false; it is that the questions behind the score still belong to the old strategy.
+
+That is the quiet governance failure inside many AI visibility reports. A prompt family can remain in the active score long after the company has changed its offer, narrowed its ICP, left a category, deprecated a competitor set, or stopped wanting a certain kind of demand.
+
+The dashboard is not lying. It is faithfully measuring a market the business has moved away from.
+
+For CMOs, Marketing Directors, and founders, that is not a reporting nuisance. It can pull content budget, positioning work, sales enablement, partnerships, and leadership attention back towards the previous version of the company.
+
+The executive decision is not only which prompts to add.
+
+It is which old market questions should lose authority over today's GEO budget.
+
+<!-- more -->
+
+## Every prompt is a market decision
+
+Prompt portfolios are often treated like neutral measurement instruments.
+
+They are not.
+
+Every tracked question encodes a view of the market. It says which buyer matters, which problem deserves observation, which category the company believes it competes in, which alternatives count, which commercial moment should be influenced, and which movement should trigger action.
+
+A prompt such as “best AI transformation partners for B2B marketing” is not only a test string. It implies a broad transformation market, a certain buyer expectation, a familiar competitor set, and a likely comparison against generalist providers.
+
+A prompt such as “who helps a CMO diagnose why AI recommendations are sending low-fit demand to sales?” encodes a different market. It points towards executive diagnosis, pipeline quality, answer-led discovery, sales impact, and a more specific buying moment.
+
+Neither question is inherently right. The issue is whether the question still represents the business the company is trying to build.
+
+That means a prompt portfolio is a shadow strategy document. If it is not governed, it can preserve old assumptions long after leadership has changed the offer, narrowed the ICP, sharpened qualification, repositioned the category, or stopped wanting certain demand.
+
+The dashboard then becomes dangerous because it looks objective. It can give an obsolete question current KPI authority, then invite the team to manage today's budget against yesterday's market definition.
+
+## A mini teardown: the prompt family that should stop voting
+
+Imagine a specialist firm that used to sell broad AI transformation projects.
+
+Its original prompt portfolio reflected that market. It tracked questions such as:
+
+- “best AI transformation partners for enterprise change”;
+- “top AI consulting firms for marketing teams”;
+- “who helps companies adopt AI tools?”;
+- “AI transformation partner versus automation consultancy”;
+- “providers for building internal AI workflows”.
+
+Those questions made sense at the time. They represented the old offer, the old buying route, and the old competitor set.
+
+Then the company changes strategy. It stops chasing broad transformation work and focuses on a narrower commercial problem: helping marketing leaders understand how answer-led discovery affects category framing, buyer qualification, competitor comparison, and sales conversations.
+
+At that point, the first management question is not whether the old prompts still produce movement. It is whether that prompt family still deserves to vote in the active score.
+
+If the answer is no, the useful finding becomes: “visibility increased on questions that no longer deserve to govern current investment.”
+
+That changes the teardown.
+
+The report may still show strength on “top AI consulting firms”. It may still show the company beside automation consultancies and workflow builders. It may still explain why some broad AI-adoption demand arrives.
+
+But those observations should not automatically authorise more broad transformation content, old proof assets, legacy partnerships, or comparison work against providers the business no longer wants to resemble.
+
+The point is not to declare the old market worthless. The point is to change the prompt family state. Preserve the old questions as history if they still explain the transition, but remove them from current KPIs and build active measurement around the market the company now wants to win.
+
+## Do not delete history; remove authority
+
+Retiring prompts does not mean pretending the past did not exist.
+
+Old questions can remain useful. They can show how the market used to describe the company. They can explain why sales used to receive a certain type of demand. They can help leadership see whether repositioning is actually taking hold. They can provide context when an old competitor, category, or buyer problem resurfaces.
+
+The mistake is letting those prompts continue to govern the active score.
+
+A historical series can answer: “How did we appear in the old market?”
+
+A current KPI should answer: “Are we becoming visible, credible, and correctly framed in the market we are trying to win now?”
+
+Those are different questions. Blending them into one share-of-answer number creates false continuity. It keeps the chart tidy by making the strategy messy.
+
+A mature GEO report should therefore separate three states.
+
+| State | Meaning | Management use |
+|---|---|---|
+| Active | The prompt represents a current buyer, category, offer, competitor set, or commercial decision. | Counts towards current KPIs and can inform budget, content, positioning, sales, and competitive action. |
+| Watchlist | The prompt may become relevant, is being tested, or represents an adjacent market the company is monitoring. | Reviewed for learning, but does not yet authorise major current spend. |
+| Historical | The prompt represented a previous strategy, retired offer, old ICP, obsolete competitor set, or deprecated buyer moment. | Preserved for context and trend notes, but excluded from current performance scoring. |
+
+That distinction protects both learning and strategy.
+
+The company does not lose history. It stops history from voting in today's budget meeting.
+
+## Retirement triggers should be tied to strategy change
+
+Prompt retirement should not be a cosmetic dashboard cleanup.
+
+It should be triggered when the business changes enough that an old question no longer deserves current authority. Useful triggers include:
+
+- Offer change: the company stops selling, packaging, or prioritising the service implied by the prompt.
+- ICP change: the question attracts a buyer segment the business no longer wants to pursue.
+- Category change: the company has moved out of a broad or adjacent category and wants to be evaluated in a sharper market.
+- Sales qualification change: the prompt creates enquiries that sales now classifies as poor fit, low priority, or wrong route.
+- Competitor-set change: the alternatives in the answer no longer represent the buying contest leadership wants to understand.
+- Market-language change: buyers have adopted a better phrase, problem frame, or decision route than the old prompt captures.
+- Strategic-priority change: leadership no longer wants the question to influence content, positioning, partnerships, or budget allocation.
+- Repeated misalignment: movement on the prompt creates action recommendations that the current strategy would reject.
+
+The last trigger is important. A stale prompt often reveals itself when its “success” asks the company to do the wrong thing.
+
+If a rising score implies “publish more broad transformation content”, but the business is trying to own a specific diagnostic buying moment, the prompt may have become historical. If a competitor still matters to the old offer but no longer appears in serious deals, the question may belong in a watchlist or archive. If an obsolete buyer segment keeps producing flattering visibility, the report should label that as old-market strength, not current progress.
+
+Retirement is not anti-measurement. It is measurement with a current strategy attached.
+
+## Preserve comparability without preserving bad incentives
+
+The main objection to prompt retirement is usually trend continuity.
+
+Leadership wants to compare this quarter with last quarter. The marketing team wants a clean line. The board wants to know whether visibility is improving. Removing prompts can make the report look harder to explain.
+
+That concern is legitimate, but it should not override strategic accuracy.
+
+The right answer is not to keep obsolete questions in the active score forever. It is to label the change clearly.
+
+A clean reporting note might say:
+
+> “Baseline v2 separates the former broad-agency prompt family into a historical set. These questions remain available for context, but they no longer count towards current Prompt Share of Voice because the company no longer prioritises that buyer, category, or competitor set. Active KPIs now reflect the current diagnostic offer and target buyer moments.”
+
+That note protects comparability better than pretending nothing changed.
+
+It tells leadership why the line moved, what was removed, what remains visible as history, and which current questions now matter. It also prevents the team from optimising for old prompts just to preserve a prettier trend.
+
+A prompt portfolio can be versioned without becoming frozen. When the strategy changes, the measurement contract should change with it. The important discipline is to show the change, not hide it inside the chart.
+
+## Google caveats do not change the governance job
+
+This work should not be turned into technical superstition.
+
+Prompt retirement is not about finding a hidden control for answer engines. It is not about claiming that one file, markup pattern, chunking approach, or structured-data tactic will make the new market appear correctly across every surface.
+
+For Google specifically, the caveat stays boring and important: Google's AI features rely on core Search ranking and quality systems. `llms.txt`, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility.
+
+Across answer-led discovery more broadly, the useful work is to make the measurement system honest about what it is observing. ChatGPT, Claude, Perplexity, Gemini, Google AI features, and similar experiences do not behave identically. They may expose sources differently, answer different buyer moments, and vary by context. But in every case, the prompt portfolio defines the market being watched.
+
+If that portfolio is stale, the report can be precise about the wrong thing.
+
+The governance job is to keep the observed market aligned with the business strategy, while keeping enough historical context to understand how the transition is unfolding.
+
+## The practical prompt-retirement review
+
+A useful review can be short, but it must have authority.
+
+For each tracked prompt family, ask:
+
+1. Which buyer does this question represent?
+2. Which category does it assume?
+3. Which offer does it imply?
+4. Which competitors or alternatives does it make relevant?
+5. Which commercial moment would change if the answer moved?
+6. Which current decision does this prompt inform?
+7. Would we fund content, positioning, sales enablement, partnerships, or product marketing because this prompt moved?
+8. If not, why is it still in the active KPI set?
+
+The eighth question is the one that matters.
+
+If nobody can name the current management decision, the prompt should not keep its authority by default. It may move to a watchlist. It may become historical. It may be rewritten around a better buyer moment. It may be split into two questions because the market has become more precise.
+
+What it should not do is remain active merely because removing it would make the chart awkward.
+
+A strong GEO dashboard should be willing to say:
+
+- active: this question governs current investment;
+- watchlist: this question is being observed but not funded yet;
+- historical: this question explains where we came from, not where we are going.
+
+That is how measurement becomes a strategic asset rather than a museum of old ambition.
+
+## The leadership question
+
+The sharper board question is not:
+
+> Are our AI visibility numbers improving?
+
+It is:
+
+> Are our AI visibility numbers measuring the business we are trying to become now?
+
+If the answer is no, the report may still contain useful history. But it should not steer current spend.
+
+Retire the prompts that measure old buyers, old categories, old offers, old competitors, and old demand. Keep the history where it helps the company understand the transition. Label it clearly. Protect the trend where the trend is still honest.
+
+But do not let yesterday's market questions govern tomorrow's budget.
+
+In GEO, the prompt portfolio is not just a measurement layer. It is a statement of which market deserves management attention.
+
+When the strategy changes, the questions have to change too.


### PR DESCRIPTION
## Summary
- Adds Day 89 Build in Public post: “Retire the Prompts That Measure Your Old Strategy”
- Applies the reviewed final artifact exactly to `docs/blog/posts/daily-blog-day-89.md`
- Keeps payload scoped to one blog post

## Verification
- Consumed reviewer verdict: `CHANGES_REQUESTED`; revised final artifact present; `ANGLE_STALE` absent
- Frontmatter/content validation passed for title, date, slug, required authority framing, active/watchlist/historical table, Google caveat, and leadership CTA
- `git diff --cached --check` passed before commit
- `git diff --check origin/main...HEAD` passed after commit
- `python3 -m mkdocs build` passed; repository emitted existing RoamLinks/nav warnings
- Payload check: `git diff --name-only origin/main...HEAD` returned only `docs/blog/posts/daily-blog-day-89.md`
