### PR TITLE
docs: add Day 100 blog post

### DIFF
--- a/docs/blog/posts/daily-blog-day-100.md
+++ b/docs/blog/posts/daily-blog-day-100.md
@@ -1,0 +1,165 @@
+---
+title: "Day 100: Do Not Average AI Visibility Across Markets"
+date: 2026-07-29
+slug: "day-100-do-not-average-ai-visibility-across-markets"
+description: "A buyer-facing market-entry decision memo for CMOs, Marketing Directors, and founders: one global AI visibility score can hide that the launch market uses different buyer language, category labels, competitors, offer availability, proof expectations, and regulatory context. Build local market views before aggregating them."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - market entry
+  - international expansion
+  - commercial strategy
+geo_tactics:
+  - "Define the market boundary before treating answer-led visibility as management evidence: geography, language, buyer situation, offer availability, category vocabulary, competitor set, and proof or regulatory context."
+  - Compare locally relevant buyer questions separately before aggregating them into a global visibility score, especially when expansion budget depends on the result.
+  - Treat literal translation as a weak input, not buyer research; adapt questions to the way the local market describes the problem, alternatives, risk, and buying route.
+  - Treat answer-led observations as bounded to the surface, prompt, market context, date, and access condition; do not claim one answer proves local demand, launch readiness, or platform-wide behaviour.
+---
+
+# Day 100: Do Not Average AI Visibility Across Markets
+
+A global AI visibility score can make an expansion plan look safer than it is.
+
+The number looks healthy. The brand appears in enough answers. The category language is broadly accurate. Competitors are visible but not dominant. Leadership can see a trend line and feel that the market is starting to understand the offer.
+
+Then the company enters a new market and the signal changes shape.
+
+The buyer language is different. The category label does not travel cleanly. A service that is available in the home market has a weaker or narrower offer locally. Familiar competitors disappear and local alternatives appear. Proof expectations change. Regulatory context may alter the buyer's first concern. Even in another English-speaking market, the same question can carry different commercial assumptions.
+
+For CMOs, Marketing Directors, and founders, the danger is not that the average is mathematically wrong. The danger is that the average is used for the wrong decision.
+
+Market-entry budget should not be released because the global visibility chart looks comfortable. It should be released because the launch market has been inspected on its own terms.
+
+<!-- more -->
+
+## The average is not the market you are entering
+
+A company can be visible in the market it already understands and weak in the market it wants to enter.
+
+That sounds obvious until the reporting layer hides it.
+
+If UK performance, US performance, European English-language performance, translated-language checks, and a few broad global prompts are collapsed into one score, leadership may see improvement while the market that matters still has no reliable buying route. The aggregate can improve because the home market is strong, because one language has more public material, because one platform surfaces familiar sources, or because the prompts overweight the company's strongest category language.
+
+None of that proves the launch market is ready.
+
+A market-entry decision needs a different unit of analysis. It needs to ask: in this specific market, for this specific buyer situation, using the language and category labels that local buyers actually use, does answer-led discovery make our offer understandable, available, credible, and worth a next step?
+
+That question is not answered by a global score.
+
+It is answered by a local view.
+
+## A generalised two-market scenario
+
+Consider a deliberately generalised scenario, not a client case.
+
+A B2B firm has strong answer-led visibility in its home market for a specialist advisory offer. When buyers ask about the problem in familiar language, answer-led surfaces describe the company reasonably well. They understand the category, name the right provider types, and connect the offer to a leadership decision.
+
+The firm now wants to enter a second market.
+
+A simple dashboard translation says the outlook is encouraging. The same core prompts are translated or lightly adapted. The brand still appears in some answers. The global score remains healthy enough for the expansion team to feel that the market is warm.
+
+But a local review shows a different picture.
+
+The buyer problem is described with different vocabulary. Local buyers use a category label closer to risk, compliance, procurement, performance marketing, sector advisory, or software evaluation rather than the phrase the firm owns at home. Some answers recommend providers the home-market team did not include in the competitor set. Some suggest a route through existing agencies, local consultants, platforms, industry bodies, or internal teams. Some treat the offer as unavailable, too foreign, too broad, too bespoke, or too early for that market's buying context.
+
+The issue is not that the original score was fake.
+
+The issue is that it answered a home-market question and was then asked to support a launch-market decision.
+
+Those are different decisions.
+
+## Literal translation is not local buyer research
+
+Translation is useful. It is not enough.
+
+A literal translation can preserve the company's preferred wording while missing how buyers in the target market frame the job. It can import the home-market category into a place where the buyer uses another label. It can preserve a prompt that assumes the same budget owner, buying stage, proof burden, delivery model, competitor set, or regulatory anxiety.
+
+That matters because answer-led systems respond to the question being asked and the public material available around that question. If the prompt uses language local buyers would not use, the test may measure whether the company is visible for its own imported vocabulary, not whether the market can find a credible route to the offer.
+
+A bounded local comparison should therefore start with buyer intent, not wording.
+
+Ask what the local buyer is trying to decide. Ask which problem name they recognise. Ask which substitutes they would plausibly consider. Ask what availability means in that market. Ask what proof they need before speaking to a supplier. Ask which risks are obvious locally but invisible to the home-market team.
+
+Only then should the team write the local questions.
+
+The discipline is simple: translate the commercial situation before translating the prompt.
+
+## Build the local market view before the global score
+
+A practical market-entry visibility view does not need to become a sprawling international research programme. It needs enough structure to stop the average from pretending several markets are the same.
+
+For each priority market, record a compact set of fields:
+
+| Field | What to capture | Why it matters |
+|---|---|---|
+| Market and language | Geography, language, and any access or localisation condition used in the check. | Prevents a global answer from standing in for a local one. |
+| Buyer situation | The role, problem, buying stage, and decision the local buyer is facing. | Keeps the work attached to expansion budget, not generic visibility. |
+| Locally relevant question | The buyer-language question used in that market. | Avoids treating literal translation as evidence of demand. |
+| Category vocabulary | The labels, adjacent categories, and problem names that appear locally. | Shows whether the company is being found under the words the market uses. |
+| Offer availability | Whether the offer can actually be bought, delivered, supported, or qualified in that market. | Stops visibility for unavailable work becoming a false positive. |
+| Competitor and substitute set | Local providers, global rivals, platforms, agencies, consultants, internal routes, or no-action alternatives. | Separates home-market rivalry from launch-market competition. |
+| Observed answer context | Surface, date, prompt context, visible sources where available, and evidence limits. | Keeps observations bounded and prevents one answer becoming market truth. |
+| Management decision | Enter, research further, localise the offer, narrow the market, hold spend, or aggregate later. | Turns the view into an allocation tool rather than a dashboard ornament. |
+
+The final row is the point.
+
+A local visibility view exists to improve a market-entry decision. If the output does not help leadership choose whether to enter, research further, localise the offer, narrow the target, or hold budget, the view is probably measuring the wrong thing.
+
+## The decision can be to wait
+
+A weak launch-market view is not automatically bad news. It is useful news if it prevents premature spend.
+
+If the home market is strong but the target market uses different category vocabulary, the right move may be localisation before campaign investment. If the offer is visible but not clearly available locally, the right move may be to define delivery boundaries and qualification criteria before demand generation. If local answers recommend a different provider type, the right move may be comparison material or partner strategy. If the competitor set is unfamiliar, the right move may be market research before positioning work. If the observations are thin, the right move may be to collect better evidence rather than dress uncertainty as a score.
+
+There are several legitimate outcomes:
+
+- enter because local buyer questions, offer availability, and answer context support the move;
+- research further because the current evidence is too thin or contradictory;
+- localise the offer because the buyer problem is real but the public route is unclear;
+- narrow the market because one segment, language, region, or use case is stronger than the aggregate suggests;
+- hold spend because visibility, availability, proof, or competitive context is not yet strong enough.
+
+That last outcome matters. GEO should not exist to justify expansion after leadership has already decided to spend. It should make the decision more honest.
+
+Sometimes the commercially useful answer is: not yet, not there, or not with that offer.
+
+## Aggregate only after the differences are visible
+
+Global reporting still has a role.
+
+A board does not need twenty pages of local prompt notes every week. Leadership may need a consolidated view of how the brand is understood across priority markets, where expansion risk is rising, where localisation is working, and where demand is beginning to appear.
+
+But the order matters.
+
+Aggregate after the local differences have been named. Do not aggregate to avoid naming them.
+
+A useful global view should be able to say: the brand is strong in Market A for the current offer; uncertain in Market B because the category vocabulary differs; visible but misrouted in Market C because local answers recommend a platform or incumbent agency; unavailable in Market D until delivery boundaries are clearer; and not yet worth spend in Market E because the evidence is too thin.
+
+That is a management view. It is not as tidy as one score, but it is safer for budget.
+
+The same restraint applies across answer-led surfaces. ChatGPT, Claude, Perplexity, Gemini, Google AI features, search results, directories, review sites, and local publications can all expose different slices of market understanding. An observed answer proves what that surface said under recorded conditions. It does not prove local demand, buyer behaviour, launch readiness, or universal platform behaviour.
+
+If Google AI features are part of the market view, keep the caveat intact: they rely on core Search ranking and quality systems. Improve the usefulness, relevance, clarity, and quality of the underlying public material where the evidence supports it. Do not treat `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data as required switches for Google AI visibility.
+
+## The leadership question
+
+The weak question is:
+
+> What is our global AI visibility score?
+
+The stronger question is:
+
+> Which markets are ready to receive expansion budget, which need localisation or research first, and which should be excluded from the average until the local buying context is understood?
+
+That question changes the commercial use of GEO.
+
+It stops a strong home-market signal from underwriting a weaker launch-market decision. It stops literal translation from masquerading as buyer research. It stops familiar competitors from defining unfamiliar markets. It forces offer availability, local vocabulary, substitute routes, proof expectations, and evidence limits into the same conversation as visibility.
+
+For CMOs, Marketing Directors, and founders, that is the difference between a dashboard and a market-entry instrument.
+
+Do not ask one average to carry several markets.
+
+Build the local views first. Then decide what deserves to be aggregated.


### PR DESCRIPTION
## Summary
- Add Day 100 Build in Public post: `Day 100: Do Not Average AI Visibility Across Markets`
- Payload is exactly one repo file: `docs/blog/posts/daily-blog-day-100.md`
- Applied a frontmatter-only YAML quoting fix to preserve the approved text while making `geo_tactics` pass the repo validator

## Verification
- `python3 tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-100.md` — passed
- `python3 tools/validate_frontmatter.py docs/blog/posts` — target passed; existing older posts fail missing `description` fields
- `mkdocs build --strict` — failed due to pre-existing RoamLinks/AutoLinks/nav warnings
- `mkdocs build` — passed

## Editorial gates consumed
- Reviewer verdict: `APPROVED`
- Final macro cluster: AI visibility is market-specific management evidence; market-entry allocation needs separate geographic/language local views before global aggregation
- Avoided cluster: individual answer/signal/route/journey/workflow/offer/demand/proof object classification/bounding/governance/routing before action
