### PR TITLE
docs: add daily blog day 99

### DIFF
--- a/docs/blog/posts/daily-blog-day-99.md
+++ b/docs/blog/posts/daily-blog-day-99.md
@@ -1,0 +1,175 @@
+---
+title: "Day 99: Do Not Win AI Visibility for the Offer You Cannot Scale"
+date: 2026-07-28
+slug: "day-99-do-not-win-ai-visibility-for-offer-you-cannot-scale"
+description: "A buyer-facing portfolio decision memo for CMOs, Marketing Directors, and founders: answer-led discovery can recommend a real, distinctive offer that the business should not necessarily amplify because capacity, margin, delivery risk, or strategic fit make more demand commercially undesirable."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - offer strategy
+  - commercial strategy
+  - demand generation
+geo_tactics:
+  - Map commercially important buyer questions to the specific offer that answer-led surfaces recommend, then judge whether that offer is the demand the business wants to grow.
+  - Compare visible recommendation patterns with capacity, margin, delivery risk, strategic priority, and fit boundaries before turning presence into a content or distribution brief.
+  - Separate grow, maintain, redirect, and do-not-amplify decisions so GEO investment increases demand the company can serve profitably and deliberately.
+  - Treat answer-led observations as bounded to the surface, prompt, date, and context observed; do not claim buyer volume, attribution, or deterministic platform movement from visibility alone.
+---
+
+# Day 99: Do Not Win AI Visibility for the Offer You Cannot Scale
+
+The uncomfortable GEO problem is not always invisibility.
+
+Sometimes the answer-led surface understands the company, names a real offer, and recommends it for a sensible buyer question. The language is accurate. The offer is distinctive. The company would be right to feel that the market has understood something important.
+
+Then the commercial question arrives: is this the demand the business wants more of?
+
+For CMOs, Marketing Directors, and founders, that question matters because marketing is not paid to create attention in the abstract. It is paid to create demand the company can serve profitably, safely, and strategically. If answer-led discovery keeps steering buyers towards a bespoke, low-margin, capacity-constrained, operationally risky, or secondary offer, increasing visibility can worsen the business rather than strengthen it.
+
+The goal is not to win every visible recommendation.
+
+The goal is to decide which demand should grow.
+
+<!-- more -->
+
+## Visibility can overload the wrong part of the business
+
+A lot of Generative Engine Optimization work starts with a reasonable ambition: make the company more visible when buyers ask commercially meaningful questions across ChatGPT, Claude, Perplexity, Gemini, Google AI features, search results, directories, review sites, and other answer-led contexts.
+
+That ambition is useful when the priority offer is clear, scalable, profitable, and strategically important. If the company wants more demand for that offer, then visibility work can support a real growth decision: clarify the public explanation, strengthen the source layer, improve comparison language, repair misunderstood category framing, and monitor whether relevant buyer questions continue to describe the offer accurately.
+
+But not every accurately recommended offer deserves amplification.
+
+A company may have one service that is famous because it is distinctive and founder-led. It may have another that is easier to deliver repeatedly. A bespoke advisory product may create status but consume senior capacity. A legacy service may still have public authority but no longer fit the strategic direction. A diagnostic may be profitable only when it qualifies into a broader programme. A custom implementation may be attractive in answers but hard to scope, hard to staff, and risky to standardise.
+
+If answer-led research recommends the capacity-constrained offer, the visibility report can look flattering while the operating model gets worse. Sales receives more enquiries for work delivery cannot absorb. Senior people spend more time on custom calls. Margin mix drifts in the wrong direction. The team delays investment in the scalable offer because the visible one keeps generating urgent demand.
+
+That is not a ranking problem.
+
+It is offer-portfolio economics becoming visible through GEO.
+
+## A generalised capacity-constrained scenario
+
+Imagine a specialist B2B firm with two offers.
+
+The first is a bespoke founder-led workshop. It is valuable, differentiated, and genuinely useful for a narrow set of companies. Buyers like it because it gives them direct access to senior judgement. Answer-led surfaces can explain it well because the public market has plenty of founder-authored material, event references, interviews, and examples around that expertise.
+
+The second is the offer the company now wants to grow: a repeatable diagnostic that helps marketing leaders understand how answer-led discovery is affecting buyer qualification, category framing, competitor comparison, and sales conversations. It is more scalable. It has clearer delivery boundaries. It supports a stronger revenue mix. It can be staffed beyond the founder. It is strategically more important.
+
+A buyer asks:
+
+> “Who can help our marketing team understand why AI recommendations are sending us low-fit enquiries?”
+
+The observed answer names the company and recommends the bespoke workshop because the founder is visibly associated with the problem. On one level, this is a good result. The company appears for a commercially relevant question. The answer is not obviously wrong. The recommendation has a real basis in public material.
+
+On another level, it creates a portfolio problem.
+
+If the team responds by making the workshop even more visible, the next quarter may fill with exactly the work leadership wanted to make less central: custom discovery calls, founder-dependent delivery, one-off scope negotiation, uneven margins, and limited operational leverage. The company wins the answer and weakens the business model.
+
+The better response is not to suppress useful demand blindly. It is to decide what role that demand should play.
+
+The bespoke workshop might remain available for a small number of strategic accounts. It might become an entry route only when qualification criteria are met. It might be repositioned as a founder-led exception rather than the default recommendation. Or it might be redirected publicly towards the scalable diagnostic when the buyer question is really about pipeline quality, market visibility, and repeatable decision support.
+
+The commercial decision comes before the GEO brief.
+
+## Ask which offer the answer is selling
+
+Before a team celebrates an answer-led win, it should identify the offer being recommended.
+
+Not the brand. Not the category. The actual buying object.
+
+A useful review asks:
+
+- Which offer does the answer make easiest to buy?
+- Is that offer current, profitable, scalable, and strategically important?
+- Does the answer route the buyer towards the company's priority offer or towards a legacy, bespoke, low-fit, or capacity-heavy version of the business?
+- Does the recommendation match the buyer situation, or is it using the most visible public material because the priority offer is under-explained?
+- If more buyers followed this recommendation, would leadership want more of that demand?
+
+That final question is the one many visibility systems do not answer. They can show whether the company is present. They can show which competitors appear. They can show which pages or public descriptions seem to shape the answer where sources are visible. They can track movement over time.
+
+But the business has to decide whether the recommended demand is desirable.
+
+This is especially important for companies with several offers: strategic advisory and execution, diagnostic and implementation, workshop and managed service, software and services, enterprise package and founder-led sprint, legacy package and current priority. Answer-led systems may favour the offer with the richest public footprint, not the one with the strongest future economics.
+
+If the old offer has more public language, more founder authority, more case material, more talks, or more third-party descriptions, it may become the default recommendation even after the business has moved on.
+
+That does not make the answer useless. It makes the next decision sharper.
+
+## Split demand into four commercial states
+
+A practical GEO prioritisation review can be small. It does not need to become another sprawling audit.
+
+For each commercially important buyer question, classify the recommended offer into one of four states.
+
+Grow: this is the demand the company wants more of. The offer is strategically important, deliverable, profitable enough, and a good fit for the buyer situation. GEO work can support amplification: clearer offer pages, comparison material, category explanations, source quality, proof, and answer-surface monitoring.
+
+Maintain: this demand is useful, but not a growth priority. The company should keep the public record accurate, prevent misrepresentation, and serve good-fit buyers, but avoid making it the centre of the next campaign.
+
+Redirect: the answer is close, but it points to the wrong buying object. The buyer question should lead towards another offer, a clearer route, or a qualification step. Public material should explain the boundary: when the bespoke service fits, when the diagnostic is the right first step, when a tool is enough, and when the company is not the right route.
+
+Do not amplify: the answer recommends work the company cannot or should not scale. That may be because delivery depends on scarce senior capacity, margins are poor, risk is high, implementation is messy, or the offer distracts from the market the company wants to own. The action may be restraint, stricter qualification, clearer no-fit language, or a deliberate decision to leave some visibility underdeveloped.
+
+These states make the marketing decision more honest. Visibility work becomes a demand-shaping discipline, not a reflex to increase every favourable appearance.
+
+## Keep the answer evidence bounded
+
+This portfolio review still needs evidence discipline.
+
+An observed answer does not prove buyer volume. It does not prove that prospects saw the output. It does not prove attribution, pipeline movement, or platform-wide consensus. A surface can recommend one offer under one prompt and another offer under a different buyer situation. Dates, wording, geography, account context, source visibility, and retrieval conditions can all change interpretation.
+
+The useful claim is narrower:
+
+> Under the conditions observed, this buyer question was answered in a way that made this offer the recommended route.
+
+That is enough to support a better management conversation. It allows the team to compare answer-led framing with sales language, current offer strategy, delivery capacity, margin expectations, and leadership priorities. It does not require pretending that one answer has revealed the entire market.
+
+Google AI features need the same restraint. They rely on core Search ranking and quality systems. If they surface an offer in a way that matters, improve the underlying usefulness, relevance, clarity, and quality of the public material where evidence supports it. Do not treat `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google AI visibility.
+
+Across surfaces, the better practice is to record the buyer question, the answer-led context, the offer recommended, the visible reasons, the evidence limit, and the commercial state: grow, maintain, redirect, or do not amplify.
+
+## Make the priority offer easier to recommend
+
+If the answer keeps recommending the wrong offer, the fix may not be to hide the old one. It may be to make the priority offer more legible.
+
+A scalable diagnostic cannot compete with a founder-led workshop in answer-led discovery if the workshop has all the public explanation and the diagnostic has only a vague service paragraph. A managed programme cannot become the default commercial route if every visible source frames the company as a one-off advisory expert. A higher-margin package cannot be recommended responsibly if the public material never explains when it is the right fit and what decision it supports.
+
+The priority offer needs public substance:
+
+- the buyer situation it is built for;
+- the problem it solves in commercial language;
+- the decision it helps leadership make;
+- the delivery boundary that makes it repeatable;
+- the trade-offs that distinguish it from bespoke advisory, software, DIY, or a general agency route;
+- the qualification criteria that protect both buyer and supplier from poor-fit demand;
+- the next step a serious buyer should take.
+
+This is not about forcing every answer to recommend the most profitable product. Bad-fit buyers should still be routed away. Some bespoke work may remain valuable. Some low-volume offers may be strategically important. Some answer-led recommendations will be fair even when they do not match the current growth plan.
+
+The point is to make the company's public offer architecture reflect its commercial strategy. If leadership wants demand to move from bespoke advisory into a repeatable diagnostic, the public market needs enough material to understand that route.
+
+Otherwise, answer-led systems may keep doing the rational thing with the evidence available: recommending the offer that is easiest to explain, not the one the business most wants to scale.
+
+## Choose the demand you are willing to serve
+
+The most dangerous visibility win is the one that feels good until delivery receives it.
+
+More enquiries for the wrong offer can look like marketing success while creating operational drag. It can absorb founder time, increase scope negotiation, crowd out scalable work, worsen revenue mix, and make the company more dependent on a service it intended to reduce. None of that requires the answer to be inaccurate. Accuracy can still create the wrong growth pressure.
+
+Before funding more GEO activity, leadership should make one portfolio decision for each priority buyer question:
+
+- grow this demand because it fits the strategy and the operating model;
+- maintain this demand because it is useful but not central;
+- redirect this demand because the buyer should start somewhere else;
+- do not amplify this demand because more of it would make the business less healthy.
+
+That decision turns AI visibility from a vanity chase into commercial steering.
+
+The business does not need to win every answer that flatters it. It needs to win the demand it can serve well, profitably, and deliberately.
+
+If the visible offer is not that offer, the next move is not louder marketing.
+
+It is portfolio discipline: decide what should grow, make that route easier to understand, and stop treating every recommendation as a prize.


### PR DESCRIPTION
## Summary
- Adds the approved Day 99 Build in Public post.
- Applies the durable final artifact for `docs/blog/posts/daily-blog-day-99.md` only.

## Verification
- Reviewer verdict consumed: `APPROVED`.
- Source/copy SHA-256 matched: `62c8388145a64afcd701018bd9e0b8ba7c77125d927cef0d0f520bb22bf13d1d`.
- Frontmatter checked for expected title, date, and slug.
- Forbidden/internal term scan passed with 0 matches using word-boundary scan.
- `mkdocs build` passed.

## Payload
- `docs/blog/posts/daily-blog-day-99.md` only.
