### PR TITLE
docs: add daily blog day 95

### DIFF
--- a/docs/blog/posts/daily-blog-day-95.md
+++ b/docs/blog/posts/daily-blog-day-95.md
@@ -1,0 +1,166 @@
+---
+title: "Day 95: Sell the Decision, Not the Model Count"
+date: 2026-07-24
+slug: "day-95-sell-decision-not-model-count"
+description: "A buyer-facing GEO procurement framework for CMOs, Marketing Directors, and founders: a long model roster can look rigorous while still failing to explain which commercial decision the work will make safer. Judge decision coverage before buying model count."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - procurement
+  - commercial strategy
+  - buyer decision
+geo_tactics:
+  - "Evaluate GEO proposals by the commercial decision they can inform, not by the number of answer-led surfaces or models included in the delivery architecture."
+  - Map each buying question to the offer, buyer situation, relevant answer surfaces, direct or proxy access, decision supported, stated boundary, and next review trigger.
+  - Treat different answer-led surfaces as different research contexts with different evidence conditions; do not flatten them into one interchangeable model roster or promise deterministic answer movement.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 95: Sell the Decision, Not the Model Count
+
+A GEO proposal can look reassuringly technical and still leave the buyer unable to approve it.
+
+The supplier lists a broad roster of answer-led surfaces. The spreadsheet has many columns. The methodology says it will inspect prompts, mentions, citations, competitors, volatility, and source patterns. The language sounds rigorous enough for a CMO, Marketing Director, or founder to believe the work is comprehensive.
+
+Then the approval question arrives:
+
+> What decision will this make safer?
+
+If the answer is vague, the model count has become a substitute for commercial clarity.
+
+That is the procurement trap. Breadth can be useful, but breadth is not the same as decision coverage. A long roster may show delivery effort. It does not automatically show that the work covers the buyer situation that matters, the market question leadership needs answered, the surfaces where that question is likely to appear, the evidence that can realistically be collected, or the business action the findings can support.
+
+Generative Engine Optimization should not be sold as a bigger list of places to query. It should be sold as a disciplined way to reduce uncertainty around a named commercial decision.
+
+<!-- more -->
+
+## Model count is delivery architecture, not the product
+
+There is nothing wrong with inspecting multiple answer-led surfaces. Buyers increasingly encounter summaries, citations, comparison advice, shortlist language, and category explanations across ChatGPT, Claude, Perplexity, Gemini, Google AI features, search results, review sites, directories, community discussions, and specialist publications. Different surfaces can expose different public evidence and different research behaviours.
+
+The problem starts when the roster becomes the value proposition.
+
+A proposal that says “we check many models” may sound more serious than a proposal that checks fewer. But the buyer is not ultimately purchasing the right to fill more cells in a report. They are buying a safer decision.
+
+That decision might be:
+
+- whether to fund a GEO baseline before a positioning change;
+- whether a new offer is being understood by the market;
+- whether answer-led research is sending buyers towards a software route, a service route, DIY, delay, or a named provider;
+- whether a category page, comparison page, or sales enablement asset deserves budget;
+- whether leadership should prioritise one buyer segment, use case, or market question over another;
+- whether a visibility problem is urgent enough to assign an owner and review cadence.
+
+Those are not model-count questions. They are business questions.
+
+The model roster sits underneath them. It is part of the delivery design: where to look, under what conditions, with which limits, and how to record observations responsibly. But a buyer should not have to infer the commercial decision from the technical breadth.
+
+If a provider cannot name the decision, the buyer is being asked to buy instrumentation before agreeing what the instrument is for.
+
+## A buyer scenario: the broad audit with no approval path
+
+Imagine a Marketing Director at a B2B company preparing a budget request.
+
+The company sells a specialist advisory service. Sales has started hearing that prospects are arriving with mixed assumptions: some think the offer is a monitoring tool, some think it is a content project, and some think it is a strategic diagnostic. The team suspects answer-led research may be shaping those assumptions, but they do not know which commercial question to test first.
+
+Three providers respond.
+
+Provider A promises the largest model roster. The proposal lists many surfaces, many tests, and many metrics. It sounds thorough, but the deliverable is framed as a visibility report.
+
+Provider B promises a quick benchmark. It will say whether the company is mentioned more or less often than a few named competitors. The scope is tidy, but it treats the buyer's problem as a ranking contest.
+
+Provider C starts with the decision: “Should leadership fund clearer offer and category material before the next campaign, or is the current confusion mainly a sales qualification issue?” It then explains which buyer situations will be tested, which surfaces are relevant to those situations, what direct evidence is available, what will remain proxy evidence, and what the findings can and cannot support.
+
+Provider C may still inspect multiple surfaces. It may still use structured records. It may still compare patterns across buyer questions. The difference is that the technical work has a commercial job.
+
+The buyer can take that to leadership because the output is not just “here is what several models said”. It is “here is the decision this evidence can make less risky, and here are the limits around that decision”.
+
+That distinction matters in procurement. A line item with a clear decision path competes better than a line item with an impressive methodology and an unclear use.
+
+## Decision coverage has six parts
+
+A practical GEO proposal should make decision coverage explicit before it talks about volume.
+
+The frame can be compact. It does not need to become another dashboard. It should answer six buyer-side questions.
+
+| Coverage field | Buyer question | Why it matters |
+|---|---|---|
+| Commercial decision | What decision will this work make safer? | Keeps the engagement tied to budget, timing, ownership, or priority rather than research for its own sake. |
+| Offer and buyer situation | Which offer, segment, role, use case, or buying moment is in scope? | Prevents a broad brand audit from pretending to cover every market question. |
+| Relevant answer surfaces | Where might this buyer realistically research, compare, validate, or challenge the offer? | Selects surfaces because they fit the decision, not because they increase the roster. |
+| Evidence and access condition | What can be directly observed, what is proxy evidence, and where are sources opaque or unavailable? | Stops screenshots, citations, and one-off outputs becoming stronger evidence than they are. |
+| Decision support and boundary | What can the findings support, and what should they not be used to claim? | Protects leadership from turning bounded observations into market-wide conclusions. |
+| Next review trigger | What change would justify another look? | Turns the work into an operating rhythm only where a trigger exists, not an endless measurement habit. |
+
+The most important row is the first one. If the commercial decision is missing, the other rows become busywork.
+
+A buyer can ask a simple procurement question:
+
+> If this work returns a clear finding, what will we do differently?
+
+If the answer is “we will have a better dashboard”, the scope is not yet buyer-ready. If the answer is “we will decide whether to rewrite the offer page, enable sales around a specific objection, separate a service from a tool category, prioritise one buyer segment, or delay spend because the evidence is weak”, the work has a decision path.
+
+## Surfaces are not interchangeable
+
+A model roster can also hide a second problem: it can imply that every surface provides equivalent evidence.
+
+They do not.
+
+Some answer-led surfaces expose sources. Some summarise without visible citations. Some are closer to a research assistant. Some are embedded in a search journey. Some are used for education, some for comparison, some for objection handling, some for drafting internal recommendations. Geography, account context, query wording, freshness, source availability, and the buyer's intent can all change what the observation means.
+
+That does not make the work impossible. It means the proposal should be honest about evidence conditions.
+
+For example:
+
+- a cited comparison answer may help inspect which public pages shape provider selection;
+- an uncited answer may still reveal a plausible buyer framing, but it is weaker evidence for source repair;
+- a search-linked AI feature should be interpreted with the caveat that Google's AI experiences rely on core Search ranking and quality systems;
+- a conversational answer may be useful for scenario testing, but it should not be treated as proof that buyers encountered the same output;
+- a repeated pattern across relevant buyer questions is stronger than one dramatic response.
+
+This is why “we cover more models” is not enough. More surfaces can add useful context, but they can also add noise if the engagement does not explain what each surface contributes to the decision.
+
+A serious proposal should say why a surface is included, what evidence it can provide, what it cannot prove, and how its findings will be weighted.
+
+## What buyers should ask before approving a GEO scope
+
+Before approving a broad visibility package, buyers can ask seven practical questions:
+
+1. Which business decision will this work inform?
+2. Which offer, buyer situation, and market question are in scope?
+3. Why do these answer-led surfaces matter for that decision?
+4. What direct evidence can we collect, and what will only be proxy evidence?
+5. What would count as a material pattern rather than a one-off observation?
+6. What claims will the work explicitly not make?
+7. What action, owner, or review trigger could follow from the findings?
+
+These questions do not punish technical breadth. They make it useful.
+
+A provider with a larger roster should be able to explain how that roster improves decision coverage. Perhaps it captures different buyer research contexts. Perhaps it separates cited source patterns from opaque summaries. Perhaps it helps distinguish category language from competitor comparison language. Perhaps it shows that a finding is surface-specific rather than market-wide.
+
+Good. Say that.
+
+But if the roster is only there to create the impression of rigour, the buyer should be sceptical. Query volume is easier to sell than commercial usefulness because it is countable. Decision coverage is harder because it requires judgement: what matters, what is out of scope, what evidence is strong enough, and what leadership can responsibly do next.
+
+That judgement is where the value sits.
+
+## The leadership question
+
+The weak question is:
+
+> How many models do you check?
+
+The stronger question is:
+
+> Which commercial decision will your coverage make safer, and what will remain outside the evidence?
+
+That question changes the buying conversation. It stops GEO becoming a procurement contest over roster size. It asks whether the work covers the buyer situation that matters, whether the evidence condition is clear, whether the findings can support a real decision, and whether the boundaries are honest.
+
+For CMOs, Marketing Directors, and founders, the point is not to buy the smallest possible audit. Nor is it to buy the biggest possible model list. The point is to fund the work that makes a priority decision less speculative.
+
+Model count can support that work.
+
+It should not be mistaken for it.


### PR DESCRIPTION
## Summary
- Adds Day 95 Build in Public post: `docs/blog/posts/daily-blog-day-95.md`
- Applies the approved final revision exactly from the Day 95 editorial artifact
- Keeps the PR payload to one blog-post file only

## Verification
- `cmp /home/claw/.hermes/zsa-editorial-artifacts/day-95/revision/daily-blog-day-95.md docs/blog/posts/daily-blog-day-95.md` — passed
- `python3 /tmp/validate_day95.py` — passed frontmatter/content guard checks
- `mkdocs build --strict` — failed on existing repository warnings (RoamLinks/AutoLinks and absolute nav path warnings), not a build error
- `mkdocs build` — passed
- `git diff origin/main...HEAD --name-only` — exactly `docs/blog/posts/daily-blog-day-95.md`
