### PR TITLE
docs: add daily blog day 98

### DIFF
--- a/docs/blog/posts/daily-blog-day-98.md
+++ b/docs/blog/posts/daily-blog-day-98.md
@@ -14,7 +14,7 @@ tags:
   - commercial strategy
 geo_tactics:
   - Use answer-led comparisons to inspect whether providers are merely named, which reasons-to-choose are attributed, and whether those reasons are distinctive or interchangeable.
-  - Separate distribution weakness from positioning weakness: if a real difference exists but is not surfaced, clarify public explanation; if no defensible difference exists, sharpen the offer before amplifying it.
+  - "Separate distribution weakness from positioning weakness: if a real difference exists but is not surfaced, clarify public explanation; if no defensible difference exists, sharpen the offer before amplifying it."
   - Record visible trade-offs, fit boundaries, buyer situations, and exclusion criteria so comparison language does not collapse every provider into the same generic promise.
   - Treat each answer-led observation as bounded to the surface, prompt, date, and context observed; do not claim one answer proves buyer perception, platform-wide consensus, or deterministic visibility movement.
 ---

--- a/docs/blog/posts/daily-blog-day-98.md
+++ b/docs/blog/posts/daily-blog-day-98.md
@@ -1,0 +1,143 @@
+---
+title: "Day 98: If Every Competitor Sounds the Same, Visibility Is Not the Problem"
+date: 2026-07-27
+slug: "day-98-if-every-competitor-sounds-same-visibility-is-not-problem"
+description: "A buyer-facing positioning failure-mode memo for CMOs, Marketing Directors, and founders: answer-led research can name several visible providers while describing them with interchangeable strengths. When no defensible reason to choose is visible, the next investment belongs in offer strategy before distribution."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - positioning
+  - competitive strategy
+  - commercial strategy
+geo_tactics:
+  - Use answer-led comparisons to inspect whether providers are merely named, which reasons-to-choose are attributed, and whether those reasons are distinctive or interchangeable.
+  - Separate distribution weakness from positioning weakness: if a real difference exists but is not surfaced, clarify public explanation; if no defensible difference exists, sharpen the offer before amplifying it.
+  - Record visible trade-offs, fit boundaries, buyer situations, and exclusion criteria so comparison language does not collapse every provider into the same generic promise.
+  - Treat each answer-led observation as bounded to the surface, prompt, date, and context observed; do not claim one answer proves buyer perception, platform-wide consensus, or deterministic visibility movement.
+---
+
+# Day 98: If Every Competitor Sounds the Same, Visibility Is Not the Problem
+
+A brand can be visible in the comparison and still lose the commercial argument.
+
+The buyer asks for providers. The answer names the company. It also names two competitors. On the first read, that looks like progress: the brand is present, the category is recognised, and the market is at least aware enough to include it.
+
+Then the buyer reads the reasons.
+
+All three providers are described as experienced, strategic, data-led, client-focused, and able to help teams improve AI visibility. Each one is said to combine technical understanding with marketing expertise. Each one is suitable for companies that want clearer insight into answer-led discovery. None has a visible trade-off. None has a sharp fit boundary. None owns a specific promise that would make a serious buyer say, “that one is clearly for us”.
+
+That is not a pure visibility problem.
+
+It is a positioning problem made legible by visibility.
+
+<!-- more -->
+
+## Presence can hide interchangeability
+
+Many Generative Engine Optimization reports still begin with a presence question: did the brand appear when a buyer asked ChatGPT, Claude, Perplexity, Gemini, Google AI features, or another answer-led surface for help?
+
+That question matters. Absence can be commercially important. Wrong category language can be commercially important. Being routed towards the wrong provider type can be commercially important.
+
+But presence is not the same as preference.
+
+A company can be mentioned in a plausible answer and still be commercially invisible if the answer cannot explain why a buyer should choose it over the other named options. The problem is not that the brand is hidden. The problem is that the difference is hidden, weak, or possibly absent.
+
+For CMOs, Marketing Directors, and founders, this changes the next investment decision. If the company is absent from relevant comparisons, distribution, public source quality, category clarity, or answer-surface coverage may deserve work. If the company is present but described with the same safe language as everyone else, buying more visibility may only amplify sameness.
+
+The uncomfortable question becomes: does the market fail to see the difference, or has the business not defined one strongly enough?
+
+## A compact three-provider comparison
+
+Imagine a buyer researching specialist partners for understanding whether answer-led discovery is affecting B2B pipeline quality. The buyer receives a comparison like this:
+
+| Provider | Why the answer says they may fit | What is missing |
+|---|---|---|
+| Provider A | Strategic AI visibility support, data-led diagnostics, senior marketing expertise. | No clear buyer situation, trade-off, or reason to choose over a broader consultancy. |
+| Provider B | Strong content and search background, practical reporting, experience with AI-era visibility. | No boundary between content execution, monitoring, and commercial diagnosis. |
+| Provider C | Technical approach, competitor comparison, useful insight for leadership teams. | No distinctive promise, proof of fit, or exclusion criteria. |
+
+This is deliberately generalised. It is not a claim about a specific market or a real provider set. It is the kind of pattern a team might observe when answer-led research can identify the category but cannot separate the offers.
+
+On a mention chart, all three providers are visible. On a buyer decision, none is clearly chosen.
+
+That difference matters because the buyer is not trying to reward the most frequently named brand. They are trying to reduce uncertainty. Which provider understands their problem? Which one is built for their company stage, sales motion, evidence needs, risk tolerance, and internal decision? Which one is wrong for them? Which one makes a promise the others do not make?
+
+If the answer cannot show those distinctions, the buyer is left with generic approval language: experienced, credible, strategic, data-led, integrated, expert, innovative, tailored.
+
+Those words rarely lose a deal by themselves. They lose the reason to choose.
+
+## The missing trade-off is the signal
+
+Distinctive positioning is not only a better adjective.
+
+It is a visible choice.
+
+A defensible offer should usually make at least one trade-off legible. It may be faster but narrower. Deeper but not ongoing monitoring. Senior-led but not cheap. Diagnostic rather than implementation. Built for high-consideration B2B sales, not consumer ecommerce. Useful before a campaign, not as a replacement for broader brand strategy. Strong when sales hears category confusion, less useful when the buyer only wants a dashboard.
+
+Those boundaries are not weaknesses. They are how a buyer understands fit.
+
+When answer-led comparisons flatten every provider into the same broad promise, inspect whether the public market has enough material to express those boundaries. Does the offer page say who the work is for and who it is not for? Does comparison language explain when a tool, agency, internal team, or specialist partner is the right route? Do public examples, methods, and claims point to a specific buyer decision? Does the company make any sacrifice competitors do not make?
+
+If the answer has no source material from which to learn the distinction, the issue may sit in public explanation. If the business itself has no crisp trade-off, the issue is upstream: offer strategy.
+
+That is the fresh macro cluster here. The finding is not another rule that a captured answer must be validated, bounded, governed, routed, or attached to a decision before action. The finding is that repeated interchangeable reasons-to-choose can reveal a strategic positioning gap: the market can name the company, but not the exclusive reason to buy it.
+
+## Use answer-led research as a mirror, not a verdict
+
+This requires restraint.
+
+One answer does not prove buyer perception. One comparison does not prove the whole market sees every provider as identical. One surface does not define the category. Even repeated patterns across relevant surfaces should be treated as observations, not universal truth.
+
+The value is more practical: answer-led comparisons can show how available public language is being compressed into buyer-facing reasons. They can reveal whether the market vocabulary makes meaningful distinctions easy or hard to express.
+
+A useful review asks four questions:
+
+1. Are the same providers merely being named, or are they being chosen for different reasons?
+2. Are the attributed reasons exclusive enough to guide a buyer, or could they apply to almost anyone in the category?
+3. Are trade-offs and fit boundaries visible, or does every option sound safely good for everyone?
+4. Does the pattern recur in other sensible buyer questions, sales language, customer interviews, public positioning, or competitor material?
+
+That last question protects the team from overreaction. An isolated bland answer may mean very little. A repeated pattern, especially when sales also hears “we are not sure how you are different”, deserves attention.
+
+Google needs the same caveat as always. Google's AI features rely on core Search ranking and quality systems. Improve the usefulness, relevance, clarity, and quality of the underlying public material where evidence supports it. Do not present `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google AI visibility.
+
+## The decision fork before more distribution
+
+When the comparison sounds interchangeable, do not jump straight to a larger content calendar.
+
+Use a compact fork.
+
+First: the difference exists, but the answer does not surface it.
+
+In that case, the work may be public explanation. Make the distinctive promise easier to retrieve and summarise. Clarify the priority buyer, the situation, the commercial decision supported, the trade-offs, and the fit boundaries. Comparison pages, offer pages, sales enablement, case framing, and founder narrative may all help if they express a real difference already inside the business.
+
+Second: the difference does not exist strongly enough.
+
+In that case, distribution is premature. More articles, more prompts, more citations, and more surface coverage will mostly spread a generic claim. The work belongs in offer strategy: define the buyer problem the company will own, the situations it will refuse, the trade-offs it will make, the promise competitors cannot easily copy, and the evidence needed to make that promise credible.
+
+Third: the observation is isolated.
+
+In that case, do not build a strategy around it. Log the answer, check a few adjacent buyer questions, compare with sales and customer language, and wait for a stronger pattern before spending. Restraint is not passivity. It is how the team avoids turning one bland output into an unnecessary repositioning exercise.
+
+This fork is more useful than the generic instruction to “improve visibility”. It forces the business to decide what kind of problem it has.
+
+## The work before amplification
+
+Interchangeable positioning is painful because it denies the comfort of a simple distribution fix.
+
+If the brand is absent, the next move can feel operational: improve source quality, clarify the category, create missing public material, inspect relevant answer surfaces, and monitor changes responsibly. That work can be hard, but it still fits the familiar visibility playbook.
+
+If the brand is present and still undifferentiated, the harder question is commercial: what would make a buyer choose this offer when the alternatives are also credible?
+
+The answer may require sharper language. It may require better proof. It may require clearer comparison material. But it may also require a narrower offer, a more explicit no-fit boundary, a stronger point of view, or a promise the company has been avoiding because generic positioning feels safer.
+
+Safe language is easy for answer-led systems to repeat. It is also easy for competitors to share.
+
+Before funding another round of amplification, leadership should ask whether the market has a sentence it can use that belongs only to this company. Not a slogan. Not a claim of being expert, strategic, technical, or data-led. A real reason to choose: the buyer situation, the trade-off, the outcome, the boundary, and the proof that make the offer distinct.
+
+If that sentence does not exist, visibility is not the bottleneck.
+
+The bottleneck is the offer becoming impossible to confuse with everyone else's.


### PR DESCRIPTION
## Summary
- Adds the approved Day 98 Build in Public post.
- Keeps the payload to one blog post: `docs/blog/posts/daily-blog-day-98.md`.
- Consumes the approved revision artifact and reviewer verdict for the interchangeable-positioning thesis.

## Verification
- Content/frontmatter/internal-leak check passed for title, date, slug, H1, `<!-- more -->`, forbidden terminology, and structural HTML.
- `python3 -m mkdocs build` passed.
- Staged diff contains exactly `docs/blog/posts/daily-blog-day-98.md`.
