### PR TITLE
docs: add daily blog day 93

### DIFF
--- a/docs/blog/posts/daily-blog-day-93.md
+++ b/docs/blog/posts/daily-blog-day-93.md
@@ -1,0 +1,165 @@
+---
+title: "Day 93: Audit the Stakeholder Lens Inside the AI Answer"
+date: 2026-07-22
+slug: "day-93-audit-stakeholder-lens-inside-ai-answer"
+description: "A mini teardown and practical GEO audit for CMOs, Marketing Directors, and founders: answer-led buying research can foreground an implicit stakeholder lens before sales hears the opportunity. Classify which evaluator's criteria are embedded in the answer, corroborate whether those concerns matter in real buying journeys, and respond proportionately without claiming the answer caused buyer behaviour."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - stakeholder alignment
+  - buyer research
+  - commercial strategy
+geo_tactics:
+  - "Audit commercially meaningful answer-led outputs for the implicit evaluator they foreground: finance, procurement, legal, security, technical, end-user, executive, or another buying role."
+  - Record the buyer question, surface context, criteria foregrounded, risk or assurance expected, alternatives suggested, decision consequence, corroboration source, and proportionate response.
+  - Treat an observed answer as evidence of what that surface said under recorded conditions, not proof that a buyer saw it, believed it, or reorganised their buying committee because of it.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 93: Audit the Stakeholder Lens Inside the AI Answer
+
+A buyer can arrive with the right company in mind and still bring the wrong approval question.
+
+The brand is not absent. The category is not wildly misdescribed. The answer may even recommend the company in broadly fair language. But inside the answer sits an implied evaluator: finance asking about cost control, procurement asking about process, legal asking about risk, security asking about data access, a technical lead asking about integrations, an end user asking about adoption, or an executive asking whether the work changes a board-level decision.
+
+For a CMO, Marketing Director, or founder, that matters because commercial momentum often slows when an invisible stakeholder concern appears late. The buyer has not necessarily been changed by an answer engine. They may never have seen the specific output your team captured. But answer-led buying research can show which criteria are being bundled into the market explanation before sales receives the opportunity.
+
+Generative Engine Optimization should therefore inspect more than brand mention, source citation, category accuracy, or share of answer. It should ask a sharper question: which stakeholder lens is the answer teaching the buyer to use?
+
+<!-- more -->
+
+## The answer may contain an evaluator
+
+Imagine a marketing leader researching a specialist GEO diagnostic for a B2B company. They ask an answer-led surface a practical question: “How should we evaluate firms that can help us understand whether AI answers are changing buyer research?”
+
+A generic answer might list sensible provider criteria: relevant experience, methodology, reporting, cost, references, and ability to work with existing marketing data.
+
+A more revealing answer foregrounds one role's concern. It might say:
+
+- finance should compare the diagnostic cost with internal analyst time and existing SEO tooling;
+- procurement should check deliverables, service boundaries, renewal terms, and vendor lock-in;
+- legal should review whether customer transcripts or sales notes will be shared externally;
+- security should confirm data access, storage, deletion, and third-party tool exposure;
+- a technical lead should inspect whether the work depends on integrations or crawler access;
+- end users should understand how findings will change sales, marketing, and content workflows;
+- executives should ask which commercial decision the diagnostic will support.
+
+None of those lenses is inherently bad. Some are exactly the questions a serious buyer should ask. The commercial issue is that each lens changes the path through the organisation.
+
+If the answer frames the work through finance, the next barrier may be budget justification. If it frames the work through procurement, the buyer may need a tighter scope and vendor comparison. If it frames the work through legal or security, the deal may wait for assurance about data handling. If it frames the work through end-user adoption, the question becomes whether the team can turn findings into daily behaviour.
+
+The same company can look credible under one lens and unfinished under another.
+
+## A mini teardown: visibility with a procurement lens
+
+Take a generalised example.
+
+A founder wants to understand why answer-led discovery is sending prospects into sales with mixed expectations. They search for specialist GEO diagnostics and find an answer that names a handful of providers, including a firm that is a plausible fit.
+
+On a surface-level visibility check, the result looks positive. The company is mentioned. The category is close enough. The answer does not invent a dramatic false claim.
+
+But the criteria in the answer are mostly procurement criteria: fixed deliverables, comparable packages, transparent pricing, standard reporting format, defined review cadence, cancellation terms, and ability to work without sensitive internal data. The answer also suggests lower-cost software tools as alternatives “if the organisation mainly needs ongoing monitoring”.
+
+That output does not prove procurement is now in charge of the deal. It does not prove the buyer will choose a tool. It does reveal that, in this observed answer, the buying problem has been compressed into a vendor-comparison and scope-control lens.
+
+That has practical consequences. The company may need public material that explains what the diagnostic does and does not include, when a tool is enough, when senior interpretation matters, which buyer decision the work supports, and what evidence is required before a larger programme is proposed. Sales may need a qualification question that distinguishes “we need monitoring” from “we need to understand a commercial route problem”. Marketing may need to make the service boundary clearer before prospects turn an advisory diagnostic into a commodity procurement exercise.
+
+The useful finding is not “AI caused the buyer to think this way”. The useful finding is narrower and safer: this answer foregrounded procurement criteria in a commercially meaningful query, and the business should check whether that lens also appears in sales conversations, comparison questions, or other relevant surfaces.
+
+## Run the stakeholder-lens audit
+
+A stakeholder-lens audit is deliberately compact. It is not another universal score. It is a way to name the evaluator embedded in the answer so the company can decide whether to respond.
+
+Start with high-intent questions, not vanity prompts. Use buyer language: “how should we evaluate”, “what are the risks of”, “which type of provider should we choose”, “what should a CMO ask before hiring”, “what alternatives should we compare”, or “what evidence would make this worth funding”.
+
+Then record the lens.
+
+| Audit field | What to capture | Why it matters |
+|---|---|---|
+| Buyer question | The exact question or scenario being tested. | Prevents a generic answer from being treated as a buying moment. |
+| Surface and context | The answer-led surface, date, location or account context where relevant, and visible sources where available. | Keeps the observation bounded to the conditions under which it appeared. |
+| Implicit evaluator | Finance, procurement, legal, security, technical, end-user, executive, or another role. | Names whose criteria the answer is foregrounding. |
+| Criteria foregrounded | Cost, risk, integration, compliance, adoption, proof, ownership, speed, fit, or alternatives. | Shows what the buyer may be invited to inspect next. |
+| Risk or assurance expected | The concern the company would need to satisfy. | Turns the finding into a commercial preparation question. |
+| Alternatives suggested | Tools, agencies, internal teams, consultants, platforms, status quo, or competitors. | Reveals which route the answer places beside the offer. |
+| Decision consequence | Budget approval, vendor comparison, data review, technical feasibility, internal ownership, or executive priority. | Connects the lens to a possible buying delay or acceleration. |
+| Corroboration source | Sales notes, customer interviews, call language, search context, visible citations, or repeated answer patterns. | Stops one output becoming market truth. |
+| Proportionate response | Observe, enable sales, clarify public material, publish a decision guide, test a page, or wait. | Keeps the action matched to the evidence. |
+
+The evaluator does not have to be singular. Some answers carry a blended lens. A comparison may start with executive urgency, then move into legal risk and procurement process. In that case, do not average the answer into a vague “stakeholder risk” score. Name the dominant lens and the secondary lens separately.
+
+The distinction matters because each response is different. A legal lens may need privacy boundaries and data-handling language. A finance lens may need cost-of-delay and budget-fit material. A technical lens may need implementation realities without pretending the work is a software integration. An executive lens may need the strategic decision the diagnostic makes possible.
+
+## Corroborate before responding loudly
+
+The audit should make the team more empirical, not more jumpy.
+
+An answer observed once is an observation. It can justify attention. It should not automatically justify a content sprint, sales alert, product-market rewrite, or board claim.
+
+Before acting, ask whether the stakeholder lens appears anywhere else:
+
+- Do sales calls contain the same concern in buyer language?
+- Do customer interviews reveal that the role genuinely influences approval?
+- Do relevant answer-led surfaces repeat the lens across similar questions?
+- Do visible citations or search results explain why the answer foregrounded that evaluator?
+- Do competitors publish material that makes the lens easier for answer systems to reuse?
+- Does the concern affect a real decision: budget, risk, scope, ownership, timing, integration, adoption, or executive priority?
+
+This keeps the finding separate from causality. The team can say, “We observed a security lens in these answers, and sales has heard data-access questions from serious prospects.” It should not say the answer independently created that requirement.
+
+That restraint is commercially useful. It protects the company from overreacting to one dramatic output while still preparing for concerns that may already be present in the buying journey.
+
+The same restraint applies across surfaces. ChatGPT, Claude, Perplexity, Gemini, Google AI features, search results, community discussions, review sites, and analyst-style pages can play different roles in research. Compare patterns where it helps, but do not flatten every surface into one truth. Google's AI features, in particular, rely on core Search ranking and quality systems; there is no special switch created by `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data that makes a stakeholder lens appear or disappear on command.
+
+## Use a proportionate response ladder
+
+Once the lens is named and corroborated, choose the smallest response that fits the evidence.
+
+### 1. Observe
+
+Use observe when the lens appears once, the query is exploratory, or the commercial consequence is unclear. Record the answer, context, evaluator, and possible implication. Do not turn it into a campaign.
+
+The output is a note: “This answer foregrounded procurement-style criteria for a provider-evaluation question. Watch for recurrence in comparison prompts and sales calls.”
+
+### 2. Corroborate
+
+Use corroborate when the concern could matter but the evidence is still thin. Run adjacent buyer questions, compare relevant surfaces, inspect visible sources where available, and ask sales or customer-facing teams whether the same language appears in real conversations.
+
+The output is a bounded research question, not a conclusion.
+
+### 3. Prioritise
+
+Use prioritise when the lens repeats and the consequence is commercially material. Decide whether the concern affects budget approval, legal review, procurement routing, security assessment, technical feasibility, adoption, or executive sponsorship.
+
+The output is an owner and a decision: who needs to satisfy this criterion, and where in the buyer journey it should be addressed.
+
+### 4. Publish, enable, or test
+
+Use publish when the public record lacks a clear answer for that evaluator. A finance lens may need a cost-and-scope explainer. A procurement lens may need package boundaries and comparison criteria. A legal or security lens may need plain-language data boundaries. A technical lens may need implementation assumptions. An end-user lens may need adoption and workflow examples. An executive lens may need a sharper explanation of the decision the work helps leadership make.
+
+Use enable when the concern is already entering sales conversations and the team needs accurate language now. Use test when the right response is uncertain and a smaller page, FAQ, comparison section, webinar, or sales note can teach the team before larger investment.
+
+### 5. Recheck
+
+After the response, recheck the buyer question and the real commercial signal. Did the public material become clearer? Did sales hear the concern less often, earlier, or in a more answerable form? Did relevant answer-led surfaces continue to foreground the same evaluator? Did another lens emerge?
+
+The goal is not to declare the answer “fixed”. The goal is to learn whether the company is better prepared for the criteria buyers may encounter before they speak to sales.
+
+## The leadership question
+
+The better question is not only:
+
+> Are we visible in AI answers?
+
+It is:
+
+> Which stakeholder lens does the answer ask the buyer to adopt, and are we ready to satisfy that evaluator without overreacting to a single observation?
+
+That question is useful because it connects answer-led research to commercial preparedness. It tells the CMO whether the next bottleneck may be budget, risk, procurement, technical feasibility, adoption, or executive priority. It tells the Marketing Director which public material may need to speak to a specific evaluator. It tells the founder whether the company is being understood through the decision they actually need to win.
+
+A brand mention can be accurate and still leave the buyer carrying a stakeholder concern the company has not prepared for.
+
+Audit the lens before the concern reaches the room.


### PR DESCRIPTION
## Summary
- Adds the approved Day 93 Build in Public post at `docs/blog/posts/daily-blog-day-93.md`
- Uses the APPROVED reviewer artifact for the stakeholder-lens audit angle
- Preserves the Google caveat, causality limits, buyer POV, and final CTA

## Verification
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-93.md` -> Frontmatter validation passed.
- `python3 tools/validate_frontmatter.py /home/claw/.hermes/zsa-editorial-artifacts/day-93/revision/daily-blog-day-93.md` -> Frontmatter validation passed.
- `cmp -s /home/claw/.hermes/zsa-editorial-artifacts/day-93/revision/daily-blog-day-93.md docs/blog/posts/daily-blog-day-93.md` -> identical.
- Required metadata/H1/slug/date/`<!-- more -->`/CTA/Google caveat markers present.
- Forbidden leakage scan returned 0 matches for repo/PR/Kanban/cron/worker/model-monitor/bugfix/tracker/implementation chronology/SearchGPT/ChatGPT-with-browsing terms.
- `PYTHONPATH=. pytest tests/test_validate_frontmatter.py test_markdown.py` -> 3 passed.
- `mkdocs build` -> passed; existing site warnings remain for nav exclusions, absolute nav paths, and unresolved RoamLinks/AutoLinks.

## Notes
- This PR changes exactly one intended file.
- Do not merge automatically; leaving open for human review.
