### PR TITLE
docs: add daily blog day 97

### DIFF
--- a/docs/blog/posts/daily-blog-day-97.md
+++ b/docs/blog/posts/daily-blog-day-97.md
@@ -1,0 +1,146 @@
+---
+title: "Day 97: Price the Exceptions Before You Automate the Workflow"
+date: 2026-07-26
+slug: "day-97-price-exceptions-before-automating-workflow"
+description: "A buyer-facing workflow-scoping field note for CMOs, Marketing Directors, and founders: happy-path automation makes GEO, research, content, and reporting workflows look cheap. The real scope sits in access limits, ambiguous evidence, private data, approval authority, irreversible decisions, and recovery."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - workflow automation
+  - commercial strategy
+  - scope design
+geo_tactics:
+  - Price GEO, research, content, and reporting automation around the exception path: missing access, ambiguous inputs, conflicting observations, sensitive data, approval authority, irreversible actions, and recovery.
+  - Separate clean API or webhook workflows with reversible outputs from scraping, RPA, email parsing, sensitive-data handling, ambiguous evidence review, and publication or positioning decisions.
+  - Define block, route, and recover rules before implementation so buyers know which exceptions can be automated, which require escalation, and who has authority to decide.
+  - Keep answer-engine evidence bounded: routine prompt capture and comparison may be automatable, but missing access, unsupported claims, conflicting observations, and publish decisions need explicit exception handling.
+---
+
+# Day 97: Price the Exceptions Before You Automate the Workflow
+
+A workflow can look profitable on the demo and expensive in the first exception.
+
+The happy path is clean. A marketing team wants to monitor AI visibility, compare answer-led mentions, draft a short internal summary, and turn the strongest findings into content, sales language, or a leadership note. The automation shows neat rows, fast drafts, and tidy handoffs. On paper, the business case looks obvious: fewer manual checks, quicker reporting, more output.
+
+Then the first awkward case appears. Access to one answer surface is unavailable. A captured answer conflicts with another observation. A claim looks commercially useful but is not supported by the public evidence. A sales note contains private data. A draft would change positioning in a way nobody has approved. A scheduled report says “visibility is down” but the issue is actually a capture failure, not the market.
+
+That is where the real scope begins.
+
+For CMOs, Marketing Directors, and founders, the question is not whether an autonomous workflow can produce the expected output when everything is available, unambiguous, and reversible. It is whether the workflow has priced, designed, and governed the exceptions that carry commercial risk.
+
+<!-- more -->
+
+## The cheap part is usually the normal case
+
+Most commercial workflow automation is sold through the normal case because the normal case is easy to show.
+
+A clean API returns data. A webhook fires. A form has the right fields. A prompt run completes. A comparison record is generated. A summary is drafted. A dashboard updates. A task moves from one stage to the next.
+
+Those are useful efficiencies. They can reduce operational drag, make reporting more consistent, and remove work that should never have depended on a person copying fields between systems. In GEO, routine prompt capture, evidence labelling, answer comparison, draft memo creation, and basic completeness checks can often be systematised.
+
+But the normal case does not tell a buyer enough about implementation risk.
+
+The expensive work sits where the workflow has to decide what to do when the input is incomplete, the evidence conflicts, the output could mislead a buyer, the next action changes public positioning, or the system is not authorised to proceed. A process that is cheap for 90 routine records and unsafe for 10 ambiguous ones may be worse than the manual process it replaced, because it moves unresolved judgement into a faster channel.
+
+That is why automation should not be scoped around task volume or hours saved. It should be scoped around exception economics.
+
+## A scenario: the AI visibility report that should not publish itself
+
+Imagine a B2B company building an automated AI visibility workflow.
+
+The intended process is sensible. Each week, the system captures a set of commercially important buyer questions across relevant answer-led surfaces, records visible citations where available, compares the brand with named competitors and substitute routes, drafts a short management note, and proposes public or sales-facing follow-up actions.
+
+On the happy path, the workflow is valuable. It can show whether the company is being framed as a strategic diagnostic partner, a monitoring tool, a content service, an existing-agency task, or a DIY exercise. It can help leadership see which buyer questions deserve attention. It can reduce the delay between market observation and commercial response.
+
+But the first serious run produces a mixed result.
+
+One surface cannot be accessed directly that week. Another gives an uncited answer that looks alarming but may be ordinary variation. A cited result describes the company accurately, but the supporting source is old. A competitor appears strongly in one comparison, while another surface recommends that buyers delay action until evidence is stronger. The draft summary suggests changing the offer page, but that change would affect sales positioning and board-level messaging.
+
+The automation has not failed because it found messy evidence. Messy evidence is the job. It fails only if the scope assumed that every record could flow through to a confident recommendation.
+
+A mature workflow would not ask, “How many outputs can we generate?” It would ask, “Which exceptions can we block, route, or recover from without creating decision risk?”
+
+## Build a compact exception inventory before buying the workflow
+
+An exception inventory does not need to be a large audit table. It needs to make the commercial burden visible before anyone commits to a price, platform, or implementation plan.
+
+A useful version can be compact:
+
+| Exception | Commercial consequence | Block, route, or recover rule |
+|---|---|---|
+| Access is unavailable for a relevant answer surface. | The report may confuse a setup or capture problem with real market invisibility. | Block the surface-specific conclusion, label the access gap, and recover by retesting or using clearly marked proxy evidence. |
+| Inputs are ambiguous, incomplete, or inferred. | The workflow may turn weak source material into strong management language. | Route to a defined evidence check before the observation can support budget, positioning, or sales action. |
+| Observations conflict across surfaces or runs. | Leadership may overreact to a single dramatic answer or average away a meaningful split. | Recover by separating surface-specific findings from broader patterns; block universal claims unless corroboration exists. |
+| Sensitive sales, customer, or commercial data appears. | The workflow may leak private context into tools, drafts, or public material. | Block public output and route to the authorised owner for redaction, minimisation, or exclusion. |
+| The suggested action changes public positioning, pricing language, offer boundaries, or buyer promises. | A fast draft could create commitments the business has not approved. | Route to the person with commercial authority; the system may prepare options, not publish the change. |
+| The next step is irreversible or costly to unwind. | Publishing, budget movement, campaign launch, or partner communication may create downstream risk. | Require an explicit approval gate and a recovery plan before execution. |
+| The workflow produces no clear recommendation. | The business may mistake “inconclusive” for “nothing matters” or “the system failed”. | Recover with a labelled inconclusive state, a next evidence step, or a decision to wait. |
+
+The important detail is not the table format. It is the shift in buying conversation.
+
+Instead of asking, “How many reports can this generate?” the buyer asks, “Which exceptions are expected, which are rare but serious, which can be handled automatically, which need a named authority, and what happens when recovery fails?”
+
+That is a much better scoping unit than hours saved.
+
+## Some workflows are naturally safer than others
+
+Not every automation carries the same exception burden.
+
+A clean API or webhook workflow with well-defined fields, reversible updates, non-sensitive data, and a clear retry path is a different implementation class from scraping a changing interface, using RPA over a fragile tool, parsing unstructured email, summarising private sales notes, or drafting public claims from mixed evidence.
+
+The first class may mostly need reliability engineering: authentication, schema validation, retries, logging, rate limits, monitoring, and a rollback plan. The second class also needs judgement design: what the system is allowed to infer, what it must not claim, what data it may handle, which errors change the commercial meaning of the result, and who can authorise the next step.
+
+GEO workflows often combine both classes.
+
+Capturing routine observations can be relatively mechanical. Interpreting them for a leadership decision is not. A missing direct observation might mean a temporary access issue, a methodology limit, a surface-specific constraint, or a real visibility problem. Conflicting answers might mean normal variation, buyer-context sensitivity, source drift, competitor movement, or a weak prompt design. A good workflow separates those states before turning them into action.
+
+That separation matters because buyers do not buy automation in the abstract. They buy lower leakage, lower decision risk, faster learning, clearer accountability, and a safer way to move from observation to action.
+
+## Authority is part of the scope
+
+Many failed automation scopes hide the authority question until late.
+
+The system is allowed to collect. Is it allowed to interpret? It is allowed to draft. Is it allowed to send? It is allowed to recommend a page change. Is it allowed to publish? It is allowed to flag a sales objection. Is it allowed to change the approved response? It is allowed to detect a budget-relevant pattern. Is it allowed to tell leadership that the market has moved?
+
+Those are different permissions.
+
+For low-risk, reversible work, the system may proceed automatically. For higher-risk work, the system may only prepare a recommendation. For public claims, private data, pricing language, legal exposure, offer boundaries, or board-level decisions, the workflow needs explicit authority mapping.
+
+That does not mean every exception needs a human. Some exceptions can be handled by retries, fallback sources, stricter validation, automatic redaction, confidence labels, or a safe “no conclusion” state. But the scope should say which route applies.
+
+The commercial mistake is to treat human involvement as an embarrassment or a failure of automation. In reality, authority mapping is part of the product. It tells the buyer where the system reduces work, where it reduces risk, and where it deliberately refuses to turn uncertainty into momentum.
+
+## Price the recovery path, not the fantasy
+
+A buyer-facing automation proposal should make the recovery path visible.
+
+If access fails, how is the report labelled? If evidence conflicts, who decides whether to retest, wait, or act? If a draft contains a claim that public sources do not support, does the system block it or soften it? If a sensitive note appears, where is it stripped out? If a recommendation would change positioning, who has approval authority? If a report later proves wrong, how does the team correct the record and prevent the same failure from recurring?
+
+Those answers shape discovery, platform choice, implementation effort, monitoring, maintenance, and price.
+
+A workflow built on reliable structured inputs, reversible actions, and low-risk outputs can be priced and delivered differently from a workflow that must manage access uncertainty, opaque answer surfaces, private evidence, judgement calls, and irreversible publication decisions. Treating both as “automation” hides the real cost from the buyer and the real risk from the supplier.
+
+That is why “we will save X hours” is usually the wrong centre of the business case. Hours saved are only valuable if the workflow also protects the decisions those hours used to contain. If the system accelerates unresolved judgement, the buyer has not bought efficiency. They have bought faster ambiguity.
+
+## The leadership question
+
+The weak question is:
+
+> How much of this workflow can we automate?
+
+The stronger question is:
+
+> Which exceptions make this workflow commercially risky, and have we priced the block, route, and recovery path before we automate the happy path?
+
+That question changes the buying conversation. It makes implementation class, evidence limits, platform fit, sensitive data, approval authority, monitoring, and maintenance visible before commitment. It helps a CMO distinguish a useful automation scope from a demo that only works when nothing difficult happens.
+
+For GEO, research, content, and reporting workflows, the point is not to automate the mess out of existence. The point is to design a system that knows what kind of mess it is looking at.
+
+Routine cases should move quickly. Ambiguous cases should be labelled. Sensitive cases should be contained. Irreversible cases should require authority. Failed cases should recover without pretending the market was the problem.
+
+Price that exception path first.
+
+Then automate the workflow.

--- a/docs/blog/posts/daily-blog-day-97.md
+++ b/docs/blog/posts/daily-blog-day-97.md
@@ -13,10 +13,10 @@ tags:
   - commercial strategy
   - scope design
 geo_tactics:
-  - Price GEO, research, content, and reporting automation around the exception path: missing access, ambiguous inputs, conflicting observations, sensitive data, approval authority, irreversible actions, and recovery.
+  - "Price GEO, research, content, and reporting automation around the exception path: missing access, ambiguous inputs, conflicting observations, sensitive data, approval authority, irreversible actions, and recovery."
   - Separate clean API or webhook workflows with reversible outputs from scraping, RPA, email parsing, sensitive-data handling, ambiguous evidence review, and publication or positioning decisions.
   - Define block, route, and recover rules before implementation so buyers know which exceptions can be automated, which require escalation, and who has authority to decide.
-  - Keep answer-engine evidence bounded: routine prompt capture and comparison may be automatable, but missing access, unsupported claims, conflicting observations, and publish decisions need explicit exception handling.
+  - "Keep answer-engine evidence bounded: routine prompt capture and comparison may be automatable, but missing access, unsupported claims, conflicting observations, and publish decisions need explicit exception handling."
 ---
 
 # Day 97: Price the Exceptions Before You Automate the Workflow


### PR DESCRIPTION
## Summary
- Adds the approved Day 97 Build in Public post.
- Applies only the final revision artifact for `docs/blog/posts/daily-blog-day-97.md`.

## Validation
- `python3 /tmp/day97_validate.py` passed: frontmatter, H1, date, slug, `<!-- more -->`, and forbidden-term scan.
- `sha256sum` confirmed the repo post matches the approved revision artifact exactly.
- `python3 -m mkdocs build` passed.

## Reviewer verdict consumed
- `APPROVED` from `/home/claw/.hermes/zsa-editorial-artifacts/day-97/review/publish-readiness.md`.
