### PR TITLE
docs: add daily blog day 90

### DIFF
--- a/docs/blog/posts/daily-blog-day-90.md
+++ b/docs/blog/posts/daily-blog-day-90.md
@@ -13,10 +13,10 @@ tags:
   - sales intelligence
   - commercial strategy
 geo_tactics:
-  - Use recurring lost-deal language as a revenue-grounded input for choosing which buyer questions deserve GEO investigation, rather than inventing prompt lists from internal assumptions.
-  - Separate observed sales evidence from hypotheses about answer-engine influence: a lost-deal note can reveal a buyer concern, but direct answer-surface evidence is required before claiming AI created it.
-  - Translate each repeated objection into a bounded research brief that names the commercial signal, buyer question, affected decision, answer surfaces, evidence limits, owner, and learning step.
-  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility.
+  - "Use recurring lost-deal language as a revenue-grounded input for choosing which buyer questions deserve GEO investigation, rather than inventing prompt lists from internal assumptions."
+  - "Separate observed sales evidence from hypotheses about answer-engine influence: a lost-deal note can reveal a buyer concern, but direct answer-surface evidence is required before claiming AI created it."
+  - "Translate each repeated objection into a bounded research brief that names the commercial signal, buyer question, affected decision, answer surfaces, evidence limits, owner, and learning step."
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
 ---
 
 # Day 90: Let Lost Deals Write Your GEO Brief

--- a/docs/blog/posts/daily-blog-day-90.md
+++ b/docs/blog/posts/daily-blog-day-90.md
@@ -1,0 +1,147 @@
+---
+title: "Day 90: Let Lost Deals Write Your GEO Brief"
+date: 2026-07-19
+slug: "day-90-let-lost-deals-write-your-geo-brief"
+description: "A revenue-grounded GEO field note for CMOs, Marketing Directors, and founders: repeated lost-deal language should decide which buyer questions deserve answer-engine investigation, but sales evidence must be kept separate from any claim that AI caused the loss."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - revenue leakage
+  - sales intelligence
+  - commercial strategy
+geo_tactics:
+  - Use recurring lost-deal language as a revenue-grounded input for choosing which buyer questions deserve GEO investigation, rather than inventing prompt lists from internal assumptions.
+  - Separate observed sales evidence from hypotheses about answer-engine influence: a lost-deal note can reveal a buyer concern, but direct answer-surface evidence is required before claiming AI created it.
+  - Translate each repeated objection into a bounded research brief that names the commercial signal, buyer question, affected decision, answer surfaces, evidence limits, owner, and learning step.
+  - Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility.
+---
+
+# Day 90: Let Lost Deals Write Your GEO Brief
+
+A lost deal should not automatically become a blame story about AI.
+
+It should become a sharper question.
+
+When the same language appears in several lost-deal notes, call recordings, sales debriefs, or no-decision explanations, the commercial team has found something more useful than a generic prompt idea. It has found revenue-grounded buyer language: a confusion, comparison, missing criterion, risk concern, category mismatch, or objection that was strong enough to appear near a decision.
+
+That does not prove ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led surface caused the concern. It proves the concern exists in the commercial field.
+
+For CMOs, Marketing Directors, and founders, that distinction matters. Lost-deal language can decide what Generative Engine Optimization investigates next, but it cannot be allowed to invent causality.
+
+The working rule is simple: sales evidence chooses the buyer question; answer-surface evidence decides whether AI is amplifying, distorting, resolving, or ignoring it.
+
+<!-- more -->
+
+## Revenue loss is a better starting point than prompt volume
+
+Many GEO programmes begin with a large prompt list.
+
+The list usually looks sensible. It contains category terms, competitor comparisons, “best provider” questions, problem statements, buying-stage queries, and a few executive prompts. The team runs them across answer surfaces, collects mentions, records citations where available, and turns the results into a visibility report.
+
+That can be useful. It can also become a beautifully measured version of the wrong market conversation.
+
+The more commercial starting point is often smaller and rougher: why did qualified buyers hesitate, choose someone else, delay the decision, misunderstand the offer, or decide the problem belonged elsewhere?
+
+A lost-deal note is not a clean research instrument. Sales notes are compressed. Prospects are polite. Procurement language can hide political reality. A competitor may be blamed when budget was the real issue. A “not a priority” reason may mean the buyer never understood the cost of inaction.
+
+Still, repeated language has value because it is attached to revenue leakage. If several credible opportunities say some version of “we are not sure this is different from an SEO agency”, “we can probably handle this internally”, “we need a platform, not a partner”, or “the board does not see the risk yet”, marketing has a better GEO input than another internally invented phrase.
+
+The task is not to ask every possible AI question.
+
+The task is to investigate the buyer questions that keep appearing where money is being lost.
+
+## A lost-deal note is evidence of language, not evidence of cause
+
+This is where teams need restraint.
+
+If a prospect says, “we compared you with content agencies,” the company has evidence that the buyer made that comparison. It does not yet have evidence that an answer engine produced the comparison.
+
+If a sales note says, “buyer thinks this is a dashboard purchase,” the company has evidence of category confusion. It does not yet know whether that confusion came from Google Search results, a ChatGPT answer, a competitor page, an analyst report, a colleague, procurement framing, or the company’s own unclear positioning.
+
+If a no-decision record says, “team will test internally first,” the company has evidence of a perceived DIY route. It does not yet know whether answer-led discovery made the internal route look safer or whether the buyer simply lacked urgency.
+
+That separation should be explicit in the brief:
+
+- observed commercial signal: what sales actually heard or recorded;
+- hypothesis: what the team thinks may be happening in answer-led discovery;
+- answer-surface observation: what was actually seen in ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another relevant surface;
+- response: what the business should change in public content, sales language, offer packaging, or follow-up.
+
+Without that separation, GEO becomes a convenient explanation for every uncomfortable loss. That is bad strategy. It makes the team less empirical, not more.
+
+The operating principle is simple: revenue-loss evidence should choose which buyer questions GEO investigates; answer-engine influence must then be tested rather than assumed.
+
+That keeps the work distinct from dashboard hygiene or prompt governance because the brief starts with commercial-loss language before any AI observation exists. It is not another lifecycle rule, prompt-retirement exercise, wrong-category repair, or post-citation trust handoff.
+
+## Turn the loss signal into a bounded GEO brief
+
+A useful brief does not need to be large. It needs to be precise enough that marketing, sales, and leadership know what is being tested and what would count as evidence.
+
+For each recurring lost-deal phrase, capture seven fields.
+
+First, the commercial signal. Write the language close to how the buyer expressed it, stripped of private detail. “They saw us as an SEO agency” is more useful than “positioning issue”. “They believed internal research would be enough” is more useful than “low urgency”.
+
+Second, the buyer question in buyer language. Not “test GEO visibility for internal substitution”. Instead: “Can our team understand AI-search risk ourselves, or do we need a specialist partner?” Not “compare category definitions”. Instead: “Is this a content problem, a search problem, a sales problem, or a board-level market-risk problem?”
+
+Third, the affected decision. Did the language affect vendor selection, budget size, urgency, category choice, internal ownership, proof requirements, procurement route, or whether the buyer acted at all?
+
+Fourth, the answer surfaces to inspect. A comparison objection may deserve ChatGPT, Perplexity, Claude, and Google AI feature checks. A citation-heavy research question may weight Perplexity differently. A broad category understanding question may need Google Search results and AI features alongside conversational systems. The point is not to pretend every surface behaves the same.
+
+Fifth, the evidence and access limits. Did the team see the buyer’s transcript? Did sales only hear a summary? Is the prompt wording inferred? Were there citations? Was geography or account context known? Is the observation repeatable, or only a one-off exploration?
+
+Sixth, the response owner. Some findings belong to public positioning. Some belong to sales qualification. Some belong to comparison pages. Some belong to product marketing. Some belong to the founder’s narrative. Some belong to “do nothing until we have better evidence”.
+
+Seventh, the learning step. Not a heavy expiry table. Just the next useful check: run variants, compare surfaces, inspect cited sources where available, ask sales to listen for the same phrase, add a field to loss review, or test whether a revised page changes the answer pattern over time.
+
+This compact brief keeps the work commercially grounded. It also prevents the classic failure where one alarming anecdote becomes a full content sprint.
+
+## A practical example without pretending it is a case study
+
+Imagine a specialist firm loses several qualified conversations with a similar line: “We think our content agency can cover this.”
+
+The weak response is to publish a defensive article about why content agencies are not enough.
+
+The stronger GEO brief starts with the buyer’s question: “Can our existing content agency handle AI visibility, or do we need a specialist diagnostic partner?”
+
+Then the team checks how answer-led surfaces frame that question. Do they recommend content agencies, SEO retainers, analytics tools, technical consultants, AI-workflow partners, or specialist GEO diagnostics? Do they describe the problem as content production, search ranking, citation monitoring, category strategy, sales leakage, or market-risk diagnosis? Do they cite pages that make one route look more credible than another? Do they distinguish visibility work from conversion, qualification, and board-level decision support?
+
+The result may show that AI is reinforcing the content-agency frame. It may show that AI is not involved at all. It may show that the company’s own public pages make the work sound like content support. It may show that competitors are clearer. It may show that the objection exists in sales but is not visible in answer-led research.
+
+Each outcome points to a different action.
+
+If answer surfaces repeatedly compress the problem into content production, public pages may need sharper criteria and comparison language. If the company’s own copy creates the ambiguity, fix the offer narrative before blaming the market. If the objection only appears in late-stage sales, enable the sales team with a better diagnostic question. If there is no repeatable evidence, keep listening before funding a content build.
+
+The point is not to force every sales loss into GEO.
+
+The point is to let revenue loss decide which questions are worth investigating first.
+
+## The response should be proportionate to the evidence
+
+A repeated lost-deal phrase can justify research. It does not automatically justify a campaign.
+
+A confirmed pattern across answer surfaces may justify public content, comparison pages, clearer category boundaries, revised sales enablement, or a sharper baseline offer. A weak pattern may justify a smaller experiment. A single anecdote may only justify a listening note. A loss reason with no answer-surface support may still matter, but it should be handled as sales, positioning, pricing, or qualification work rather than dressed up as AI visibility.
+
+That proportionality is especially important for Google. Google’s AI features rely on core Search ranking and quality systems. Teams should not respond to lost-deal language by assuming that `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data are required switches for Google AI visibility. If Google matters to the buyer journey, inspect the actual search and AI-feature context, then improve the underlying public evidence and page quality accordingly.
+
+GEO should make the commercial learning loop tighter, not more theatrical.
+
+Sales hears the buyer language. Marketing translates it into buyer questions. GEO inspects the answer surfaces. Leadership chooses a response based on the strength of evidence and the size of revenue leakage.
+
+That loop is more valuable than a larger dashboard because it starts from a real commercial wound.
+
+## The leadership question
+
+The CMO question is not “how many prompts are we tracking?”
+
+It is: “Which repeated lost-deal reasons are important enough to become answer-engine research briefs, and what evidence would change our public or sales response?”
+
+That question keeps GEO attached to revenue without overclaiming causality.
+
+It also gives sales a role that is more useful than anecdote delivery. Sales is not asked to diagnose answer engines. It is asked to preserve the language of real buyer friction. Marketing and GEO then do the disciplined work of testing whether the answer layer is part of the problem.
+
+Lost deals should not write the conclusion.
+
+They should write the brief.


### PR DESCRIPTION
## Summary
- Adds Day 90 Build in Public post: "Let Lost Deals Write Your GEO Brief"
- Frames recurring lost-deal language as the input for bounded GEO research, without claiming AI caused the loss
- Preserves the Google caveat around `llms.txt`, special AI markup, arbitrary chunking, and over-focused structured data

## Validation
- Content validation passed: frontmatter, Day/date/slug/H1, `<!-- more -->`, reviewer verdict, forbidden terms, causality caveat, and Google caveat
- `python3 -m py_compile tools/blog_hook.py`
- `mkdocs build` completed successfully with existing RoamLinks/AutoLinks warnings

## Scope
- One-file payload only: `docs/blog/posts/daily-blog-day-90.md`
