### PR TITLE
docs: add daily blog day 101

### DIFF
--- a/docs/blog/posts/daily-blog-day-101.md
+++ b/docs/blog/posts/daily-blog-day-101.md
@@ -1,0 +1,148 @@
+---
+title: "Day 101: Test Discovery Without Giving AI the Brand Name"
+date: 2026-07-30
+slug: "day-101-test-discovery-without-giving-ai-brand-name"
+description: "A practical GEO measurement note for CMOs, Marketing Directors, and founders: compare matched branded and unbranded buyer questions before claiming answer-led visibility. A brand that performs only when named in the prompt has shown assisted recognition, not category discovery."
+categories:
+  - Build in Public
+  - Generative Engine Optimization
+tags:
+  - GEO
+  - AI visibility
+  - answer engines
+  - measurement
+  - competitive visibility
+geo_tactics:
+  - Compare matched unbranded and branded buyer questions before claiming that answer-led surfaces can discover the company for a commercially meaningful problem.
+  - Record whether the brand enters the candidate set unprompted, how it is categorised, which alternatives appear, and whether the answer creates a plausible next step.
+  - Treat paired-prompt observations as bounded by surface, prompt, date, market, access context, and repeated sampling; do not turn them into a universal score or claim proof of buyer behaviour.
+  - "Keep the Google caveat clear: Google's AI features rely on core Search ranking and quality systems; llms.txt, special AI markup, arbitrary chunking, and over-focused structured data are not required switches for Google AI visibility."
+---
+
+# Day 101: Test Discovery Without Giving AI the Brand Name
+
+A branded prompt can make AI visibility look stronger than it is.
+
+Ask an answer engine, “What does Acme do for enterprise marketing teams?” and the result may sound reassuring. The company is described clearly. The category is broadly right. The answer may mention services, use cases, competitors, and a sensible next step.
+
+That is useful, but it is not the same as discovery.
+
+The harder commercial question is whether the brand appears when a buyer has the problem but does not already know the company. If the answer only looks good after the brand has been supplied in the question, the test has measured assisted recognition or description. It has not shown that the company enters an unfamiliar buyer's candidate set.
+
+For CMOs, Marketing Directors, and founders, that distinction matters because “AI visibility” reports can become comforting very quickly. A named-brand prompt proves that the surface can talk about the company under those conditions. It does not prove that buyers asking about the priority problem, category, market, or buying situation would find the company without help.
+
+The practical move is simple: test the unbranded question first, then compare it with a matched branded version.
+
+<!-- more -->
+
+## Recognition is not discovery
+
+Recognition starts with the brand already in the room.
+
+A buyer, analyst, salesperson, board member, or marketer names the company and asks an answer-led surface to explain it, compare it, summarise it, or check whether it fits a situation. This can reveal useful things: stale positioning, inaccurate geography, confusing offer boundaries, weak competitor comparison, missing proof, or an unclear next step.
+
+But the prompt has already solved the first commercial problem: inclusion.
+
+Discovery starts earlier. The buyer has a problem, a category need, a budget question, a risk, or an unfamiliar buying situation. They ask for routes, providers, alternatives, criteria, or examples without naming the company. The answer-led surface then chooses what belongs in the candidate set.
+
+Those are different events.
+
+If a firm appears in branded prompts but not in unbranded buyer questions, the market signal is narrower than the dashboard may imply. The surface can recognise the company when directed to it. It may even describe the company well. But it has not demonstrated that the brand is part of the answer when the buyer asks, “Who helps with this problem?” rather than “Tell me about this named vendor.”
+
+That is not a failure by itself. Some brands are discoverable for one buying situation and only recognisable for another. Some newer offers need branded education before category discovery catches up. Some markets are too thin or too ambiguous for confident inclusion from one prompt. The point is not to punish the branded result. The point is to label it correctly.
+
+## A generalised buyer scenario
+
+Imagine a B2B company that sells a specialist diagnostic for marketing leaders. The diagnostic helps a team understand whether answer-led discovery is changing how prospects describe the company, compare providers, and arrive in sales conversations.
+
+A reassuring branded test would be:
+
+> “What does ExampleCo offer for AI visibility diagnostics?”
+
+The answer names the company, describes a diagnostic, mentions marketing leaders, and says it may help teams understand how answer engines represent their brand. The result confirms that the surface has enough public material to produce a coherent description when the company is named.
+
+Now ask the unbranded buyer question:
+
+> “Who can help a B2B marketing team understand whether AI answers are changing the quality of prospects entering sales?”
+
+This asks whether the brand enters the candidate set when the buyer starts with the commercial problem. The answer may name specialist agencies, SEO consultancies, analytics platforms, existing marketing partners, or internal research routes. It may not name ExampleCo at all. It may categorise the need as monitoring software rather than diagnostic advisory. It may recommend a self-check before hiring anyone. It may mention competitors the company did not expect.
+
+That unbranded answer is not automatically “truer” than the branded one. It is testing a different commercial moment.
+
+The useful comparison is the gap between them.
+
+## Run the paired test
+
+A paired test should keep the buyer intent as stable as practical while changing whether the brand is supplied.
+
+Start with the unbranded version. Use end-buyer language and a commercially meaningful situation. Avoid prompts so broad they invite generic market summaries, and avoid prompts secretly designed around the company's own phrasing.
+
+For example:
+
+> “Which firms can help a B2B SaaS CMO understand why AI recommendations are sending prospects towards the wrong type of provider?”
+
+Then write the branded match:
+
+> “Could ExampleCo help a B2B SaaS CMO understand why AI recommendations are sending prospects towards the wrong type of provider?”
+
+The pair is not perfect science. The branded prompt changes the task. It gives the answer surface a named entity, and that changes what can be retrieved, inferred, or summarised. That is precisely why the comparison is useful. It shows whether inclusion depends on the brand being handed to the system.
+
+Record the result in a compact matrix:
+
+| Observation | Unbranded buyer question | Branded matched question | What it suggests |
+|---|---|---|---|
+| Brand enters candidate set | Yes, no, or partial. | Usually yes if the surface recognises the entity. | Whether the company is discoverable without being named. |
+| Category assigned | Diagnostic, agency, tool, consultant, content service, internal route, or other. | How the named company is described. | Whether the surface sees the company in the same buying category. |
+| Alternatives named | Competitors, tools, agencies, DIY, existing partners, delay, or no purchase. | Alternatives compared with the named brand, if any. | Which routes occupy the buyer's candidate set. |
+| Commercial next step | Speak to a provider, run a self-check, buy software, use an existing team, wait, or research further. | Whether the named brand has a plausible next action. | Whether recognition turns into a usable buying route. |
+| Evidence limit | Surface, prompt, date, market, account/access context, visible sources where available. | Same fields. | What the observation can and cannot support. |
+
+This is deliberately small. The output is a measurement note, not a universal score.
+
+## Interpret the gap, not just the win
+
+The most common mistake is to celebrate the branded answer and skip the unbranded gap.
+
+A strong branded answer can still hide weak category discovery. The answer may know the company after being prompted, but choose competitors, tools, or adjacent providers when the buyer asks from the problem outward. That suggests the public market may not connect the brand strongly enough to the buyer situation that matters.
+
+A weak branded answer and weak unbranded answer suggest a different problem: the surface may not have enough clear public material to describe the company or place it in the category. That may be a source clarity, entity understanding, offer explanation, or category-language problem.
+
+A strong unbranded answer and strong branded answer is healthier, but still bounded. It shows the brand appeared under recorded conditions and was describable when named. It does not prove buyer demand, pipeline attribution, market share, or durable platform preference.
+
+A strong unbranded answer and weak branded answer is rarer but useful. The company may be included in a candidate set while its named description is stale, thin, or inaccurate. That can create sales risk even when discovery is working.
+
+The interpretation should remain practical:
+
+- If the brand is absent unbranded but strong branded, improve the public connection between buyer problem, category, offer, and next step.
+- If the brand is present unbranded but miscategorised, clarify the buying route and fit boundary.
+- If alternatives dominate unbranded answers, inspect whether the market sees software, DIY, existing agencies, or delay as more natural routes.
+- If the branded answer creates praise without a plausible next step, strengthen the offer page and qualification path.
+- If results vary across runs, repeat before drawing a management conclusion.
+
+## Keep the claim bounded
+
+A paired prompt is not a causal experiment. It does not prove what real buyers asked, saw, trusted, remembered, or acted on. It does not prove demand. It does not measure platform-wide preference. It should not be averaged across ChatGPT, Claude, Perplexity, Gemini, Google AI features, search results, directories, review sites, and other surfaces as if they were one channel.
+
+Each surface has different evidence conditions. Some expose citations. Some summarise without visible sources. Some are closer to search. Some are closer to conversational research. Market, language, account context, date, and prompt wording can all change the observation.
+
+Google AI features need the familiar caveat. They rely on core Search ranking and quality systems. If a Google AI feature does not include the brand for an unbranded buyer question, the response is not to assume that `llms.txt`, special AI markup, arbitrary chunking, or over-focused structured data are missing switches. The better response is to inspect the usefulness, relevance, clarity, and quality of the public material that could make the company a credible answer for that buyer question.
+
+The useful claim is narrower and stronger:
+
+> Under these recorded conditions, the brand was recognised when named, but was or was not discovered when the buyer question omitted it.
+
+That sentence is commercially useful because it prevents a visibility report from smuggling the brand into the evidence.
+
+## The leadership test
+
+Before a team calls the result “AI visibility”, leadership should know which event was actually observed.
+
+Was the company described after the evaluator supplied the brand name? Or did the company enter the candidate set when the buyer described the problem, category, market, or buying situation without naming it?
+
+The answer changes the commercial meaning of the report. It separates description from discovery. It stops a comforting branded summary from being sold as proof of market presence. It makes competitor and substitute routes visible before leadership spends to amplify a false positive.
+
+For CMOs, Marketing Directors, and founders, this is the commercial value of the paired test. It does not claim to reveal the whole market. It tells you whether the brand is being recognised after help or discovered before help.
+
+Those are not the same thing.
+
+Test both before you call it visibility.


### PR DESCRIPTION
## Summary
- Adds the approved Day 101 Build in Public post from the durable revision artifact.
- Keeps the public angle focused on paired branded/unbranded buyer-question testing: recognition when named is not the same as unprompted category discovery.

## Verification
- `python tools/validate_frontmatter.py docs/blog/posts/daily-blog-day-101.md`
- `/tmp/zsa_day101_checks.py` for date/title/slug/H1/`<!-- more -->`/raw structural HTML assertions
- `python -m pytest tests/test_validate_frontmatter.py`
- `mkdocs build`

## Payload
- `docs/blog/posts/daily-blog-day-101.md` only
