### PR TITLE
docs: add daily blog day 96

### DIFF
--- a/docs/blog/posts/daily-blog-day-96.md
+++ b/docs/blog/posts/daily-blog-day-96.md
@@ -1,0 +1,156 @@
+---
+title: "Day 96: The First Prompt Is Not the Buying Journey"
+date: 2026-07-25
+slug: "day-96-first-prompt-is-not-buying-journey"
+description: "A three-turn buyer-scenario walkthrough for CMOs, Marketing Directors, and founders: early answer-led visibility can hide where relevance is lost as the buyer moves from category learning to comparison, risk, approval, and next step. Map the question chain before treating one prompt as the journey."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - buyer journey
+  - question design
+  - commercial strategy
+geo_tactics:
+  - Map answer-led buying research as a question chain, not as a set of isolated prompt rankings, so discovery, comparison, risk, approval, and action questions are interpreted together.
+  - Record how the buyer question, category frame, alternatives, criteria, useful source, and commercial next step change from one turn to the next.
+  - Treat a synthetic chain as a bounded research design, not proof of real buyer behaviour; corroborate important transitions with transcripts, sales language, customer interviews, observed journeys, or repeated answer-surface evidence where available.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 96: The First Prompt Is Not the Buying Journey
+
+A brand can win the first answer and still lose the buyer by the third question.
+
+That is the problem with treating Generative Engine Optimization as a set of isolated prompt rankings. The first answer may include the company. It may even describe the category fairly and cite a useful source. The report can record a positive mention, a decent position, and a plausible competitor set.
+
+Then the buyer asks a follow-up.
+
+The frame changes. A broad category question becomes a comparison question. A comparison question becomes a risk question. A risk question becomes an approval question. The brand that looked relevant at the start may disappear, be reclassified, sit beside different alternatives, or face criteria its public material does not answer.
+
+For CMOs, Marketing Directors, and founders, the commercial question is therefore not only “did we appear for the first prompt?” It is “where does the buyer's research lose momentum as the questions change?”
+
+<!-- more -->
+
+## One answer is not the research journey
+
+Most answer-led visibility work is easier to manage when each prompt is treated as a separate observation. That is understandable. A team can record the surface, prompt wording, date, visible citations, brand mentions, competitors, and summary. The rows are neat. Movement can be measured.
+
+But buyers do not always think in rows.
+
+A serious buyer may begin with curiosity, then narrow the market, then test risk, then prepare an internal recommendation. Each question can make a different job visible:
+
+- learn what the category means;
+- understand which routes or provider types exist;
+- compare a shortlist;
+- identify risks, costs, and objections;
+- decide what evidence leadership needs before approving next steps.
+
+A one-prompt report can miss that sequence. It can show that the company appears in early category education while failing to show that the same buyer is later steered towards software, an existing agency, an internal test, a procurement checklist, or no action. It can also miss the opposite pattern: a company may be absent from a broad first answer but become highly relevant once the buyer asks a sharper commercial question.
+
+That is why the unit of analysis should sometimes be the transition between questions, not only the answer to one question.
+
+## A three-turn buyer scenario
+
+Imagine a Marketing Director at a B2B company trying to understand whether answer-led discovery is changing the quality of prospects entering sales. The company is not yet buying anything. The buyer is trying to name the problem.
+
+Turn one is broad:
+
+> “How should a B2B marketing team understand whether AI answers are affecting buyer research?”
+
+A visibility report might stop here. The answer explains the category, mentions several tactics, names a few providers, and includes the brand. Good news.
+
+But the buyer has not made a buying decision. They have only learned a frame. The next question is more commercial:
+
+> “Should we hire a specialist partner, use our current SEO agency, or buy a monitoring tool for this?”
+
+Now the answer has a different job. It may separate strategic diagnosis from reporting software. It may make the current SEO agency sound sufficient for early checks. It may say a specialist partner is useful only when the issue affects positioning, sales qualification, or leadership decisions. The brand's early inclusion is no longer the whole story. The buyer is comparing routes, not only names.
+
+Then comes a third question:
+
+> “What would we need to show the board before funding a diagnostic?”
+
+The criteria change again. The answer may talk about revenue risk, evidence from sales conversations, repeated answer observations, source clarity, budget size, owner, and decision consequence. A company that appeared in turn one can still lose relevance if its public material never explains what evidence a diagnostic produces, what decision it supports, when a tool is enough, or why leadership should care now.
+
+This synthetic chain does not prove that real buyers use those exact words or follow those exact steps. It is a research design. Its value is to expose how meaning changes from question to question so the team can decide what deserves corroboration in real transcripts, sales notes, customer interviews, search behaviour, or observed answer-led journeys.
+
+## What the isolated report misses
+
+The isolated-prompt view asks:
+
+> Did the brand appear in this answer?
+
+That is a useful question, but it is incomplete.
+
+The question-chain view asks a different set of questions:
+
+- What did the buyer learn in the first answer?
+- What follow-up did that answer make natural?
+- Did the category frame become broader, narrower, or different?
+- Which alternatives entered or left the consideration set?
+- Which evaluation criteria became important in the next turn?
+- What source, proof, comparison page, sales asset, or public explanation would help the buyer continue?
+- Did the chain create a sensible next step, or did momentum leak into delay, DIY, an adjacent provider, or no action?
+
+Those questions turn GEO from a mention check into a journey diagnostic.
+
+The practical difference is sharp. If the company appears in turn one but disappears when the buyer compares routes, the response may be clearer positioning and comparison language. If it survives comparison but fails at board approval, the response may be a stronger decision case, evidence boundary, or sales enablement asset. If the answer keeps pushing the buyer towards a tool, the issue may be tool-versus-service framing. If the answer suggests no action until evidence is stronger, the right response may be a small self-check rather than a louder sales page.
+
+The point is not to force every turn towards the company. That would be fantasy and bad advice. The point is to understand where a serious buyer's next question stops carrying the company forward.
+
+## Use a compact question-chain method
+
+A question-chain review does not need to become a large audit table. Start with one commercially important buyer scenario and map three turns.
+
+For each turn, write one short note under six headings:
+
+1. Buyer question: what the buyer is trying to learn now.
+2. Frame: how the answer defines the problem, category, route, or decision.
+3. Alternatives: which provider types, competitors, internal options, tools, delays, or no-action routes appear.
+4. Criteria: what the buyer is told to evaluate next.
+5. Useful source: what public page, comparison, proof point, sales asset, or external reference would help the buyer continue responsibly.
+6. Transition: what question the answer makes likely next.
+
+The sixth heading is the one most prompt reports miss.
+
+A buyer journey is not only a collection of outputs. It is also a chain of invitations. Each answer teaches the buyer what to ask next. If the next question moves away from the company's offer, changes the budget owner, reframes the problem as software, or asks for proof the company does not publish, the visibility problem may sit between turns rather than inside a single answer.
+
+That changes the work. The team is not simply trying to improve a rank, chase a citation, or publish more generic content. It is deciding where the buyer needs a clearer bridge from category learning to comparison, from comparison to risk, from risk to approval, and from approval to action.
+
+## Keep the evidence bounded
+
+Question chains need restraint because they can tempt teams into storytelling.
+
+A synthetic three-turn path is not buyer evidence by itself. It does not prove that customers asked those questions, saw those answers, trusted them, or acted on them. It can show where a research design should look next. It can help a team find weak transitions in public positioning. It can produce hypotheses for sales, marketing, and leadership to test.
+
+Before making a large decision, corroborate the important transitions:
+
+- do sales calls contain similar follow-up questions or objections?
+- do customer interviews reveal the same comparison, risk, or approval criteria?
+- do relevant answer-led surfaces repeat the transition across sensible variants?
+- do visible citations or search results explain why a route or criterion appears?
+- does the company have public material that answers the next question in buyer language?
+- would fixing this transition change a real commercial decision?
+
+That evidence discipline matters across every answer-led surface. ChatGPT, Claude, Perplexity, Gemini, Google AI features, search results, review sites, directories, community discussions, and specialist publications can all play different roles in research. Some expose sources. Some do not. Some are useful for comparison, others for explanation, drafting, reassurance, or challenge. Do not flatten them into one universal rule.
+
+Google needs the familiar caveat as well. Google's AI features rely on core Search ranking and quality systems. Improve the usefulness, clarity, relevance, and quality of the public material where the evidence supports it. Do not treat `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google AI visibility.
+
+## The leadership question
+
+The weak question is:
+
+> Did we appear for the first prompt?
+
+The stronger question is:
+
+> As the buyer's questions move from discovery to comparison, risk, approval, and next step, where does our relevance strengthen, weaken, or vanish?
+
+That question is more useful because it matches how commercial uncertainty often unfolds. A CMO may need to know whether the first category explanation leads to the right comparison. A Marketing Director may need to know whether the comparison leads to useful proof. A founder may need to know whether the approval question makes the work feel urgent, optional, internal, or not worth funding yet.
+
+For buyers, this makes GEO less theatrical. The goal is not to make every answer mention the company. The goal is to make sure a serious research journey can move from curiosity to a responsible next step without the company becoming irrelevant for reasons it could have clarified.
+
+If the first prompt looks good, do not stop there.
+
+Ask what the buyer asks next.


### PR DESCRIPTION
## Summary
- Adds Day 96 blog post from the approved final editorial artifact.
- Keeps the payload scoped to `docs/blog/posts/daily-blog-day-96.md` only.
- Preserves the approved title/date/slug and bounded three-turn question-chain angle.

## Checks
- `python tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-96.md` — passed.
- `python /tmp/day96_content_check.py` — passed.
- `mkdocs build` — passed.
- `mkdocs build --strict` — failed on existing site warnings from roamlinks/autolinks/nav, while non-strict build passed.

## Notes
- Reviewer verdict consumed: `APPROVED`.
- Final artifact source: `/home/claw/.hermes/zsa-editorial-artifacts/day-96/revision/daily-blog-day-96.md`.
- Day 95 PR #291 remains separate.
