### PR TITLE
docs: add daily blog day 92

### DIFF
--- a/docs/blog/posts/daily-blog-day-92.md
+++ b/docs/blog/posts/daily-blog-day-92.md
@@ -1,0 +1,123 @@
+---
+title: "Day 92: Do Not Build a Data Room Before Your First GEO Call"
+date: 2026-07-21
+slug: "day-92-do-not-build-data-room-before-first-geo-call"
+description: "A buyer-scenario walkthrough for CMOs, Marketing Directors, and founders: a serious GEO diagnostic should start with a light first-call input set, then request delivery-grade evidence only when it improves a defined commercial decision."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - buyer journey
+  - diagnostic design
+  - commercial strategy
+geo_tactics:
+  - Separate minimum first-call inputs from delivery-enrichment evidence so buyers can start a useful GEO conversation without assembling analytics exports, sales notes, transcripts, proof assets, and competitor inventories in advance.
+  - Use the first conversation to define the commercial stakes, priority offer, target buyers, and investigation question before requesting deeper evidence such as answer-engine transcripts, Search Console data, analytics, proof assets, or technical source checks.
+  - Label direct answer-engine evidence, proxy or citation-surface evidence, site and technical evidence, competitor evidence, and hypotheses clearly so lower onboarding friction does not weaken diagnostic rigour.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 92: Do Not Build a Data Room Before Your First GEO Call
+
+A serious GEO conversation should not begin with homework that feels larger than the problem.
+
+If a CMO, Marketing Director, or founder has to collect every analytics export, sales note, transcript, proof asset, approved claim, competitor list, Search Console view, and answer-engine screenshot before the first call, the seller has moved delivery complexity into the buyer's doorway.
+
+That does not make the diagnostic more rigorous. It often makes it less likely to happen.
+
+The better rule is lighter and stricter at the same time: start with the domain, the priority offer, the target buyers, and a few competitors or commercially important buyer questions. Use the first call to decide whether there is a real AI-visibility problem worth investigating. Ask for deeper evidence only when it improves a defined delivery decision.
+
+Lower first-call friction is not lower standards. It is service design.
+
+<!-- more -->
+
+## The overloaded first step
+
+Imagine a founder who suspects answer-led discovery is misrepresenting their company. They do not know whether ChatGPT, Claude, Perplexity, Gemini, Google AI features, or market content is the issue. They only know that prospects are arriving with odd assumptions: the offer sounds too tactical, a competitor seems to own the category language, or a strategic service is being treated like a tool comparison.
+
+They book a GEO diagnostic call. Then the preparation email arrives: analytics access, Search Console access, CRM notes, transcripts, proof points, customer segments, competitor URLs, content inventory, technical stack details, geographies, and screenshots from AI tools.
+
+Some of that may become useful later. The problem is timing. Before the first conversation, the buyer is not yet sure what question is being investigated, what evidence will matter, or whether the commercial stakes justify the effort.
+
+So the meeting slips. Someone needs to check data permissions. Someone else owns call recordings. The proof library is out of date. The buyer has not done anything wrong; the seller has accidentally turned the first step into a private data room.
+
+For GEO, that is especially damaging because many buyers are still trying to name the problem. They may not be asking for a full measurement programme. They may be asking a simpler commercial question: are answer-led systems helping, confusing, excluding, or misrouting the buyers we care about?
+
+That question does not need a complete evidence pack to begin.
+
+## Minimum input is enough to choose the right conversation
+
+The first call should answer three commercial questions before it asks for richer material.
+
+First: what offer matters? A company can be visible for many things and still fail where the money is. A priority offer gives the diagnostic a commercial centre of gravity.
+
+Second: which buyers matter? A founder researching agencies, a CMO comparing partners, and a technical evaluator checking delivery risk may ask different questions and trust different sources. Target buyers prevent generic prompt theatre.
+
+Third: which market comparisons or buyer questions already feel commercially important? A few competitor names, category alternatives, procurement concerns, or board-level objections are enough to shape the first investigation. They do not prove answer-engine influence. They simply point the work towards the right commercial terrain.
+
+That leaves a deliberately small first-call input set:
+
+| Minimum first-call input | Why it matters |
+|---|---|
+| Domain | Establishes the public source estate and likely citation surfaces. |
+| Priority offer | Keeps the discussion attached to revenue, not vanity visibility. |
+| Target buyers | Defines whose answer journey matters. |
+| A few competitors or buyer questions | Gives the diagnostic an initial market frame without pretending it is complete. |
+
+This is not a full audit. It is the smallest useful frame for deciding whether a GEO diagnostic is relevant, what it should investigate, and what evidence would be worth collecting next.
+
+The seller can still be evidence-led on the call. They can look at the public site, ask how buyers describe the problem, discuss answer-led surfaces, identify likely source gaps, and separate known facts from hypotheses. What they should not do is imply that the buyer must arrive with a finished research archive before the first useful conversation is allowed to start.
+
+## Delivery-grade evidence belongs after the question is defined
+
+Once the first call establishes a real commercial question, deeper evidence becomes valuable because it has a job.
+
+Direct answer-engine transcripts can show what a surface actually said, under which prompt, date, location, or access condition. Visible citations can show whether the answer is drawing from the company site, third-party articles, directories, reviews, competitor pages, or unrelated material. Search Console and search evidence can help distinguish answer-led visibility from core search visibility.
+
+Sales language can reveal recurring buyer confusion. Proof assets can show whether public support exists for important claims. Technical source checks can identify whether key pages are accessible, coherent, indexable, internally linked, and aligned with the offer. Competitor and source mapping can show which references shape the market conversation.
+
+All of that can strengthen a GEO diagnostic. None of it needs to be demanded before the first call by default.
+
+The practical distinction is whether a piece of evidence changes what the team asks for next.
+
+If the question is, “Are answer-led systems describing our service as a software platform?”, then direct answer observations, cited sources, competitor pages, and offer-page language may matter quickly. If the question is, “Which buyer segment should we prioritise for the first diagnostic?”, sales notes and revenue context may matter more. If the question is, “Why are Google's AI features summarising this topic differently?”, the caveat matters: Google's AI features rely on core Search ranking and quality systems. The response should not be framed as flipping an `llms.txt` switch, adding special AI markup, chunking pages arbitrarily, or over-focusing structured data as if it were a magic control.
+
+Evidence is not being dismissed. It is being sequenced.
+
+## Label the evidence so speed does not become sloppiness
+
+The risk of a lighter first step is not that the buyer brings too little data. The risk is that the seller starts treating early observations as stronger than they are.
+
+A first call can produce hypotheses. It can identify likely buyer questions. It can expose obvious positioning conflicts. It can reveal that the public offer page is thin, that competitors own clearer category language, or that the company has no visible proof for a claim sales relies on.
+
+But the first call should not claim to prove answer-engine visibility, causality, ranking movement, or citation behaviour unless direct evidence exists.
+
+The discipline is to label the evidence as the work progresses:
+
+- direct answer-engine evidence: observed answers, prompts, dates, surfaces, access notes, and visible citations;
+- proxy or citation-surface evidence: search results, cited pages, third-party references, directories, reviews, and market pages that may inform answer-led discovery;
+- site and technical evidence: accessibility, indexability, page structure, internal links, offer clarity, and public source quality;
+- competitor and reference evidence: the sources and language that define alternatives in the buyer's category;
+- hypotheses: plausible explanations that still need testing.
+
+This labelling is what lets lower onboarding friction coexist with rigour. The buyer can start with a light input set, while the diagnostic remains honest about what is known, what is inferred, and what still needs evidence.
+
+## A better buyer journey
+
+The poor buyer journey says: “Before we can talk, please assemble the data room.”
+
+The better journey says: “Bring the domain, the offer you care about, the buyers you need to influence, and a few competitors or questions that keep appearing. We will use the first call to decide what evidence is actually worth collecting.”
+
+That changes the commercial feeling of the service. The buyer is not being asked to complete a project before finding out whether the project is worthwhile. They are being invited into a focused diagnostic conversation where their preparation burden matches the stage of decision.
+
+It also protects the delivery team. Instead of receiving a pile of unsorted material, the team can request the right evidence at the right moment: answer transcripts for a specific buyer question, Search Console evidence for a specific visibility hypothesis, sales notes for a specific objection pattern, proof assets for a specific claim gap, or technical checks for a specific source problem.
+
+This is different from narrowing the downstream budget after a diagnostic has already begun. The point here is earlier: reduce the burden before the first conversation without transferring uncertainty into vague promises. It is also different from using sales notes to create a lost-deal research brief. Sales notes may enrich the work later, but they are not the price of entry.
+
+The practical first-call rule is simple:
+
+Ask only for the inputs needed to decide whether there is a commercially meaningful GEO question. Request delivery-grade evidence when it will change what you ask for next, investigate, recommend, or prioritise.
+
+For buyers, that makes the first useful step feel lighter. For the diagnostic team, it keeps the work evidence-led. And for the commercial relationship, it sends the right signal: we will not make you organise the whole warehouse before we have agreed which shelf matters.


### PR DESCRIPTION
## Summary
- Adds Day 92 Build in Public post: “Do Not Build a Data Room Before Your First GEO Call”
- Publishes the approved final revision artifact as one clean blog-post file
- Keeps the first-call/data-room thesis, evidence sequencing, hypothesis caution, and Google caveat intact

## Verification
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-92.md`
- targeted frontmatter/content gate for title/date/slug/H1/`<!-- more -->`/forbidden terms
- `python3 -m pytest tests/test_validate_frontmatter.py`
- `mkdocs build --strict` (fails on existing nav/RoamLinks warnings; site still compiles)
- `mkdocs build`
- diff hygiene: exactly `docs/blog/posts/daily-blog-day-92.md`

## Notes
- Reviewer verdict consumed: `APPROVED`
- Research status consumed: `FRESH`
- This PR intentionally keeps Days 87-91 and PR #269 separate.
