### PR TITLE
docs: add daily blog day 91

### DIFF
--- a/docs/blog/posts/daily-blog-day-91.md
+++ b/docs/blog/posts/daily-blog-day-91.md
@@ -1,0 +1,159 @@
+---
+title: "Day 91: Fix the Sales Objection Before You Fix the AI Answer"
+date: 2026-07-20
+slug: "day-91-fix-sales-objection-before-ai-answer"
+description: "A commercial response playbook for CMOs, Marketing Directors, and founders: when a repeated or materially credible AI inaccuracy becomes a live sales objection, protect the opportunity now with evidence-safe sales language while public-source correction and answer retesting run on a slower track."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - sales enablement
+  - buyer objections
+  - commercial response
+geo_tactics:
+  - Treat a repeated or materially credible AI inaccuracy as a live commercial objection when prospects start repeating it in sales conversations, not as proof that every isolated answer deserves an incident response.
+  - Give sales an evidence-safe rebuttal, qualification question, and escalation path immediately while marketing corrects the authoritative public material separately.
+  - Retest ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led surfaces over time without promising that a public edit will quickly or deterministically change the answer.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 91: Fix the Sales Objection Before You Fix the AI Answer
+
+The awkward moment is not the bad AI answer.
+
+The awkward moment is when a serious buyer brings that answer into a live sales conversation and treats it as market knowledge.
+
+“We read that you only serve the US.”
+
+“ChatGPT says you are a software platform, not a strategic partner.”
+
+“Perplexity suggests this only works for enterprise teams.”
+
+“Google’s AI answer makes it sound as if your current offer has been retired.”
+
+If the claim is repeated, materially credible, and commercially relevant, marketing cannot wait for the public web to be corrected, reprocessed, retrieved, summarised, and trusted differently by answer-led systems. That slower repair matters. But the revenue risk is already in the room.
+
+The useful response is dual-speed: protect the sales conversation now, and repair the public source layer without promising instant answer-engine change.
+
+<!-- more -->
+
+## The buyer does not care where the wrong claim came from
+
+Imagine a hypothetical B2B services firm that sells a specialist diagnostic for marketing leaders. The firm works across the UK and Europe, but several answer-led surfaces have started describing it as UK-only. The cause is not obvious. It may be an old event page. It may be a dated directory profile. It may be a sentence on the company site that over-emphasises one market. It may be a third-party article. It may be answer synthesis flattening a more nuanced public record.
+
+By the time the claim reaches a sales call, the buyer is not asking for a forensic lecture about retrieval behaviour. They are asking whether the vendor can serve them.
+
+If sales responds with, “That answer is wrong, we are fixing the website,” the opportunity can still lose momentum. The buyer has not received decision-grade reassurance. They may worry that delivery geography is unclear, that the vendor is stretching beyond its real operating model, or that the public market record is more current than the salesperson.
+
+The first job is therefore not to make the AI answer change. It is to stop the incorrect claim from becoming an unanswered objection.
+
+That distinction keeps the response commercial. A single strange screenshot should not trigger a company-wide scramble. But once a material inaccuracy has been established through repeated observation, credible buyer repetition, or direct commercial consequence, the team needs a live-response pattern.
+
+## Give sales a narrow rebuttal, not a defensive essay
+
+A sales rebuttal for an AI-derived objection should be short, specific, and evidence-safe.
+
+The weak version sounds like: “AI tools get things wrong all the time.” That may be true, but it makes the company sound dismissive of the buyer’s research.
+
+The stronger version sounds like: “That answer is not current. We serve UK and European teams; here are the markets we can support, and here is how we confirm fit before proposing work.”
+
+The point is not to attack the surface the buyer used. The point is to replace the wrong public claim with a verifiable commercial boundary.
+
+A useful sales note should contain four elements:
+
+1. the incorrect claim the buyer may repeat;
+2. the accurate statement sales is allowed to make;
+3. the supporting proof or qualification cue;
+4. the escalation path when the buyer needs more certainty.
+
+For example:
+
+| AI-derived objection | Safe sales response | Escalate when |
+|---|---|---|
+| “You only operate in one geography.” | “We support clients in these markets; delivery fit depends on regulation, language, stakeholder access, and timeline.” | The buyer needs local accreditation, on-site delivery, or jurisdiction-specific proof. |
+| “This is a software product.” | “The engagement is a diagnostic service with defined outputs, not a seat-based platform.” | The buyer asks for integrations, licences, uptime, or feature comparisons. |
+| “You only work with enterprise teams.” | “The offer is designed around the complexity of the buyer problem, not headcount alone.” | Budget, internal ownership, or implementation capacity is unclear. |
+| “The current package is no longer available.” | “This is the current offer; older descriptions may still exist in public sources.” | The buyer saw a dated source that needs marketing review. |
+
+This is not a script for winning an argument. It is a way to keep the deal qualified and factual while the source correction catches up.
+
+## Separate the live objection from the slower source repair
+
+The public repair track has a different rhythm.
+
+Marketing still needs to identify which authoritative sources are creating or failing to correct the bad claim. That may mean revising the core offer page, updating location language, clarifying implementation models, retiring old packages, correcting third-party profiles where possible, or publishing a concise qualification boundary.
+
+But the team should not describe those edits as a switch. ChatGPT, Claude, Perplexity, Gemini, Google AI features, and other answer-led experiences may not revisit the same material immediately. They may use different sources, expose citations differently, personalise context, retrieve stale material, or summarise a mixed source set in ways that remain imperfect for a period of time.
+
+Google needs particular care. Its AI features rely on core Search ranking and quality systems. A company should improve the underlying usefulness, clarity, relevance, and trustworthiness of its public material; it should not pretend that `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data are required switches for Google AI visibility.
+
+The honest public-source plan sounds like this:
+
+- correct the canonical owned page first;
+- remove or supersede the most misleading old public material where the company controls it;
+- update high-authority third-party profiles when access exists;
+- make the accurate boundary easy for buyers and answer systems to interpret;
+- retest relevant answer-led surfaces over time;
+- tell sales which claims are still appearing and which response is approved.
+
+That is slower than the sales need. It is also more truthful than promising that a page edit will make the next answer correct.
+
+## Do not turn every bad answer into a crisis
+
+The danger with this topic is overreaction.
+
+Answer-led systems produce ordinary variation. A weak prompt, local context, temporary source mix, or one strange response can create a false sense of urgency. Teams should not turn every isolated bad answer into a public rewrite, sales alert, and leadership incident.
+
+The dual-speed lane is for material cases: inaccuracies that touch availability, current offer, implementation model, geography, accreditation, pricing model, integration reality, qualification boundary, or another point that changes a buyer’s decision. It is especially relevant when the error has been repeated, appears in a serious buyer conversation, shows up across more than one relevant surface, or concerns a high-value opportunity.
+
+The proportionality rule is simple:
+
+If the answer is odd but commercially remote, log it and watch.
+
+If the answer is repeated and commercially relevant, prepare sales language.
+
+If the answer is already appearing in live opportunities, sales gets the rebuttal before marketing finishes the source repair.
+
+If the claim exposes a genuine public ambiguity, fix the source even if the current AI answer cannot be changed on demand.
+
+This keeps the work from becoming measurement theatre. The goal is not to panic faster. The goal is to defend revenue without pretending to control surfaces the company does not control.
+
+## The useful handoff is a one-page objection brief
+
+A practical brief can be small enough for sales to use and precise enough for marketing to act on.
+
+It should answer:
+
+- What wrong claim has been observed or repeated?
+- Which buyer decision could it affect?
+- What is the accurate commercial statement?
+- What proof, page, policy, example, or qualification cue supports that statement?
+- What should sales say in one sentence?
+- When should sales escalate to marketing, product, delivery, legal, or leadership?
+- Which public sources need correction or clarification?
+- Which answer-led surfaces will be retested, and when?
+- What must not be promised?
+
+The last question is important. Sales should not promise that “the AI will be fixed soon.” Marketing should not promise deterministic movement after a public edit. Leadership should not treat the objection as solved merely because a page has changed.
+
+A better internal status is: “Sales has a safe answer now; public materials have been corrected; answer surfaces are being retested; the commercial risk remains under review until the bad claim stops appearing in serious buyer contexts.”
+
+That is measured, but it is not another measurement-governance thesis. The centre of the work is the live commercial objection. The metric is whether the buyer can move past an inaccurate claim without the company overclaiming what it controls.
+
+## The leadership question
+
+The board-level question is not, “How quickly can we make the AI answer change?”
+
+It is:
+
+> When a materially wrong answer enters a sales conversation, do we have an approved way to protect the opportunity today while the public record is corrected and retested over time?
+
+That question gives marketing and sales different jobs.
+
+Sales protects the conversation with accurate, narrow, proof-backed language. Marketing repairs the public explanation and keeps the team honest about answer-engine limits. Leadership decides whether the issue is commercially large enough to deserve escalation.
+
+The buyer does not need a lecture on model behaviour. They need confidence that the answer they saw is not the company’s current truth.
+
+Fix that objection first. Then keep repairing the public material until future answers have a better chance of learning the same thing.


### PR DESCRIPTION
## Summary
- Adds the Day 91 Build in Public post: “Fix the Sales Objection Before You Fix the AI Answer”
- Applies the approved revision artifact after the reviewer-requested `geo_tactics` YAML quoting fix
- Keeps the payload to one blog post file only

## Verification
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-91.md`
- targeted YAML/title/date/slug/H1/`<!-- more -->` assertions
- `PYTHONPATH=. pytest -q tests/test_validate_frontmatter.py`
- `python3 -m mkdocs build`

## Notes
- Reviewer verdict consumed: `CHANGES_REQUESTED`
- Final macro cluster: two-speed commercial response for AI-derived sales objections
- Avoided old cluster: measurement/input governance from Days 84/87/89
