### PR TITLE
docs: add daily blog day 94

### DIFF
--- a/docs/blog/posts/daily-blog-day-94.md
+++ b/docs/blog/posts/daily-blog-day-94.md
@@ -1,0 +1,163 @@
+---
+title: "Day 94: Track the Route, Not Just the Rival"
+date: 2026-07-23
+slug: "day-94-track-the-route-not-just-the-rival"
+description: "A competitive GEO teardown and route-map checklist for CMOs, Marketing Directors, and founders: answer-led research can recommend software, an existing partner, an internal team, DIY, delay, or no purchase instead of a named rival. Classify the recommended route before treating brand mentions as the market."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - competitive strategy
+  - buyer journey
+  - commercial strategy
+geo_tactics:
+  - Classify the action route recommended by commercially meaningful answers before counting named competitors, citations, or share of answer.
+  - Distinguish named vendors, adjacent provider categories, software or tools, existing partners, internal teams, DIY checklists, delay, and status quo as different competitive outcomes.
+  - Record the buyer question, surface context, recommended route, named providers, substitute type, criteria, trade-offs, visible sources where available, decision consequence, corroboration, and proportionate response.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 94: Track the Route, Not Just the Rival
+
+A competitor report can look reassuring while the buyer is being advised not to buy from the category at all.
+
+The dashboard says the familiar rivals appeared. The brand was mentioned in some answers and absent in others. A few providers were cited. A shortlist was captured. The team can now argue about share of answer, citation quality, and which competitor is being named most often.
+
+But the buyer may have received a different recommendation: use the agency you already have, buy a monitoring tool, ask the internal content team to run the first test, follow a public checklist, wait until the market is clearer, or do nothing until the problem is more urgent.
+
+In that case, the commercial contest was not only brand versus brand.
+
+It was vendor purchase versus substitute route.
+
+For a CMO, Marketing Director, or founder, that distinction matters. Budget can leave the category without a named rival winning it. Momentum can move to an existing partner, a software line item, an internal team, a DIY experiment, a later quarter, or the status quo. Competitive Generative Engine Optimization therefore has to ask a prior question before counting competitor mentions:
+
+> What course of action did the answer recommend?
+
+<!-- more -->
+
+## The named rival is not always the market
+
+Most competitive visibility work begins with a sensible question: which providers appear when a buyer asks for help?
+
+That question is useful. It is also incomplete.
+
+Answer-led research often responds to a buyer problem by choosing a route before choosing a provider. A buyer might ask how to understand whether AI-shaped research is affecting pipeline quality, category framing, competitor comparison, or sales conversations. The answer can recommend several routes:
+
+- hire a named specialist provider;
+- use an adjacent agency, consultancy, analyst, SEO partner, or content firm;
+- buy software to monitor visibility or citations;
+- ask the existing agency or marketing operations team to extend their remit;
+- run an internal audit first;
+- use a free checklist, public framework, or template;
+- delay until there is stronger evidence;
+- keep the status quo because the answer frames the problem as low urgency.
+
+Those outcomes do not have the same commercial meaning.
+
+A named competitor appearing in a shortlist suggests one kind of battle: differentiation, proof, category clarity, comparison language, and sales follow-up. A software recommendation suggests another: tool-versus-service framing, setup assumptions, reporting expectations, and budget owner. A DIY recommendation suggests another: perceived simplicity, low urgency, internal capability, and the need to explain where judgement matters. A delay or status-quo recommendation suggests the problem has not crossed the threshold from interesting to fundable.
+
+If the report records only brand names, it misses that strategic fork.
+
+The company may think it is losing to Rival A when the answer is actually teaching the buyer to spend nothing, use what they already have, or put the work into a different budget line.
+
+## A route map catches substitution and non-consumption
+
+Imagine a founder researching how to understand whether answer-led discovery is changing the type of prospects entering sales.
+
+A brand-mention audit might ask whether specialist GEO firms appear, which competitors are named, which pages are cited, and whether the company is included. That is a necessary layer.
+
+A route-map audit asks what the buyer is being encouraged to do next.
+
+One observed answer might say a specialist diagnostic partner is useful when the issue affects positioning, sales qualification, and board-level investment. Another might say the company should start with its existing SEO agency because the work is mostly content and search visibility. Another might recommend a software platform because the buyer appears to need ongoing monitoring. Another might provide a step-by-step internal checklist and suggest hiring only if repeated patterns appear. Another might advise waiting because one strange answer does not justify a programme.
+
+None of those observations proves that a real buyer saw the answer, believed it, or acted on it. They do show how that surface, under recorded conditions, framed the next move.
+
+That is the commercial signal.
+
+A route-map audit treats those next moves as part of the competitive market. It does not collapse them into “we appeared” or “we did not appear”. It separates the practical alternatives a buyer may be encouraged to fund, delegate, defer, or avoid.
+
+## The route changes the buyer's criteria
+
+Routes carry evaluation rules.
+
+If the answer recommends a named vendor, the buyer may compare expertise, proof, category fit, methodology, commercial outcomes, and credibility. If it recommends an adjacent provider category, such as an existing SEO agency or content agency, the buyer may ask whether the problem is really specialist enough to justify a new partner. If it recommends software, the buyer may look for integrations, dashboards, exports, seats, subscriptions, and monthly reporting. If it recommends an internal team, the buyer may focus on time cost, skill coverage, ownership, and whether existing tools are enough.
+
+A DIY route carries a different burden. It implies the problem can be handled with a checklist, public guidance, and a few prompt runs. A delay route implies the evidence is not yet decision-grade. A status-quo route implies the cost of action is higher than the visible risk.
+
+That is why “do nothing” should not be used as a gimmick. It is a real substitute in commercial strategy. Non-consumption can win the buying moment when the answer makes the problem look too small, too early, too uncertain, too tactical, or too easy to absorb internally.
+
+For GEO, the route also changes the public work needed. A company that is omitted from a vendor shortlist may need comparison clarity. A company that is displaced by software may need to explain where interpretation, judgement, and commercial diagnosis sit beyond monitoring. A company that is displaced by an existing agency may need to define the boundary between general marketing support and specialist answer-led market research. A company that is displaced by DIY may need a no-hype explanation of when self-assessment is enough and when it becomes risky.
+
+Those are different responses. A bigger content calendar is not automatically the right one.
+
+## Run the route-map audit
+
+A practical route-map audit can be compact. The important move is to add the recommended route as a first-class field rather than treating it as background prose.
+
+| Audit field | What to capture | Why it matters |
+|---|---|---|
+| Buyer problem or question | The exact problem, role, and buying situation being tested. | Prevents generic prompts from being treated as commercial evidence. |
+| Surface and context | The answer-led surface, date, geography or account context where relevant, and visible source state where available. | Keeps the observation bounded to the conditions under which it appeared. |
+| Recommended route | Vendor, adjacent provider, software, existing partner, internal team, DIY, delay, status quo, or blended route. | Names the actual course of action being suggested. |
+| Named providers | Brands, firms, tools, agencies, analysts, directories, or no named provider. | Separates route choice from brand visibility. |
+| Substitute type | Internal capability, current supplier, cheaper tool, free resource, procurement delay, or non-consumption. | Shows where budget or momentum could move instead. |
+| Criteria and trade-offs | Cost, speed, expertise, risk, evidence strength, data access, delivery effort, ownership, or urgency. | Reveals why the answer made that route feel rational. |
+| Visible sources where available | Cited pages, search-visible material, comparison pages, directories, reviews, or no visible sources. | Helps distinguish source-supported recommendation from opaque summary. |
+| Decision consequence | Fund a vendor, expand a supplier, buy a tool, assign internally, run a test, defer, or take no action. | Connects the observation to a business decision. |
+| Corroboration | Related prompts, other surfaces, sales language, customer interviews, search context, or market evidence. | Stops one answer becoming market truth. |
+| Proportionate response | Observe, clarify, enable sales, adjust comparison language, test an asset, update source material, or wait. | Matches action to evidence strength. |
+
+The key column is “recommended route”. Without it, a report can list every brand in the answer and still miss the commercial instruction the buyer received.
+
+## Do not flatten the surfaces into one rule
+
+Route mapping needs restraint.
+
+ChatGPT, Claude, Perplexity, Gemini, Google AI features, search results, review sites, community pages, and specialist directories can all shape research differently. Some expose citations. Some do not. Some behave like source inspection. Some behave like broad advice. Some are used by buyers for education, others for comparison, drafting, reassurance, or challenge.
+
+An observed answer proves only what that answer said under recorded conditions. It does not prove that every surface would recommend the same route. It does not prove that a buyer saw the answer. It does not prove that the answer caused the buyer to choose the route.
+
+That limit is not a weakness. It is what keeps the audit useful.
+
+The team can still say: “In this comparison-style question, this surface recommended software first, named two tools, treated agencies as a secondary route, and suggested a specialist partner only after the buyer had repeated evidence.” That is a precise observation. It can be compared with other surfaces, sales conversations, search results, and customer language.
+
+The team should not say: “AI tells buyers to buy software instead of services.” That is too broad and probably false.
+
+Google needs the same discipline. Google's AI features rely on core Search ranking and quality systems. If a Google AI feature frames the route in a certain way, improve the underlying usefulness, relevance, source quality, and clarity of public material where the evidence supports it. Do not treat `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google AI visibility.
+
+## Choose the response by route, not panic
+
+Once the route is named and corroborated, the response should be smaller and sharper than “publish more content”.
+
+| Observed route | What it may mean | Proportionate response |
+|---|---|---|
+| Named specialist vendor | The buyer is in the category and comparing firms. | Improve differentiation, fit/no-fit cues, proof, comparison language, and sales follow-up. |
+| Adjacent provider or existing agency | The problem is being treated as close to work the buyer already funds. | Clarify when the adjacent partner is enough and when specialist diagnosis changes the decision. |
+| Software or tool | The answer has framed the need as monitoring, reporting, or workflow tooling. | Explain tool-versus-service trade-offs and where human judgement, commercial interpretation, or leadership decision support matters. |
+| Internal team or DIY | The problem appears manageable without external help. | Provide a bounded self-check and make the escalation threshold explicit. Do not punish buyers for wanting to learn first. |
+| Delay or status quo | The answer has not made urgency or commercial consequence clear. | Show the cost of waiting only where evidence supports it; otherwise keep observing. |
+| Blended route | The answer sees stages: self-check first, tool second, partner later. | Match the offer to the stage rather than forcing an all-or-nothing sale. |
+
+That last row is often the most realistic. A serious buyer may not need a provider immediately. They may need a quick self-check, then a focused diagnostic, then ongoing monitoring if the risk is real. If the answer suggests that sequence, the company should not respond as if every non-vendor route is an enemy. Some substitute routes are entry points. Some are qualification filters. Some are signs that the category is being misunderstood. Some are evidence that the buyer is not ready.
+
+The route-map audit helps leadership decide which is which.
+
+## The leadership question
+
+The weak question is:
+
+> Which competitors did the answer name?
+
+The stronger question is:
+
+> What did the answer advise the buyer to do, and would that route move budget, ownership, urgency, or momentum away from the vendor category?
+
+That question changes competitive GEO. It makes software, adjacent providers, existing partners, internal teams, DIY, delay, and no purchase visible as commercial alternatives. It also keeps the response proportionate. A named rival may require sharper differentiation. A DIY route may require an escalation threshold. A software route may require clearer service boundaries. A delay route may require better evidence of urgency or no response at all.
+
+For CMOs, Marketing Directors, and founders, the point is not to make every answer recommend the company. That would be fantasy. The point is to understand the market route the answer is normalising before budget moves.
+
+Track the rival, yes.
+
+But track the route first.


### PR DESCRIPTION
## Summary
- Adds Day 94 daily blog post: `Track the Route, Not Just the Rival`
- Applies the approved final artifact exactly to `docs/blog/posts/daily-blog-day-94.md`
- Keeps Day 93 PR #288 and unrelated PR #209 separate

## Verification
- `python3 /tmp/day94_checks.py` — PASS day94 content/frontmatter/privacy checks
- `mkdocs build --strict` — aborted on existing repo warnings (RoamLinks/AutoLinks/nav warnings; no build exception)
- `mkdocs build` — PASS, documentation built in 14.59 seconds
- `git diff --cached --name-only` before commit — exactly `docs/blog/posts/daily-blog-day-94.md`
- Artifact compare — exact match against `/home/claw/.hermes/zsa-editorial-artifacts/day-94/revision/daily-blog-day-94.md`

## Editorial gate
- Reviewer verdict consumed: `CHANGES_REQUESTED`
- Required replacements already applied in final artifact: `implementation assumptions` -> `setup assumptions`; `implementation effort` -> `delivery effort`
- Final cluster: route-map competitive GEO; recommended course of action as market unit
- Avoided clusters: signal governance, wrong-category/entity repair, unowned-question white space, sales loop, stakeholder lens
